### PR TITLE
Make step line **exactly** centered wrt step badge

### DIFF
--- a/docs/components/Steps/Steps.module.css
+++ b/docs/components/Steps/Steps.module.css
@@ -5,6 +5,7 @@
   --dark-mode-text: white;
   --badge-size: 1.75rem;
   --step-gap: 0.5rem; /* gap between steps */
+  --step-line-width: 1px;
 }
 
 .stepsContainer {
@@ -40,10 +41,10 @@
 }
 
 .stepLine {
-  width: 1px;
+  width: var(--step-line-width);
   flex-grow: 1;
   background-color: var(--light-mode-background);
-  margin-left: calc(var(--badge-size) / 2);
+  margin-left: calc(var(--badge-size) / 2 - var(--step-line-width) / 2);
 }
 
 .stepContent {


### PR DESCRIPTION
Step line width did not take its own width into account, and therefore was not *perfectly* centered (was off by half a pixel). This commit fixes this issue.