### PR TITLE
feat: add Docker support for openui-chat example and update README

### DIFF
--- a/examples/openui-chat/.dockerignore
+++ b/examples/openui-chat/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+.env
+.next

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,47 @@
+# -------------------------
+# Base
+# -------------------------
+FROM node:20-alpine AS base
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+# -------------------------
+# Dependencies
+# -------------------------
+FROM base AS deps
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY tsconfig.json ./
+COPY packages ./packages
+COPY examples/openui-chat ./examples/openui-chat
+
+RUN pnpm install --frozen-lockfile
+
+# -------------------------
+# Build
+# -------------------------
+FROM deps AS builder
+
+WORKDIR /app/examples/openui-chat
+
+RUN pnpm build
+
+# -------------------------
+# Production
+# -------------------------
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+RUN npm install -g pnpm
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app /app
+
+WORKDIR /app/examples/openui-chat
+
+EXPOSE 3000
+
+CMD ["pnpm","start"]

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -19,6 +19,30 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `src/app/api/route.ts` and improving your agent
 by adding system prompts or tools.
 
+
+## Run with Docker
+
+You can run the OpenUI chat example using Docker without installing Node.js or dependencies locally.
+
+### Build the Docker image
+
+From the repository root:
+
+```bash
+docker build -f examples/openui-chat/Dockerfile -t openui-chat .
+```
+
+### Run the container
+```bash
+docker run -p 3000:3000 \
+-e OPENAI_API_KEY=sk-your-key \
+openui-chat
+```
+
+### Then open your browser at:
+
+http://localhost:3000
+
 ## Learn More
 
 To learn more about OpenUI, take a look at the following resources:


### PR DESCRIPTION
## Summary
This PR adds Docker support for the `examples/openui-chat` example to make it easier for users to run the chat application without manually installing dependencies.

## Changes
- Added Dockerfile for containerizing the Next.js chat example
- Added .dockerignore to optimize Docker builds
- Updated README with instructions for running the app using Docker

## Usage

Build the image

docker build -f examples/openui-chat/Dockerfile -t openui-chat .

Run the container

docker run -p 3000:3000 -e OPENAI_API_KEY=sk-xxx openui-chat