### PR TITLE
Escape "%" in css variable generation in charts

### DIFF
--- a/js/packages/react-ui/src/components/Charts/Charts.tsx
+++ b/js/packages/react-ui/src/components/Charts/Charts.tsx
@@ -53,7 +53,7 @@ function useChart() {
 }
 
 export function keyTransform(key: string) {
-  return key.replaceAll(/\s/g, "-");
+  return key.replaceAll(/\s/g, "-").replaceAll("%", "__per__");
 }
 
 /**


### PR DESCRIPTION
"%" symbol in a css variable makes it invalid, leading to chart rendering without colors