### PR TITLE
feat: add @radix-ui/react-separator package and update CSS utility file

### DIFF
--- a/js/packages/react-ui/cp-css.js
+++ b/js/packages/react-ui/cp-css.js
@@ -42,6 +42,9 @@ function copyCssFiles() {
 
   const indexCSSContent = fs.readFileSync(path.join(srcDir, "index.css"), "utf8");
   fs.writeFileSync(path.join(distDir, "index.css"), indexCSSContent);
+
+  const cssUtilsSrc = fs.readFileSync(path.join(dirname, "src", "cssUtils.scss"), "utf8");
+  fs.writeFileSync(path.join(distDir, "cssUtils.scss"), cssUtilsSrc);
 }
 
 try {

--- a/js/packages/react-ui/package.json
+++ b/js/packages/react-ui/package.json
@@ -62,6 +62,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-radio-group": "^1.2.2",
     "@radix-ui/react-select": "^2.1.5",
+    "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",

--- a/js/packages/react-ui/package.json
+++ b/js/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@crayonai/react-ui",
   "license": "MIT",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/js/packages/react-ui/src/components/Separator/Separator.tsx
+++ b/js/packages/react-ui/src/components/Separator/Separator.tsx
@@ -1,0 +1,8 @@
+import * as RadixSeparator from "@radix-ui/react-separator";
+import clsx from "clsx";
+
+const Separator = ({ className, ...props }: React.ComponentProps<typeof RadixSeparator.Root>) => {
+  return <RadixSeparator.Root className={clsx("crayon-separator", className)} {...props} />;
+};
+
+export { Separator };

--- a/js/packages/react-ui/src/components/Separator/dependencies.ts
+++ b/js/packages/react-ui/src/components/Separator/dependencies.ts
@@ -1,0 +1,2 @@
+const dependencies = ["Separator"];
+export default dependencies;

--- a/js/packages/react-ui/src/components/Separator/index.ts
+++ b/js/packages/react-ui/src/components/Separator/index.ts
@@ -1,0 +1,1 @@
+export * from "./Separator";

--- a/js/packages/react-ui/src/components/Separator/separator.scss
+++ b/js/packages/react-ui/src/components/Separator/separator.scss
@@ -1,0 +1,15 @@
+@use "../../cssUtils" as cssUtils;
+
+.crayon-separator {
+  background-color: cssUtils.$stroke-default;
+
+  &[data-orientation="horizontal"] {
+    height: 1px;
+    width: 100%;
+  }
+
+  &[data-orientation="vertical"] {
+    width: 1px;
+    height: 100%;
+  }
+}

--- a/js/packages/react-ui/src/components/Separator/separator.scss
+++ b/js/packages/react-ui/src/components/Separator/separator.scss
@@ -1,7 +1,7 @@
 @use "../../cssUtils" as cssUtils;
 
 .crayon-separator {
-  background-color: cssUtils.$stroke-default;
+  background-color: cssUtils.$stroke-interactive-el;
 
   &[data-orientation="horizontal"] {
     height: 1px;

--- a/js/packages/react-ui/src/components/Separator/stories/Separator.stories.tsx
+++ b/js/packages/react-ui/src/components/Separator/stories/Separator.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Separator } from "../Separator";
+
+const meta: Meta<typeof Separator> = {
+  title: "Components/Separator",
+  component: Separator,
+  tags: ["autodocs", "!dev"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { Separator } from '@crayon-ui/react-ui';\n```",
+      },
+    },
+  },
+  decorators: [
+    (Story, { args }) => (
+      <div style={args.orientation === "vertical" ? { height: "100px" } : { width: "100px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    orientation: {
+      control: "radio",
+      options: ["horizontal", "vertical"],
+      description: "The orientation of the separator.",
+      defaultValue: "horizontal",
+    },
+    decorative: {
+      control: "boolean",
+      description:
+        "When ```true```, signifies that it is purely visual, carries no semantic meaning, and ensures it is not present in the accessibility tree.",
+      defaultValue: false,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Separator>;
+
+export const Horizontal: Story = {
+  args: {
+    orientation: "horizontal",
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    orientation: "vertical",
+  },
+};

--- a/js/packages/react-ui/src/components/index.scss
+++ b/js/packages/react-ui/src/components/index.scss
@@ -42,3 +42,4 @@
 @forward "./ToggleItem/toggleItem.scss";
 @forward "./TextCallout/textCallout.scss";
 @forward "./Charts/charts.scss";
+@forward "./Separator/separator.scss";

--- a/js/pnpm-lock.yaml
+++ b/js/pnpm-lock.yaml
@@ -132,6 +132,9 @@ importers:
       '@radix-ui/react-select':
         specifier: ^2.1.5
         version: 2.2.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.7
+        version: 1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slider':
         specifier: ^1.2.2
         version: 1.3.5(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1227,6 +1230,19 @@ packages:
 
   '@radix-ui/react-select@2.2.5':
     resolution: {integrity: sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4827,6 +4843,15 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-remove-scroll: 2.7.1(@types/react@19.1.8)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 19.1.6(@types/react@19.1.8)
+
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
       '@types/react': 19.1.8
       '@types/react-dom': 19.1.6(@types/react@19.1.8)


### PR DESCRIPTION
- Introduced the @radix-ui/react-separator package with version 1.1.7 to enhance UI component options.
- Updated cp-css.js to include copying of cssUtils.scss to the distribution directory, ensuring all necessary styles are available.
- Updated package.json to include the new @radix-ui/react-separator dependency.