### PR TITLE
Fix documentation link on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://crayonai.org">Homepage</a> ·
-  <a href="https://crayonai.org/docs/getting-started">Documentation</a> ·
+  <a href="https://crayonai.org/docs">Documentation</a> ·
   <a href="https://thesys.dev">Thesys</a>
 </p>
 


### PR DESCRIPTION
Broken Link:
https://crayonai.org/docs/getting-started
![Screenshot 2025-03-18 065528](https://github.com/user-attachments/assets/2890ca5a-6dc0-460e-bbad-a8d66095eb11)

Fixed Link
https://crayonai.org/docs
![Screenshot 2025-03-18 065738](https://github.com/user-attachments/assets/e838bfcc-d95a-468c-b2fd-259d380f267c)
