### PR TITLE
Add isOpen and setIsOpen props to DatePicker component for better control over visibility

### DIFF
--- a/js/packages/react-ui/src/components/DatePicker/DatePicker.tsx
+++ b/js/packages/react-ui/src/components/DatePicker/DatePicker.tsx
@@ -10,6 +10,8 @@ export interface DatePickerProps {
   selectedRangeDates?: DateRange;
   setSelectedSingleDate?: (date?: Date) => void;
   setSelectedRangeDates?: (range?: DateRange) => void;
+  isOpen?: boolean;
+  setIsOpen?: (isOpen: boolean) => void;
   className?: string;
   style?: React.CSSProperties;
 }
@@ -23,6 +25,8 @@ const DatePicker = (props: DatePickerProps) => {
     selectedRangeDates,
     setSelectedSingleDate,
     setSelectedRangeDates,
+    isOpen,
+    setIsOpen,
     className,
     style,
   } = props;
@@ -33,6 +37,7 @@ const DatePicker = (props: DatePickerProps) => {
   const [internalSelectedRange, setInternalSelectedRange] = useState<DateRange | undefined>(
     selectedRangeDates,
   );
+  const [internalIsOpen, setInternalIsOpen] = useState(isOpen ?? false);
 
   // this derived setter state is used to make this component more flexible
   // it allows the user to pass in a setter function from the parent component
@@ -69,6 +74,8 @@ const DatePicker = (props: DatePickerProps) => {
       selectedRangeFromParent={selectedRangeDates ?? internalSelectedRange}
       setSelectedDateFromParent={selectedDateHandler}
       setSelectedRangeFromParent={selectedRangeHandler}
+      isOpenFromParent={isOpen ?? internalIsOpen}
+      setIsOpenFromParent={setIsOpen ?? setInternalIsOpen}
     >
       <FloatingDatePickerRenderer className={className} style={style} />
     </DatePickerProvider>

--- a/js/packages/react-ui/src/components/DatePicker/helpers/context/DatePickerContext.tsx
+++ b/js/packages/react-ui/src/components/DatePicker/helpers/context/DatePickerContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext } from "react";
 import { DateRange } from "react-day-picker";
 
 interface DatePickerContextType {
@@ -45,6 +45,8 @@ interface DatePickerProviderProps {
 
   setSelectedDateFromParent: (date: Date | undefined) => void;
   setSelectedRangeFromParent: (range: DateRange | undefined) => void;
+  isOpenFromParent: boolean;
+  setIsOpenFromParent: (isOpen: boolean) => void;
 }
 
 export const DatePickerProvider: React.FC<DatePickerProviderProps> = ({
@@ -54,12 +56,12 @@ export const DatePickerProvider: React.FC<DatePickerProviderProps> = ({
   selectedRangeFromParent,
   setSelectedDateFromParent,
   setSelectedRangeFromParent,
+  isOpenFromParent,
+  setIsOpenFromParent,
 
   mode,
   botType,
 }) => {
-  const [isOpen, setIsOpen] = useState(false);
-
   return (
     <DatePickerContext.Provider
       value={{
@@ -71,8 +73,8 @@ export const DatePickerProvider: React.FC<DatePickerProviderProps> = ({
 
         mode,
 
-        isOpen,
-        setIsOpen,
+        isOpen: isOpenFromParent,
+        setIsOpen: setIsOpenFromParent,
 
         botType,
       }}


### PR DESCRIPTION
- Introduced `isOpen` and `setIsOpen` props to the DatePicker component, allowing parent components to manage the open state of the date picker.
- Updated internal state management to accommodate the new props, enhancing flexibility and usability.
- Adjusted DatePickerProvider to pass down the new open state properties, ensuring consistent behavior across the component.