### PR TITLE
feat: setup Co-op Translator for Chinese documentation

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -1,0 +1,53 @@
+name: Translate Documentation
+
+on:
+  push:
+    paths:
+      - README.md
+
+  workflow_dispatch:
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Co-op Translator
+        run: |
+          python -m pip install --upgrade pip
+          pip install co-op-translator
+
+      - name: Run Co-op Translator
+        env:
+          PYTHONIOENCODING: utf-8
+          AZURE_AI_SERVICE_API_KEY: ${{ secrets.AZURE_AI_SERVICE_API_KEY }}
+          AZURE_AI_SERVICE_ENDPOINT: ${{ secrets.AZURE_AI_SERVICE_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_MODEL_NAME: ${{ secrets.AZURE_OPENAI_MODEL_NAME }}
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: ${{ secrets.AZURE_OPENAI_CHAT_DEPLOYMENT_NAME }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          translate -l "zh-Hans"
+
+      - name: Commit and push translations
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add .
+          git commit -m "chore: update translations" || echo "No changes to commit"
+          git push

--- a/translations/zh/README.md
+++ b/translations/zh/README.md
@@ -1,0 +1,4 @@
+# Chinese Documentation
+
+Chinese (Simplified) translations for OpenUI documentation will be generated
+automatically using Co-op Translator.

--- a/translator.config.json
+++ b/translator.config.json
@@ -1,0 +1,6 @@
+{
+  "sourceLanguage": "en",
+  "targetLanguages": ["zh-Hans"],
+  "sourceDirectory": ".",
+  "targetDirectory": "translations"
+}


### PR DESCRIPTION
This PR sets up Co-op Translator to automatically generate Chinese (Simplified)
translations for OpenUI documentation.

Changes:
- Added GitHub Actions workflow for automated translations
- Added translator.config.json
- Created translations/zh directory

This provides a scalable i18n foundation so additional languages can be added easily.

Closes #296