### PR TITLE
Bug Fix: Use EventType.value as event name for sse encoding

### DIFF
--- a/py/stream/pyproject.toml
+++ b/py/stream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "crayonai_stream"
-version = "0.6.1"
+version = "0.6.2"
 description = "Streaming utilities for CrayonAI"
 authors = ["Thesys Inc. <engineering@thesys.dev>"]
 readme = "README.md"

--- a/py/stream/setup.py
+++ b/py/stream/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="crayonai_stream",
-    version="0.6.1",
+    version="0.6.2",
     description="Streaming utilities for CrayonAI",
     author="CrayonAI",
     packages=find_packages(where="src"),

--- a/py/stream/src/crayonai_stream/protocol.py
+++ b/py/stream/src/crayonai_stream/protocol.py
@@ -28,7 +28,7 @@ class TextChunk(Chunk):
     chunk: str
 
     def toSSEString(self) -> str:
-        return encode_sse(SSEType.TextDelta, self.chunk)
+        return encode_sse(SSEType.TextDelta.value, self.chunk)
 
 
 class ResponseTemplate(Chunk):
@@ -37,32 +37,32 @@ class ResponseTemplate(Chunk):
 
     def toSSEString(self) -> str:
         data = {"name": self.name, "templateProps": self.templateProps}
-        return encode_json_sse(SSEType.ResponseTemplate, data)
+        return encode_json_sse(SSEType.ResponseTemplate.value, data)
 
 
 class ResponseTemplatePropsChunk(Chunk):
     chunk: str
 
     def toSSEString(self) -> str:
-        return encode_sse(SSEType.ResponseTemplatePropsChunk, self.chunk)
+        return encode_sse(SSEType.ResponseTemplatePropsChunk.value, self.chunk)
 
 
 class ContextUpdate(Chunk):
     contextItem: JSONValue
 
     def toSSEString(self) -> str:
-        return encode_json_sse(SSEType.ContextAppend, self.contextItem)
+        return encode_json_sse(SSEType.ContextAppend.value, self.contextItem)
 
 
 class MessageUpdate(Chunk):
     id: str
 
     def toSSEString(self) -> str:
-        return encode_json_sse(SSEType.MessageUpdate, {"id": self.id})
+        return encode_json_sse(SSEType.MessageUpdate.value, {"id": self.id})
 
 
 class Error(Chunk):
     error: str
 
     def toSSEString(self) -> str:
-        return encode_sse(SSEType.Error, self.error)
+        return encode_sse(SSEType.Error.value, self.error)


### PR DESCRIPTION
Earlier we were just passing the enum which caused the event type to look like `EventType.text` rather than `text`