### PR TITLE
Update Table component styles to enhance typography and layout consistency

### DIFF
--- a/js/packages/react-ui/src/components/Table/table.scss
+++ b/js/packages/react-ui/src/components/Table/table.scss
@@ -7,7 +7,7 @@
 }
 
 .crayon-table {
-  @include cssUtils.typography(body, default);
+  @include cssUtils.typography(body, small);
   width: 100%;
   caption-side: bottom;
   border-collapse: collapse;
@@ -30,7 +30,7 @@
 .crayon-table-head {
   border-bottom: 1px solid cssUtils.$stroke-default;
   & .crayon-table-head-label {
-    @include cssUtils.typography(body, heavy);
+    @include cssUtils.typography(body, small);
     color: cssUtils.$secondary-text;
     display: inline-flex;
     flex-grow: 1;
@@ -61,4 +61,5 @@
   &:nth-child(even) {
     background-color: cssUtils.$bg-highlight-subtle;
   }
+  border-bottom: 1px solid cssUtils.$stroke-default;
 }


### PR DESCRIPTION
- Changed typography style for the crayon-table and crayon-table-head-label to use 'small' instead of 'default' and 'heavy', respectively, improving visual hierarchy.
- Added a border-bottom to the last row of the table for better separation and clarity.