### PR TITLE
Enhance chart components with renderOptions prop for customizable UI elements

### DIFF
--- a/js/packages/react-ui/src/components/Charts/AreaChart/AreaChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/AreaChart/AreaChart.tsx
@@ -54,6 +54,7 @@ export interface AreaChartProps<T extends AreaChartData> {
   className?: string;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const X_AXIS_PADDING = 36;
@@ -76,6 +77,7 @@ const AreaChartComponent = <T extends AreaChartData>({
   className,
   height,
   width,
+  renderOptions,
 }: AreaChartProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -301,6 +303,7 @@ const AreaChartComponent = <T extends AreaChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && <div className="crayon-area-chart-options">{renderOptions()}</div>}
           <div className="crayon-area-chart-container-inner" ref={chartContainerRef}>
             {/* Y-axis of the chart */}
             {yAxis}

--- a/js/packages/react-ui/src/components/Charts/AreaChart/areaChart.scss
+++ b/js/packages/react-ui/src/components/Charts/AreaChart/areaChart.scss
@@ -1,5 +1,9 @@
 @use "../../../cssUtils" as cssUtils;
 
+.crayon-area-chart-container {
+  position: relative;
+}
+
 .crayon-area-chart-container-inner {
   display: flex;
   width: 100%;
@@ -22,4 +26,12 @@
 
   /* Hide scrollbar for IE and Edge */
   -ms-overflow-style: none;
+}
+
+.crayon-area-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/AreaChart/stories/areaChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/AreaChart/stories/areaChart.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { AreaChart, AreaChartProps } from "../AreaChart";
 
 // 🔥 COMPREHENSIVE DATA VARIATIONS - Designed to test label collision scenarios
@@ -804,7 +806,19 @@ export const DataExplorer: Story = {
           </div>
         </div>
         <Card style={{ width: "600px" }}>
-          <AreaChart {...args} data={currentData} categoryKey={currentCategoryKey} />
+          <AreaChart
+            {...args}
+            data={currentData}
+            categoryKey={currentCategoryKey}
+            renderOptions={() => (
+              <IconButton
+                icon={<RefreshCcwIcon />}
+                onClick={() => {
+                  console.log("refresh");
+                }}
+              />
+            )}
+          />
         </Card>
       </div>
     );

--- a/js/packages/react-ui/src/components/Charts/AreaChartCondensed/AreaChartCondensed.tsx
+++ b/js/packages/react-ui/src/components/Charts/AreaChartCondensed/AreaChartCondensed.tsx
@@ -43,6 +43,7 @@ export interface AreaChartCondensedProps<T extends AreaChartData> {
   className?: string;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const CHART_HEIGHT = 296;
@@ -65,6 +66,7 @@ const AreaChartCondensedComponent = <T extends AreaChartData>({
   className,
   height = CHART_HEIGHT,
   width,
+  renderOptions,
 }: AreaChartCondensedProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -248,6 +250,9 @@ const AreaChartCondensedComponent = <T extends AreaChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && (
+            <div className="crayon-area-chart-condensed-options">{renderOptions()}</div>
+          )}
           {yAxisLabel && (
             <div className="crayon-area-chart-condensed-y-axis-label">{yAxisLabel}</div>
           )}

--- a/js/packages/react-ui/src/components/Charts/AreaChartCondensed/areaChartCondensed.scss
+++ b/js/packages/react-ui/src/components/Charts/AreaChartCondensed/areaChartCondensed.scss
@@ -3,6 +3,7 @@
 .crayon-area-chart-condensed-container {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .crayon-area-chart-condensed-container-inner {
@@ -29,4 +30,12 @@
     color: cssUtils.$secondary-text;
     padding-bottom: cssUtils.$spacing-s;
   }
+}
+
+.crayon-area-chart-condensed-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/AreaChartCondensed/stories/areaChartCondensed.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/AreaChartCondensed/stories/areaChartCondensed.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { AreaChartCondensed, AreaChartCondensedProps } from "../AreaChartCondensed";
 
 // 🔥 COMPREHENSIVE DATA VARIATIONS - Designed to test various scenarios
@@ -618,6 +620,14 @@ export const DataExplorer: Story = {
             data={currentData}
             categoryKey={currentCategoryKey}
             tickVariant={tickVariant}
+            renderOptions={() => (
+              <IconButton
+                icon={<RefreshCcwIcon />}
+                onClick={() => {
+                  console.log("refresh");
+                }}
+              />
+            )}
           />
         </Card>
       </div>

--- a/js/packages/react-ui/src/components/Charts/BarChart/BarChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/BarChart/BarChart.tsx
@@ -65,6 +65,7 @@ export interface BarChartProps<T extends BarChartData> {
   className?: string;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const BAR_GAP = 10; // Gap between bars
@@ -91,6 +92,7 @@ const BarChartComponent = <T extends BarChartData>({
   className,
   height,
   width,
+  renderOptions,
 }: BarChartProps<T>) => {
   const widthOfGroup = getWidthOfGroup(data, categoryKey as string, variant);
 
@@ -428,6 +430,7 @@ const BarChartComponent = <T extends BarChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && <div className="crayon-bar-chart-options">{renderOptions()}</div>}
           <div className="crayon-bar-chart-container-inner" ref={chartContainerRef}>
             {/* Y-axis of the chart */}
             {yAxis}

--- a/js/packages/react-ui/src/components/Charts/BarChart/barChart.scss
+++ b/js/packages/react-ui/src/components/Charts/BarChart/barChart.scss
@@ -1,5 +1,9 @@
 @use "../../../cssUtils" as cssUtils;
 
+.crayon-bar-chart-container {
+  position: relative;
+}
+
 .crayon-bar-chart-container-inner {
   display: flex;
   width: 100%;
@@ -22,4 +26,12 @@
 
   /* Hide scrollbar for IE and Edge */
   -ms-overflow-style: none;
+}
+
+.crayon-bar-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 10;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/BarChart/stories/barChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/BarChart/stories/barChart.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Monitor, TabletSmartphone } from "lucide-react";
+import { Monitor, RefreshCcwIcon, TabletSmartphone } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { BarChart, BarChartProps } from "../BarChart";
 
 // 📊 ALL DATA VARIATIONS - For easy switching in stories
@@ -935,7 +936,12 @@ export const DataExplorer: Story = {
           </div>
         </div>
         <Card style={{ width: "700px" }}>
-          <BarChart {...args} data={currentData} categoryKey={currentCategoryKey} />
+          <BarChart
+            {...args}
+            data={currentData}
+            categoryKey={currentCategoryKey}
+            renderOptions={() => <IconButton icon={<RefreshCcwIcon />} onClick={() => {}} />}
+          />
         </Card>
       </div>
     );

--- a/js/packages/react-ui/src/components/Charts/BarChartCondensed/BarChartCondensed.tsx
+++ b/js/packages/react-ui/src/components/Charts/BarChartCondensed/BarChartCondensed.tsx
@@ -46,6 +46,7 @@ export interface BarChartCondensedProps<T extends BarChartData> {
   className?: string;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const BAR_WIDTH = 12;
@@ -74,6 +75,7 @@ const BarChartCondensedComponent = <T extends BarChartData>({
   className,
   height = CHART_HEIGHT,
   width,
+  renderOptions,
 }: BarChartCondensedProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -350,6 +352,9 @@ const BarChartCondensedComponent = <T extends BarChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && (
+            <div className="crayon-bar-chart-condensed-options">{renderOptions()}</div>
+          )}
           {yAxisLabel && (
             <div className="crayon-bar-chart-condensed-y-axis-label">{yAxisLabel}</div>
           )}

--- a/js/packages/react-ui/src/components/Charts/BarChartCondensed/barChartCondensed.scss
+++ b/js/packages/react-ui/src/components/Charts/BarChartCondensed/barChartCondensed.scss
@@ -3,6 +3,7 @@
 .crayon-bar-chart-condensed-container {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .crayon-bar-chart-condensed-container-inner {
@@ -29,4 +30,12 @@
     color: cssUtils.$secondary-text;
     padding-bottom: cssUtils.$spacing-s;
   }
+}
+
+.crayon-bar-chart-condensed-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/BarChartCondensed/stories/barChartCondensed.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/BarChartCondensed/stories/barChartCondensed.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { BarChartCondensed, BarChartCondensedProps } from "../BarChartCondensed";
 
 // 🔥 COMPREHENSIVE DATA VARIATIONS - Designed to test various scenarios
@@ -576,6 +578,7 @@ export const DataExplorer: Story = {
             categoryKey={currentCategoryKey}
             variant={variant}
             tickVariant={tickVariant}
+            renderOptions={() => <IconButton icon={<RefreshCcwIcon />} onClick={() => {}} />}
           />
         </Card>
       </div>

--- a/js/packages/react-ui/src/components/Charts/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/HorizontalBarChart/HorizontalBarChart.tsx
@@ -65,6 +65,7 @@ export interface HorizontalBarChartProps<T extends HorizontalBarChartData> {
   className?: string;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const X_AXIS_HEIGHT = 40; // Height of X-axis chart when shown
@@ -89,6 +90,7 @@ const HorizontalBarChartComponent = <T extends HorizontalBarChartData>({
   className,
   height,
   width,
+  renderOptions,
 }: HorizontalBarChartProps<T>) => {
   const maxCategoryLabelWidth = useMaxCategoryLabelWidth(data, categoryKey as string);
 
@@ -344,6 +346,9 @@ const HorizontalBarChartComponent = <T extends HorizontalBarChartData>({
         setData={setSideBarTooltipData}
       >
         <div className={clsx("crayon-horizontal-bar-chart-container", className)}>
+          {renderOptions && (
+            <div className="crayon-horizontal-bar-chart-options">{renderOptions()}</div>
+          )}
           <div
             className="crayon-horizontal-bar-chart-container-inner-wrapper"
             style={{

--- a/js/packages/react-ui/src/components/Charts/HorizontalBarChart/horizontalBarChart.scss
+++ b/js/packages/react-ui/src/components/Charts/HorizontalBarChart/horizontalBarChart.scss
@@ -60,3 +60,11 @@
     box-sizing: border-box;
   }
 }
+
+.crayon-horizontal-bar-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/js/packages/react-ui/src/components/Charts/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Monitor, TabletSmartphone } from "lucide-react";
+import { Monitor, RefreshCcwIcon, TabletSmartphone } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { HorizontalBarChart, HorizontalBarChartProps } from "../HorizontalBarChart";
 
 // 📊 ALL DATA VARIATIONS - For easy switching in stories
@@ -750,7 +751,19 @@ export const DataExplorer: Story = {
           </div>
         </div>
         <Card style={{ width: "700px" }}>
-          <HorizontalBarChart {...args} data={currentData} categoryKey={currentCategoryKey} />
+          <HorizontalBarChart
+            {...args}
+            data={currentData}
+            categoryKey={currentCategoryKey}
+            renderOptions={() => (
+              <IconButton
+                icon={<RefreshCcwIcon />}
+                onClick={() => {
+                  console.log("refresh");
+                }}
+              />
+            )}
+          />
         </Card>
       </div>
     );

--- a/js/packages/react-ui/src/components/Charts/LineChart/LineChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/LineChart/LineChart.tsx
@@ -53,6 +53,7 @@ export interface LineChartProps<T extends LineChartData> {
   height?: number;
   width?: number;
   strokeWidth?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const X_AXIS_PADDING = 36;
@@ -76,6 +77,7 @@ export const LineChart = <T extends LineChartData>({
   height,
   width,
   strokeWidth = 2,
+  renderOptions,
 }: LineChartProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -311,6 +313,7 @@ export const LineChart = <T extends LineChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && <div className="crayon-line-chart-options">{renderOptions()}</div>}
           <div className="crayon-line-chart-container-inner" ref={chartContainerRef}>
             {/* Y-axis of the chart */}
             {yAxis}

--- a/js/packages/react-ui/src/components/Charts/LineChart/lineChart.scss
+++ b/js/packages/react-ui/src/components/Charts/LineChart/lineChart.scss
@@ -1,5 +1,9 @@
 @use "../../../cssUtils" as cssUtils;
 
+.crayon-line-chart-container {
+  position: relative;
+}
+
 .crayon-line-chart-container-inner {
   display: flex;
   width: 100%;
@@ -22,4 +26,12 @@
 
   /* Hide scrollbar for IE and Edge */
   -ms-overflow-style: none;
+}
+
+.crayon-line-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/LineChart/stories/lineChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/LineChart/stories/lineChart.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { LineChart, LineChartProps } from "../LineChart";
 
 const customColorPalette = [
@@ -820,7 +822,19 @@ export const DataExplorer: Story = {
           </div>
         </div>
         <Card style={{ width: "600px" }}>
-          <LineChart {...args} data={currentData} categoryKey={currentCategoryKey} />
+          <LineChart
+            {...args}
+            data={currentData}
+            categoryKey={currentCategoryKey}
+            renderOptions={() => (
+              <IconButton
+                icon={<RefreshCcwIcon />}
+                onClick={() => {
+                  console.log("refresh");
+                }}
+              />
+            )}
+          />
         </Card>
       </div>
     );

--- a/js/packages/react-ui/src/components/Charts/LineChartCondensed/LineChartCondensed.tsx
+++ b/js/packages/react-ui/src/components/Charts/LineChartCondensed/LineChartCondensed.tsx
@@ -44,6 +44,7 @@ export interface LineChartCondensedProps<T extends LineChartData> {
   height?: number;
   width?: number;
   strokeWidth?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const CHART_HEIGHT = 296;
@@ -67,6 +68,7 @@ const LineChartCondensedComponent = <T extends LineChartData>({
   height = CHART_HEIGHT,
   width,
   strokeWidth = 2,
+  renderOptions,
 }: LineChartCondensedProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -248,6 +250,9 @@ const LineChartCondensedComponent = <T extends LineChartData>({
             width: width ? `${width}px` : undefined,
           }}
         >
+          {renderOptions && (
+            <div className="crayon-line-chart-condensed-options">{renderOptions()}</div>
+          )}
           {yAxisLabel && (
             <div className="crayon-line-chart-condensed-y-axis-label">{yAxisLabel}</div>
           )}

--- a/js/packages/react-ui/src/components/Charts/LineChartCondensed/lineChartCondensed.scss
+++ b/js/packages/react-ui/src/components/Charts/LineChartCondensed/lineChartCondensed.scss
@@ -3,6 +3,7 @@
 .crayon-line-chart-condensed-container {
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .crayon-line-chart-condensed-container-inner {
@@ -29,4 +30,12 @@
     color: cssUtils.$secondary-text;
     padding-bottom: cssUtils.$spacing-s;
   }
+}
+
+.crayon-line-chart-condensed-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
 }

--- a/js/packages/react-ui/src/components/Charts/LineChartCondensed/stories/lineChartCondensed.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/LineChartCondensed/stories/lineChartCondensed.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { LineChartCondensed, LineChartCondensedProps } from "../LineChartCondensed";
 
 // 🔥 COMPREHENSIVE DATA VARIATIONS - Designed to test various scenarios
@@ -629,6 +631,14 @@ export const DataExplorer: Story = {
             data={currentData}
             categoryKey={currentCategoryKey}
             tickVariant={tickVariant}
+            renderOptions={() => (
+              <IconButton
+                icon={<RefreshCcwIcon />}
+                onClick={() => {
+                  console.log("refresh");
+                }}
+              />
+            )}
           />
         </Card>
       </div>

--- a/js/packages/react-ui/src/components/Charts/PieChart/PieChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/PieChart/PieChart.tsx
@@ -42,6 +42,7 @@ export interface PieChartProps<T extends PieChartData> {
   // Add height and width props
   height?: number | string;
   width?: number | string;
+  renderOptions?: () => React.ReactNode;
 }
 
 const STACKED_LEGEND_BREAKPOINT = 400;
@@ -71,6 +72,7 @@ const PieChartComponent = <T extends PieChartData>({
   minChartSize = MIN_CHART_SIZE,
   height,
   width,
+  renderOptions,
 }: PieChartProps<T>) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [wrapperRect, setWrapperRect] = useState({ width: 0, height: 0 });
@@ -438,6 +440,7 @@ const PieChartComponent = <T extends PieChartData>({
   return (
     <div ref={wrapperRef} className={wrapperClassName} style={wrapperStyle}>
       <div className="crayon-pie-chart-container">
+        {renderOptions && <div className="crayon-pie-chart-options">{renderOptions()}</div>}
         <div className="crayon-pie-chart-container-inner">
           <div style={chartSizeStyle}>
             <ChartContainer

--- a/js/packages/react-ui/src/components/Charts/PieChart/pieChart.scss
+++ b/js/packages/react-ui/src/components/Charts/PieChart/pieChart.scss
@@ -82,3 +82,11 @@
     align-items: center;
   }
 }
+
+.crayon-pie-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/js/packages/react-ui/src/components/Charts/PieChart/stories/PieChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/PieChart/stories/PieChart.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { RefreshCcwIcon } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { PieChart, PieChartProps } from "../PieChart";
 
 const monthlySalesData = [
@@ -288,7 +290,19 @@ export const InteractivePlayground: Story = {
     height: undefined,
     width: undefined,
   },
-  render: (args: any) => <PieChart {...args} />,
+  render: (args: any) => (
+    <PieChart
+      {...args}
+      renderOptions={() => (
+        <IconButton
+          icon={<RefreshCcwIcon />}
+          onClick={() => {
+            console.log("refresh");
+          }}
+        />
+      )}
+    />
+  ),
 };
 
 /**

--- a/js/packages/react-ui/src/components/Charts/RadarChart/RadarChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/RadarChart/RadarChart.tsx
@@ -34,6 +34,7 @@ export interface RadarChartProps<T extends RadarChartData> {
   isAnimationActive?: boolean;
   height?: number;
   width?: number;
+  renderOptions?: () => React.ReactNode;
 }
 
 const RadarChartComponent = <T extends RadarChartData>({
@@ -50,6 +51,7 @@ const RadarChartComponent = <T extends RadarChartData>({
   isAnimationActive = false,
   height,
   width,
+  renderOptions,
 }: RadarChartProps<T>) => {
   const dataKeys = useMemo(() => {
     return getDataKeys(data, categoryKey as string);
@@ -188,6 +190,7 @@ const RadarChartComponent = <T extends RadarChartData>({
     >
       <div ref={wrapperRef} className={wrapperClassName} style={wrapperStyle}>
         <div className="crayon-radar-chart-container">
+          {renderOptions && <div className="crayon-radar-chart-options">{renderOptions()}</div>}
           <div className="crayon-radar-chart-container-inner">
             <div style={chartSizeStyle}>
               <ChartContainer

--- a/js/packages/react-ui/src/components/Charts/RadarChart/radarChart.scss
+++ b/js/packages/react-ui/src/components/Charts/RadarChart/radarChart.scss
@@ -47,3 +47,11 @@
   color: cssUtils.$secondary-text;
   white-space: nowrap;
 }
+
+.crayon-radar-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/js/packages/react-ui/src/components/Charts/RadarChart/stories/RadarChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/RadarChart/stories/RadarChart.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Shield, Star, Target } from "lucide-react";
+import { RefreshCcwIcon, Shield, Star, Target } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { RadarChart, RadarChartProps } from "../RadarChart";
 
 // 📊 COMPREHENSIVE DATA VARIATIONS - Designed to test various radar chart scenarios
@@ -347,7 +348,17 @@ export const DefaultConfiguration: Story = {
           Comparing key performance indicators across three teams.
         </p>
       </div>
-      <RadarChart {...args} />
+      <RadarChart
+        {...args}
+        renderOptions={() => (
+          <IconButton
+            icon={<RefreshCcwIcon />}
+            onClick={() => {
+              console.log("refresh");
+            }}
+          />
+        )}
+      />
     </Card>
   ),
   parameters: {

--- a/js/packages/react-ui/src/components/Charts/RadialChart/RadialChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/RadialChart/RadialChart.tsx
@@ -39,6 +39,7 @@ export interface RadialChartProps<T extends RadialChartData> {
   minChartSize?: number;
   height?: number | string;
   width?: number | string;
+  renderOptions?: () => React.ReactNode;
 }
 
 const STACKED_LEGEND_BREAKPOINT = 400;
@@ -66,6 +67,7 @@ export const RadialChart = <T extends RadialChartData>({
   minChartSize = MIN_CHART_SIZE,
   height,
   width,
+  renderOptions,
 }: RadialChartProps<T>) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [wrapperRect, setWrapperRect] = useState({ width: 0, height: 0 });
@@ -330,6 +332,7 @@ export const RadialChart = <T extends RadialChartData>({
       aria-description="radial-chart-wrapper"
     >
       <div className="crayon-radial-chart-container">
+        {renderOptions && <div className="crayon-radial-chart-options">{renderOptions()}</div>}
         <div className="crayon-radial-chart-container-inner">
           <div style={chartSizeStyle}>
             <ChartContainer

--- a/js/packages/react-ui/src/components/Charts/RadialChart/radialChart.scss
+++ b/js/packages/react-ui/src/components/Charts/RadialChart/radialChart.scss
@@ -82,3 +82,11 @@
     align-items: center; // Vertically center legend content
   }
 }
+
+.crayon-radial-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/js/packages/react-ui/src/components/Charts/RadialChart/stories/RadialChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/RadialChart/stories/RadialChart.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { RefreshCcwIcon } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { RadialChart, RadialChartProps } from "../RadialChart";
 
 /**
@@ -388,7 +390,17 @@ export const DefaultConfiguration: Story = {
           Comprehensive view of revenue distribution across 12 months
         </p>
       </div>
-      <RadialChart {...args} />
+      <RadialChart
+        {...args}
+        renderOptions={() => (
+          <IconButton
+            icon={<RefreshCcwIcon />}
+            onClick={() => {
+              console.log("refresh");
+            }}
+          />
+        )}
+      />
     </Card>
   ),
   parameters: {

--- a/js/packages/react-ui/src/components/Charts/ScatterChart/ScatterChart.tsx
+++ b/js/packages/react-ui/src/components/Charts/ScatterChart/ScatterChart.tsx
@@ -40,6 +40,7 @@ export interface ScatterChartProps {
   height?: number | string;
   width?: number | string;
   shape?: "circle" | "square";
+  renderOptions?: () => React.ReactNode;
 }
 
 const DEFAULT_CHART_HEIGHT = 296;
@@ -60,6 +61,7 @@ export const ScatterChart = ({
   height,
   width,
   shape = "circle",
+  renderOptions,
 }: ScatterChartProps) => {
   const datasets = useMemo(() => {
     return getScatterDatasets(data);
@@ -301,6 +303,7 @@ export const ScatterChart = ({
         }}
         ref={chartWrapperRef}
       >
+        {renderOptions && <div className="crayon-scatter-chart-options">{renderOptions()}</div>}
         <div className="crayon-scatter-chart-container-inner">
           {yAxis}
           <div

--- a/js/packages/react-ui/src/components/Charts/ScatterChart/scatterChart.scss
+++ b/js/packages/react-ui/src/components/Charts/ScatterChart/scatterChart.scss
@@ -40,3 +40,11 @@
 .crayon-scatter-chart-legend-container {
   border-top: 1px solid cssUtils.$stroke-default;
 }
+
+.crayon-scatter-chart-options {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+  pointer-events: auto;
+}

--- a/js/packages/react-ui/src/components/Charts/ScatterChart/stories/ScatterChart.stories.tsx
+++ b/js/packages/react-ui/src/components/Charts/ScatterChart/stories/ScatterChart.stories.tsx
@@ -4,6 +4,7 @@ import {
   Globe,
   Laptop,
   Monitor,
+  RefreshCcwIcon,
   Smartphone,
   TabletSmartphone,
   Tv,
@@ -11,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Card } from "../../../Card";
+import { IconButton } from "../../../IconButton";
 import { ScatterChart, ScatterChartProps } from "../ScatterChart";
 
 const customColorPalette = [
@@ -649,7 +651,19 @@ export const BasicScatter: Story = {
     width: 700,
     height: 400,
   },
-  render: (args: any) => <ScatterChart {...args} />,
+  render: (args: any) => (
+    <ScatterChart
+      {...args}
+      renderOptions={() => (
+        <IconButton
+          icon={<RefreshCcwIcon />}
+          onClick={() => {
+            console.log("refresh");
+          }}
+        />
+      )}
+    />
+  ),
 };
 
 /**


### PR DESCRIPTION
- Added `renderOptions` prop to AreaChart, BarChart, LineChart, and their condensed versions, allowing for the inclusion of custom UI elements like buttons.
- Updated SCSS styles to accommodate new options containers in each chart component, ensuring proper positioning and interaction.
- Enhanced story examples to demonstrate the usage of `renderOptions`, showcasing the integration of IconButton with refresh functionality across various chart types.