### PR TITLE
feat(MarkDownRenderer): remove dark mode styles

### DIFF
--- a/js/packages/react-ui/src/components/MarkDownRenderer/MarkDownRenderer.tsx
+++ b/js/packages/react-ui/src/components/MarkDownRenderer/MarkDownRenderer.tsx
@@ -69,9 +69,6 @@ export const MarkDownRenderer = memo((props: MarkDownRendererProps) => {
       className={clsx(
         props["variant"] && variantStyles[props["variant"] as keyof typeof variantStyles],
         "crayon-markdown-renderer",
-        {
-          "crayon-markdown-renderer-dark-mode": mode === "dark",
-        },
         props.className,
       )}
     >

--- a/js/packages/react-ui/src/components/MarkDownRenderer/markDownRenderer.scss
+++ b/js/packages/react-ui/src/components/MarkDownRenderer/markDownRenderer.scss
@@ -182,15 +182,3 @@
     margin-bottom: 0;
   }
 }
-
-.crayon-markdown-renderer-dark-mode {
-  & p,
-  & h1,
-  & h2,
-  & h3,
-  & h4,
-  & h5,
-  & h6 {
-    color: color-mix(in oklab, cssUtils.$primary-text 70%, transparent);
-  }
-}


### PR DESCRIPTION
The changes remove the dark mode styles for the MarkDownRenderer component. This is done to simplify the component and remove unnecessary styling that is not being used. The focus of these changes is to remove the dark mode specific styles and keep the component more generic.