### PR TITLE
fix: remove dark mode styles from global CSS

### DIFF
--- a/docs/components/Steps/Steps.module.css
+++ b/docs/components/Steps/Steps.module.css
@@ -67,7 +67,7 @@
   );
 }
 
-@media (prefers-color-scheme: dark) {
+html[data-theme="dark"] {
   .stepNumberBadge {
     background: var(--dark-mode-background);
     color: var(--dark-mode-text);

--- a/docs/src/pages/globals.css
+++ b/docs/src/pages/globals.css
@@ -29,9 +29,3 @@ a {
   color: inherit;
   text-decoration: none;
 }
-
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-}


### PR DESCRIPTION
This commit fixes an issue where docusaurus theme would sometimes break when user switched system theme and docusaurus theme at the same time