### PR TITLE
feat: add @openuidev/svelte-lang — Svelte 5 renderer [Bounty #302 — $100]

### DIFF
--- a/packages/svelte-lang/README.md
+++ b/packages/svelte-lang/README.md
@@ -1,0 +1,212 @@
+# @openuidev/svelte-lang
+
+Define component libraries, generate LLM system prompts, and render streaming [OpenUI Lang](https://openui.com) output in **Svelte 5** — the core runtime for OpenUI generative UI.
+
+This is the Svelte equivalent of [`@openuidev/react-lang`](../react-lang/).
+
+## Installation
+
+```bash
+npm install @openuidev/svelte-lang zod
+```
+
+## Quick Start
+
+### 1. Define Components
+
+```ts
+// lib/components.ts
+import { defineComponent, createLibrary } from "@openuidev/svelte-lang";
+import { z } from "zod";
+import Header from "./Header.svelte";
+import Card from "./Card.svelte";
+
+const HeaderDef = defineComponent({
+  name: "Header",
+  props: z.object({
+    title: z.string(),
+    subtitle: z.string().optional(),
+  }),
+  description: "Page header with title and optional subtitle",
+  component: Header,
+});
+
+const CardDef = defineComponent({
+  name: "Card",
+  props: z.object({
+    title: z.string(),
+    content: z.string(),
+    items: z.array(HeaderDef.ref).optional(),
+  }),
+  description: "Content card",
+  component: Card,
+});
+
+export const library = createLibrary({
+  components: [HeaderDef, CardDef],
+  root: "Card",
+});
+```
+
+### 2. Create Component Renderers
+
+```svelte
+<!-- Header.svelte -->
+<script lang="ts">
+  import type { ComponentRenderProps } from "@openuidev/svelte-lang";
+  import { RenderValue } from "@openuidev/svelte-lang";
+
+  let { props, renderNode }: ComponentRenderProps<{
+    title: string;
+    subtitle?: string;
+  }> = $props();
+</script>
+
+<header>
+  <h1>{props.title}</h1>
+  {#if props.subtitle}
+    <p>{props.subtitle}</p>
+  {/if}
+</header>
+```
+
+```svelte
+<!-- Card.svelte -->
+<script lang="ts">
+  import type { ComponentRenderProps } from "@openuidev/svelte-lang";
+  import { RenderValue } from "@openuidev/svelte-lang";
+
+  let { props, renderNode }: ComponentRenderProps<{
+    title: string;
+    content: string;
+    items?: unknown[];
+  }> = $props();
+</script>
+
+<div class="card">
+  <h2>{props.title}</h2>
+  <p>{props.content}</p>
+  {#if props.items}
+    {#each props.items as item}
+      <RenderValue value={item} />
+    {/each}
+  {/if}
+</div>
+```
+
+### 3. Use the Renderer
+
+```svelte
+<!-- App.svelte -->
+<script lang="ts">
+  import { Renderer } from "@openuidev/svelte-lang";
+  import { library } from "./lib/components";
+
+  let response = $state<string | null>(null);
+  let isStreaming = $state(false);
+
+  async function generate() {
+    isStreaming = true;
+    // Stream from your LLM API using library.prompt() as system prompt
+    const stream = await fetchStream(library.prompt());
+    for await (const chunk of stream) {
+      response = (response ?? "") + chunk;
+    }
+    isStreaming = false;
+  }
+</script>
+
+<button onclick={generate}>Generate UI</button>
+
+<Renderer
+  {response}
+  {library}
+  {isStreaming}
+  onAction={(event) => console.log("Action:", event)}
+  onStateUpdate={(state) => console.log("Form state:", state)}
+/>
+```
+
+## API Reference
+
+### `defineComponent(config)`
+
+Define a component with its name, Zod props schema, description, and Svelte component.
+
+### `createLibrary(definition)`
+
+Create a component library from defined components. Returns a `Library` with:
+- `prompt(options?)` — Generate the LLM system prompt
+- `toJSONSchema()` — Get the JSON Schema for all components
+- `components` — Map of component definitions
+
+### `<Renderer>`
+
+The main streaming renderer component.
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `response` | `string \| null` | Raw OpenUI Lang response text |
+| `library` | `Library` | Component library from `createLibrary()` |
+| `isStreaming` | `boolean` | Whether the LLM is still streaming |
+| `onAction` | `(event: ActionEvent) => void` | Action callback |
+| `onStateUpdate` | `(state) => void` | Form state change callback |
+| `initialState` | `Record<string, any>` | Initial form state |
+| `onParseResult` | `(result: ParseResult \| null) => void` | Parse result callback |
+
+### `<RenderValue>`
+
+Helper component for rendering nested values inside component renderers.
+
+```svelte
+<RenderValue value={props.children} />
+```
+
+### Context Functions
+
+Svelte uses `getContext`/`setContext` instead of React hooks:
+
+- `getOpenUI()` — Full OpenUI context (equivalent to React's `useOpenUI`)
+- `getRenderNode()` — Get the renderNode function
+- `getTriggerAction()` — Get the action trigger function
+- `getIsStreaming()` — Whether LLM is streaming
+- `getGetFieldValue()` — Get form field values
+- `getSetFieldValue()` — Set form field values
+- `getFormName()` — Current form name
+- `setFormNameContext(name)` — Set form name (for form components)
+
+### Form Validation
+
+- `createFormValidation()` — Create form validation state
+- `getFormValidation()` — Access form validation context
+- `setFormValidationContext(value)` — Set validation context
+
+### Parser (Server-side)
+
+- `createParser(schema)` — Create a one-shot parser
+- `createStreamingParser(schema)` — Create a streaming parser
+
+## Svelte vs React Patterns
+
+| React | Svelte |
+|-------|--------|
+| `useOpenUI()` | `getOpenUI()` |
+| `useRenderNode()` | `getRenderNode()` |
+| `useTriggerAction()` | `getTriggerAction()` |
+| `useIsStreaming()` | `getIsStreaming()` |
+| `useGetFieldValue()` | `getGetFieldValue()` |
+| `useSetFieldValue()` | `getSetFieldValue()` |
+| `useFormName()` | `getFormName()` |
+| `useFormValidation()` | `getFormValidation()` |
+| `useCreateFormValidation()` | `createFormValidation()` |
+| `React.FC<ComponentRenderProps>` | Svelte component with `ComponentRenderProps` props |
+| `{renderNode(value)}` | `<RenderValue value={value} />` |
+
+## Requirements
+
+- Svelte 5+
+- Zod 4+
+
+## License
+
+MIT

--- a/packages/svelte-lang/package.json
+++ b/packages/svelte-lang/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@openuidev/svelte-lang",
+  "version": "0.1.0",
+  "description": "Define component libraries, generate LLM system prompts, and render streaming OpenUI Lang output in Svelte — the core runtime for OpenUI generative UI",
+  "license": "MIT",
+  "type": "module",
+  "svelte": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "svelte-package -i src -o dist",
+    "watch": "svelte-package -i src -o dist --watch",
+    "lint:check": "eslint ./src",
+    "lint:fix": "eslint ./src --fix",
+    "format:fix": "prettier --write ./src",
+    "format:check": "prettier --check ./src",
+    "prepare": "pnpm run build",
+    "ci": "pnpm run lint:check && pnpm run format:check"
+  },
+  "keywords": [
+    "openui",
+    "generative-ui",
+    "svelte",
+    "llm",
+    "streaming",
+    "renderer",
+    "parser",
+    "ai",
+    "components",
+    "prompt-generation",
+    "zod",
+    "ui-generation",
+    "model-driven-ui",
+    "openui-lang"
+  ],
+  "homepage": "https://openui.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/thesysdev/openui.git",
+    "directory": "packages/svelte-lang"
+  },
+  "bugs": {
+    "url": "https://github.com/thesysdev/openui/issues"
+  },
+  "author": "engineering@thesys.dev",
+  "dependencies": {
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "svelte": ">=5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/package": "^2.3.0",
+    "svelte": "^5.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/svelte-lang/src/RenderNode.svelte
+++ b/packages/svelte-lang/src/RenderNode.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import type { Library, DefinedComponent } from "./library.js";
+  import type { ElementNode } from "./parser/types.js";
+
+  interface Props {
+    node: ElementNode;
+    library: Library;
+  }
+
+  let { node, library }: Props = $props();
+
+  const def = $derived(library.components[node.typeName]);
+  const Comp = $derived(def?.component);
+
+  const resolvedProps = $derived.by(() => {
+    if (!def) return {};
+    let props = node.props;
+    if (!props) {
+      const args = (node as any).args as unknown[] | undefined;
+      if (args) {
+        const fieldNames = Object.keys(def.props.shape);
+        props = {};
+        for (let i = 0; i < fieldNames.length && i < args.length; i++) {
+          props[fieldNames[i]] = args[i];
+        }
+      }
+      props = props ?? {};
+    }
+    return props;
+  });
+
+  /**
+   * renderNode function passed to component renderers.
+   * Components use this with <RenderValue> to render nested children.
+   */
+  function renderNode(value: unknown): unknown {
+    return value;
+  }
+</script>
+
+{#if Comp}
+  <svelte:component this={Comp} props={resolvedProps} {renderNode} />
+{/if}

--- a/packages/svelte-lang/src/RenderValue.svelte
+++ b/packages/svelte-lang/src/RenderValue.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { getOpenUI } from "./context.js";
+  import type { ElementNode } from "./parser/types.js";
+  import RenderNode from "./RenderNode.svelte";
+
+  interface Props {
+    value: unknown;
+  }
+
+  let { value }: Props = $props();
+
+  const ctx = getOpenUI();
+</script>
+
+{#if value == null}
+  <!-- null/undefined: render nothing -->
+{:else if typeof value === "string"}
+  {value}
+{:else if typeof value === "number" || typeof value === "boolean"}
+  {String(value)}
+{:else if Array.isArray(value)}
+  {#each value as item, i (i)}
+    <svelte:self value={item} />
+  {/each}
+{:else if typeof value === "object" && value !== null && (value as Record<string, unknown>).type === "element"}
+  <RenderNode node={value as unknown as ElementNode} library={ctx.library} />
+{/if}

--- a/packages/svelte-lang/src/Renderer.svelte
+++ b/packages/svelte-lang/src/Renderer.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { setOpenUIContext } from "./context.js";
+  import type { ComponentRenderer, DefinedComponent, Library } from "./library.js";
+  import type { ActionEvent, ElementNode, ParseResult } from "./parser/types.js";
+  import { createOpenUIState } from "./stores/openui.svelte.js";
+  import RenderNode from "./RenderNode.svelte";
+
+  interface Props {
+    /** Raw response text (openui-lang code). */
+    response: string | null;
+    /** Component library from createLibrary(). */
+    library: Library;
+    /** Whether the LLM is still streaming (form interactions disabled during streaming). */
+    isStreaming?: boolean;
+    /** Callback when a component triggers an action. */
+    onAction?: (event: ActionEvent) => void;
+    /**
+     * Called whenever a form field value changes. Receives the raw form state map.
+     */
+    onStateUpdate?: (state: Record<string, any>) => void;
+    /**
+     * Initial form state to hydrate on load.
+     */
+    initialState?: Record<string, any>;
+    /** Called whenever the parse result changes. */
+    onParseResult?: (result: ParseResult | null) => void;
+  }
+
+  let {
+    response,
+    library,
+    isStreaming = false,
+    onAction,
+    onStateUpdate,
+    initialState,
+    onParseResult,
+  }: Props = $props();
+
+  /**
+   * Recursively renders a parsed value (element, array, primitive)
+   * into Svelte-renderable content. Used by component renderers.
+   *
+   * In Svelte, we return the raw data and let RenderNode handle rendering.
+   * This function is passed to component renderers so they can render
+   * nested children.
+   */
+  function renderDeep(value: unknown): any {
+    return value;
+  }
+
+  const state = createOpenUIState(
+    () => ({
+      response,
+      library,
+      isStreaming,
+      onAction,
+      onStateUpdate,
+      initialState,
+    }),
+    renderDeep as any,
+  );
+
+  // Notify parent when parse result changes
+  $effect(() => {
+    onParseResult?.(state.result);
+  });
+
+  // Set the context for child components
+  setOpenUIContext(state.contextValue);
+</script>
+
+{#if state.result?.root}
+  <RenderNode node={state.result.root} {library} />
+{/if}

--- a/packages/svelte-lang/src/context.ts
+++ b/packages/svelte-lang/src/context.ts
@@ -1,0 +1,143 @@
+import { getContext, setContext } from "svelte";
+import type { Snippet } from "svelte";
+import type { Library } from "./library.js";
+
+const OPENUI_CONTEXT_KEY = Symbol("openui-context");
+const FORM_NAME_CONTEXT_KEY = Symbol("openui-form-name");
+
+/**
+ * Shared context provided by <Renderer /> to all rendered components.
+ */
+export interface OpenUIContextValue {
+  /** The active component library (schema + renderers). */
+  library: Library;
+
+  /**
+   * Render any value (element, array, primitive) into a Svelte snippet.
+   */
+  renderNode: (value: unknown) => Snippet;
+
+  /**
+   * Trigger an action. Components call this to fire structured ActionEvents.
+   *
+   * @param userMessage  Human-readable label ("Submit Application")
+   * @param formName  Optional form name — if provided, form state for this form is included
+   * @param action  Optional custom action config { type, params }
+   */
+  triggerAction: (
+    userMessage: string,
+    formName?: string,
+    action?: { type?: string; params?: Record<string, any> },
+  ) => void;
+
+  /** Whether the LLM is currently streaming content. */
+  isStreaming: boolean;
+
+  /** Get a form field value. Returns undefined if not set. */
+  getFieldValue: (formName: string | undefined, name: string) => any;
+
+  /**
+   * Set a form field value.
+   *
+   * @param formName  The form's name prop
+   * @param componentType  The component type (e.g. "Input", "Select", "RadioGroup")
+   * @param name  The field's name prop
+   * @param value  The new value
+   * @param shouldTriggerSaveCallback  When true, persists the updated state via updateMessage.
+   */
+  setFieldValue: (
+    formName: string | undefined,
+    componentType: string | undefined,
+    name: string,
+    value: any,
+    shouldTriggerSaveCallback?: boolean,
+  ) => void;
+}
+
+/**
+ * Set the OpenUI context. Called internally by <Renderer />.
+ */
+export function setOpenUIContext(value: OpenUIContextValue): void {
+  setContext(OPENUI_CONTEXT_KEY, value);
+}
+
+/**
+ * Access the full OpenUI context. Throws if used outside a <Renderer />.
+ */
+export function getOpenUI(): OpenUIContextValue {
+  const ctx = getContext<OpenUIContextValue | undefined>(OPENUI_CONTEXT_KEY);
+  if (!ctx) {
+    throw new Error("getOpenUI must be used within a <Renderer /> component.");
+  }
+  return ctx;
+}
+
+/**
+ * Get the renderNode function for rendering nested component values.
+ */
+export function getRenderNode() {
+  return getOpenUI().renderNode;
+}
+
+/**
+ * Get the triggerAction function for firing structured action events.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { getTriggerAction } from '@openuidev/svelte-lang';
+ *   const triggerAction = getTriggerAction();
+ * </script>
+ * <button onclick={() => triggerAction("Submit", "myForm")}>Submit</button>
+ * ```
+ */
+export function getTriggerAction() {
+  return getOpenUI().triggerAction;
+}
+
+/**
+ * Whether the LLM is currently streaming content.
+ */
+export function getIsStreaming() {
+  return getOpenUI().isStreaming;
+}
+
+/**
+ * Get a form field value from the form state context.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { getGetFieldValue } from '@openuidev/svelte-lang';
+ *   const getFieldValue = getGetFieldValue();
+ *   const name = getFieldValue("contactForm", "name");
+ * </script>
+ * ```
+ */
+export function getGetFieldValue() {
+  return getOpenUI().getFieldValue;
+}
+
+/**
+ * Get the setFieldValue function for updating form field values.
+ */
+export function getSetFieldValue() {
+  return getOpenUI().setFieldValue;
+}
+
+// ─── FormName context ───
+
+/**
+ * Set the form name context. Called by form components.
+ */
+export function setFormNameContext(name: string | undefined): void {
+  setContext(FORM_NAME_CONTEXT_KEY, name);
+}
+
+/**
+ * Get the current form name (set by the nearest parent Form component).
+ * Returns undefined if not inside a Form.
+ */
+export function getFormName(): string | undefined {
+  return getContext<string | undefined>(FORM_NAME_CONTEXT_KEY);
+}

--- a/packages/svelte-lang/src/index.ts
+++ b/packages/svelte-lang/src/index.ts
@@ -1,0 +1,56 @@
+// define library
+export { createLibrary, defineComponent } from "./library.js";
+export type {
+  ComponentGroup,
+  ComponentRenderProps,
+  ComponentRenderer,
+  DefinedComponent,
+  Library,
+  LibraryDefinition,
+  PromptOptions,
+  SubComponentOf,
+} from "./library.js";
+
+// openui-lang renderer
+export { default as Renderer } from "./Renderer.svelte";
+
+// openui-lang helper components for rendering nested values
+export { default as RenderValue } from "./RenderValue.svelte";
+export { default as RenderNode } from "./RenderNode.svelte";
+
+// openui-lang action types
+export { BuiltinActionType } from "./parser/types.js";
+export type { ActionEvent, ElementNode, ParseResult } from "./parser/types.js";
+
+// openui-lang parser (server-side use)
+export { createParser, createStreamingParser, type LibraryJSONSchema } from "./parser/index.js";
+
+// openui-lang context (for use inside component renderers)
+export {
+  getFormName,
+  getGetFieldValue,
+  getIsStreaming,
+  getOpenUI,
+  getRenderNode,
+  getSetFieldValue,
+  getTriggerAction,
+  setFormNameContext,
+  setOpenUIContext,
+} from "./context.js";
+export type { OpenUIContextValue } from "./context.js";
+
+// openui-lang stores (Svelte-idiomatic state management)
+export { createOpenUIState } from "./stores/openui.svelte.js";
+export type { OpenUIStateOptions } from "./stores/openui.svelte.js";
+
+// openui-lang form validation
+export {
+  createFormValidation,
+  getFormValidation,
+  setFormValidationContext,
+} from "./stores/formValidation.svelte.js";
+export type { FormValidationContextValue } from "./stores/formValidation.svelte.js";
+
+// openui-lang validation utilities
+export { builtInValidators, parseRules, parseStructuredRules, validate } from "./utils/validation.js";
+export type { ParsedRule, ValidatorFn } from "./utils/validation.js";

--- a/packages/svelte-lang/src/library.ts
+++ b/packages/svelte-lang/src/library.ts
@@ -1,0 +1,159 @@
+import type { Component, Snippet } from "svelte";
+import { z } from "zod";
+import { generatePrompt } from "./parser/prompt.js";
+
+// ─── Sub-component type ──────────────────────────────────────────────────────
+
+/**
+ * Runtime shape of a parsed sub-component element as seen by parent renderers.
+ */
+export type SubComponentOf<P> = {
+  type: "element";
+  typeName: string;
+  props: P;
+  partial: boolean;
+};
+
+// ─── Renderer types ───────────────────────────────────────────────────────────
+
+export interface ComponentRenderProps<P = Record<string, unknown>> {
+  props: P;
+  renderNode: (value: unknown) => Snippet;
+}
+
+/**
+ * A Svelte component that receives ComponentRenderProps as its props.
+ * This is the type for user-defined component renderers.
+ */
+export type ComponentRenderer<P = Record<string, unknown>> = Component<ComponentRenderProps<P>>;
+
+// ─── DefinedComponent ─────────────────────────────────────────────────────────
+
+/**
+ * A fully defined component with name, schema, description, renderer,
+ * and a `.ref` for type-safe cross-referencing in parent schemas.
+ */
+export interface DefinedComponent<T extends z.ZodObject<any> = z.ZodObject<any>> {
+  name: string;
+  props: T;
+  description: string;
+  component: ComponentRenderer<z.infer<T>>;
+  /** Use in parent schemas: `z.array(ChildComponent.ref)` */
+  ref: z.ZodType<SubComponentOf<z.infer<T>>>;
+}
+
+/**
+ * Define a component with name, schema, description, and renderer.
+ * Registers the Zod schema globally and returns a `.ref` for parent schemas.
+ *
+ * @example
+ * ```ts
+ * const TabItem = defineComponent({
+ *   name: "TabItem",
+ *   props: z.object({ value: z.string(), trigger: z.string(), content: z.array(ContentChildUnion) }),
+ *   description: "Tab panel",
+ *   component: TabItemComponent,
+ * });
+ *
+ * const Tabs = defineComponent({
+ *   name: "Tabs",
+ *   props: z.object({ items: z.array(TabItem.ref) }),
+ *   description: "Tabbed container",
+ *   component: TabsComponent,
+ * });
+ * ```
+ */
+export function defineComponent<T extends z.ZodObject<any>>(config: {
+  name: string;
+  props: T;
+  description: string;
+  component: ComponentRenderer<z.infer<T>>;
+}): DefinedComponent<T> {
+  (config.props as any).register(z.globalRegistry, { id: config.name });
+  return {
+    ...config,
+    ref: config.props as unknown as z.ZodType<SubComponentOf<z.infer<T>>>,
+  };
+}
+
+// ─── Groups & Prompt ──────────────────────────────────────────────────────────
+
+export interface ComponentGroup {
+  name: string;
+  components: string[];
+  notes?: string[];
+}
+
+export interface PromptOptions {
+  preamble?: string;
+  additionalRules?: string[];
+  examples?: string[];
+}
+
+// ─── Library ──────────────────────────────────────────────────────────────────
+
+export interface Library {
+  readonly components: Record<string, DefinedComponent>;
+  readonly componentGroups: ComponentGroup[] | undefined;
+  readonly root: string | undefined;
+
+  prompt(options?: PromptOptions): string;
+  /**
+   * Returns a single, valid JSON Schema document for the entire library.
+   * All component schemas are in `$defs`, keyed by component name.
+   */
+  toJSONSchema(): object;
+}
+
+export interface LibraryDefinition {
+  components: DefinedComponent[];
+  componentGroups?: ComponentGroup[];
+  root?: string;
+}
+
+/**
+ * Create a component library from an array of defined components.
+ *
+ * @example
+ * ```ts
+ * const library = createLibrary({
+ *   components: [TabItem, Tabs, Card],
+ *   root: "Card",
+ * });
+ * ```
+ */
+export function createLibrary(input: LibraryDefinition): Library {
+  const componentsRecord: Record<string, DefinedComponent> = {};
+  for (const comp of input.components) {
+    if (!z.globalRegistry.has(comp.props)) {
+      comp.props.register(z.globalRegistry, { id: comp.name });
+    }
+    componentsRecord[comp.name] = comp;
+  }
+
+  if (input.root && !componentsRecord[input.root]) {
+    const available = Object.keys(componentsRecord).join(", ");
+    throw new Error(
+      `[createLibrary] Root component "${input.root}" was not found in components. Available components: ${available}`,
+    );
+  }
+
+  const library: Library = {
+    components: componentsRecord,
+    componentGroups: input.componentGroups,
+    root: input.root,
+
+    prompt(options?: PromptOptions): string {
+      return generatePrompt(library, options);
+    },
+
+    toJSONSchema(): object {
+      const combinedSchema = z.object(
+        Object.fromEntries(Object.entries(componentsRecord).map(([k, v]) => [k, v.props])) as any,
+      );
+      return z.toJSONSchema(combinedSchema);
+    },
+  };
+
+  return library;
+}

--- a/packages/svelte-lang/src/parser/index.ts
+++ b/packages/svelte-lang/src/parser/index.ts
@@ -1,0 +1,7 @@
+export { BuiltinActionType } from "./types.js";
+export type { ActionEvent, ElementNode, ParseResult, ValidationError } from "./types.js";
+
+export { createParser, createStreamingParser, parse } from "./parser.js";
+export type { LibraryJSONSchema, Parser, StreamParser } from "./parser.js";
+
+export { generatePrompt } from "./prompt.js";

--- a/packages/svelte-lang/src/parser/parser.ts
+++ b/packages/svelte-lang/src/parser/parser.ts
@@ -1,0 +1,787 @@
+import type { ParseResult } from "./types";
+
+/**
+ * The JSON Schema document produced by `library.toJSONSchema()`.
+ * All component schemas live in `$defs`, keyed by component name.
+ */
+export interface LibraryJSONSchema {
+  $defs?: Record<
+    string,
+    {
+      properties?: Record<string, unknown>;
+      required?: string[];
+    }
+  >;
+}
+
+export interface ParamDef {
+  /** Parameter name, e.g. "title", "columns". */
+  name: string;
+  /** Whether the parameter is required by the component. */
+  required: boolean;
+  /** Default value from JSON Schema — used when the required field is missing/null. */
+  defaultValue?: unknown;
+}
+
+/**
+ * Internal parameter map.
+ */
+export type ParamMap = Map<string, { params: ParamDef[] }>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AST node types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Discriminated union representing every value that can appear in an
+ * openui-lang expression. The `k` field is the discriminant.
+ *
+ * - `Comp`  — a component call: `Header("Hello", "Subtitle")`
+ * - `Str`   — a string literal: `"hello"`
+ * - `Num`   — a number literal: `42` or `3.14`
+ * - `Bool`  — a boolean literal: `true` or `false`
+ * - `Null`  — the null literal
+ * - `Arr`   — an array: `[a, b, c]`
+ * - `Obj`   — an object: `{ key: value }`
+ * - `Ref`   — a reference to another statement: `myTable` (resolved later)
+ * - `Ph`    — a placeholder for an unresolvable reference (dropped as null in output)
+ */
+type ASTNode =
+  | { k: "Comp"; name: string; args: ASTNode[] }
+  | { k: "Str"; v: string }
+  | { k: "Num"; v: number }
+  | { k: "Bool"; v: boolean }
+  | { k: "Null" }
+  | { k: "Arr"; els: ASTNode[] }
+  | { k: "Obj"; entries: [string, ASTNode][] }
+  | { k: "Ref"; n: string }
+  | { k: "Ph"; n: string };
+
+const enum T {
+  Newline = 0,
+  LParen = 1, // (
+  RParen = 2, // )
+  LBrack = 3, // [
+  RBrack = 4, // ]
+  LBrace = 5, // {
+  RBrace = 6, // }
+  Comma = 7, // ,
+  Colon = 8, // :
+  Equals = 9, // =
+  True = 10,
+  False = 11,
+  Null = 12,
+  EOF = 13,
+  Str = 14, // carries string value
+  Num = 15, // carries numeric value
+  Ident = 16, // lowercase identifier — becomes a reference
+  Type = 17, // PascalCase identifier — becomes a component name or reference
+}
+
+type Token = { t: T; v?: string | number };
+
+function autoClose(input: string): { text: string; wasIncomplete: boolean } {
+  const stack: string[] = [];
+  let inStr = false,
+    esc = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+
+    if (esc) {
+      esc = false;
+      continue;
+    }
+    if (c === "\\" && inStr) {
+      esc = true;
+      continue;
+    }
+    if (c === '"') {
+      inStr = !inStr;
+      continue;
+    }
+    if (inStr) continue;
+
+    if (c === "(" || c === "[" || c === "{") stack.push(c);
+    else if (c === ")" && stack[stack.length - 1] === "(") stack.pop();
+    else if (c === "]" && stack[stack.length - 1] === "[") stack.pop();
+    else if (c === "}" && stack[stack.length - 1] === "{") stack.pop();
+  }
+
+  const wasIncomplete = inStr || stack.length > 0;
+  if (!wasIncomplete) return { text: input, wasIncomplete: false };
+
+  let out = input;
+  if (inStr) {
+    if (esc) out += "\\";
+    out += '"';
+  } // close open string
+  for (
+    let j = stack.length - 1;
+    j >= 0;
+    j-- // close brackets in reverse
+  )
+    out += stack[j] === "(" ? ")" : stack[j] === "[" ? "]" : "}";
+
+  return { text: out, wasIncomplete: true };
+}
+
+// lexer
+function tokenize(src: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  const n = src.length;
+
+  while (i < n) {
+    // Skip horizontal whitespace (not newlines — they're significant)
+    while (i < n && (src[i] === " " || src[i] === "\t" || src[i] === "\r")) i++;
+    if (i >= n) break;
+
+    const c = src[i];
+
+    // ── Single-character punctuation ──────────────────────────────────────
+    if (c === "\n") {
+      tokens.push({ t: T.Newline });
+      i++;
+      continue;
+    }
+    if (c === "(") {
+      tokens.push({ t: T.LParen });
+      i++;
+      continue;
+    }
+    if (c === ")") {
+      tokens.push({ t: T.RParen });
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      tokens.push({ t: T.LBrack });
+      i++;
+      continue;
+    }
+    if (c === "]") {
+      tokens.push({ t: T.RBrack });
+      i++;
+      continue;
+    }
+    if (c === "{") {
+      tokens.push({ t: T.LBrace });
+      i++;
+      continue;
+    }
+    if (c === "}") {
+      tokens.push({ t: T.RBrace });
+      i++;
+      continue;
+    }
+    if (c === ",") {
+      tokens.push({ t: T.Comma });
+      i++;
+      continue;
+    }
+    if (c === ":") {
+      tokens.push({ t: T.Colon });
+      i++;
+      continue;
+    }
+    if (c === "=") {
+      tokens.push({ t: T.Equals });
+      i++;
+      continue;
+    }
+
+    // string literal: "..."
+    if (c === '"') {
+      const start = i;
+      i++; // skip opening quote
+
+      let isClosed = false;
+      // Fast-forward to the closing quote, respecting escapes
+      while (i < n) {
+        if (src[i] === "\\") {
+          i += 2; // skip backslash and the escaped character
+        } else if (src[i] === '"') {
+          i++; // include the closing quote
+          isClosed = true;
+          break;
+        } else {
+          i++;
+        }
+      }
+
+      const rawString = src.slice(start, i);
+
+      try {
+        // Let JavaScript's native JSON parser handle all unescaping (\n, \t, \uXXXX, etc.)
+        // If the string is incomplete (streaming), we add a closing quote to parse what we have so far.
+        const validJsonString = isClosed ? rawString : rawString + '"';
+
+        tokens.push({ t: T.Str, v: JSON.parse(validJsonString) });
+      } catch {
+        // Fallback if JSON.parse fails (e.g., malformed unicode escape during streaming)
+        // Strip the quotes and return the raw text so the UI doesn't crash
+        const stripped = rawString.replace(/^"|"$/g, "");
+        tokens.push({ t: T.Str, v: stripped });
+      }
+      continue;
+    }
+
+    // number literal: 42, -3, 1.5
+    const isDigit = c >= "0" && c <= "9";
+    const isNegDigit = c === "-" && i + 1 < n && src[i + 1] >= "0" && src[i + 1] <= "9";
+    if (isDigit || isNegDigit) {
+      const start = i;
+      if (src[i] === "-") i++; // optional minus
+      while (i < n && src[i] >= "0" && src[i] <= "9") i++; // integer part
+      if (i < n && src[i] === ".") {
+        // optional decimal
+        i++;
+        while (i < n && src[i] >= "0" && src[i] <= "9") i++;
+      }
+      if (i < n && (src[i] === "e" || src[i] === "E")) {
+        // optional exponent
+        i++;
+        if (i < n && (src[i] === "+" || src[i] === "-")) i++;
+        while (i < n && src[i] >= "0" && src[i] <= "9") i++;
+      }
+      tokens.push({ t: T.Num, v: +src.slice(start, i) });
+      continue;
+    }
+
+    // keyword or identifier
+    const isAlpha = (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_";
+    if (isAlpha) {
+      const start = i;
+      while (
+        i < n &&
+        ((src[i] >= "a" && src[i] <= "z") ||
+          (src[i] >= "A" && src[i] <= "Z") ||
+          (src[i] >= "0" && src[i] <= "9") ||
+          src[i] === "_")
+      )
+        i++;
+
+      const word = src.slice(start, i);
+
+      if (word === "true") {
+        tokens.push({ t: T.True });
+        continue;
+      }
+      if (word === "false") {
+        tokens.push({ t: T.False });
+        continue;
+      }
+      if (word === "null") {
+        tokens.push({ t: T.Null });
+        continue;
+      }
+
+      // PascalCase → component type name; lowercase → variable reference
+      const kind = c >= "A" && c <= "Z" ? T.Type : T.Ident;
+      tokens.push({ t: kind, v: word });
+      continue;
+    }
+
+    i++; // skip any other character (e.g. @, #, emojis)
+  }
+
+  tokens.push({ t: T.EOF });
+  return tokens;
+}
+
+interface RawStmt {
+  id: string;
+  tokens: Token[];
+}
+
+/**
+ * Splits the flat token stream into individual statements.
+ *
+ * Each statement has the form `identifier = expression`. Statements are
+ * separated by newlines at depth 0 (newlines inside brackets are ignored).
+ *
+ * Example input tokens for:
+ *   `root = Root([tbl])\ntbl = Table(...)`
+ *
+ * Produces two RawStmts:
+ *   { id: "root", tokens: [Root, (, [, tbl, ], )] }
+ *   { id: "tbl",  tokens: [Table, (, ..., )] }
+ *
+ * Invalid lines (no `=`, or no identifier) are silently skipped.
+ */
+function split(tokens: Token[]): RawStmt[] {
+  const stmts: RawStmt[] = [];
+  let pos = 0;
+
+  while (pos < tokens.length) {
+    // Skip blank lines
+    while (pos < tokens.length && tokens[pos].t === T.Newline) pos++;
+    if (pos >= tokens.length || tokens[pos].t === T.EOF) break;
+
+    // Expect: Ident|Type = expression
+    const tok = tokens[pos];
+    if (tok.t !== T.Ident && tok.t !== T.Type) {
+      while (pos < tokens.length && tokens[pos].t !== T.Newline && tokens[pos].t !== T.EOF) pos++;
+      continue;
+    }
+    const id = tok.v as string;
+    pos++;
+
+    // Must be followed by `=`
+    if (pos >= tokens.length || tokens[pos].t !== T.Equals) {
+      while (pos < tokens.length && tokens[pos].t !== T.Newline && tokens[pos].t !== T.EOF) pos++;
+      continue;
+    }
+    pos++;
+
+    // Collect expression tokens until a depth-0 newline or EOF
+    const expr: Token[] = [];
+    let depth = 0;
+    while (pos < tokens.length && tokens[pos].t !== T.EOF) {
+      const tt = tokens[pos].t;
+      if (tt === T.Newline && depth <= 0) break; // statement boundary
+      if (tt === T.Newline) {
+        pos++;
+        continue;
+      } // newline inside bracket — skip
+      if (tt === T.LParen || tt === T.LBrack || tt === T.LBrace) depth++;
+      else if (tt === T.RParen || tt === T.RBrack || tt === T.RBrace) depth--;
+      expr.push(tokens[pos++]);
+    }
+
+    if (expr.length) stmts.push({ id, tokens: expr });
+  }
+
+  return stmts;
+}
+
+function parseTokens(tokens: Token[]): ASTNode {
+  let pos = 0;
+  const cur = (): Token => tokens[pos] ?? { t: T.EOF };
+  const adv = () => pos++;
+  const eat = (kind: T) => {
+    if (cur().t === kind) adv();
+  };
+
+  function parseExpr(): ASTNode {
+    const tok = cur();
+
+    if (tok.t === T.Type) {
+      // PascalCase followed by `(` → component call; otherwise a reference
+      return tokens[pos + 1]?.t === T.LParen
+        ? parseComp()
+        : (adv(), { k: "Ref", n: tok.v as string });
+    }
+    if (tok.t === T.Str) {
+      adv();
+      return { k: "Str", v: tok.v as string };
+    }
+    if (tok.t === T.Num) {
+      adv();
+      return { k: "Num", v: tok.v as number };
+    }
+    if (tok.t === T.True) {
+      adv();
+      return { k: "Bool", v: true };
+    }
+    if (tok.t === T.False) {
+      adv();
+      return { k: "Bool", v: false };
+    }
+    if (tok.t === T.Null) {
+      adv();
+      return { k: "Null" };
+    }
+    if (tok.t === T.LBrack) return parseArr();
+    if (tok.t === T.LBrace) return parseObj();
+    if (tok.t === T.Ident) {
+      adv();
+      return { k: "Ref", n: tok.v as string };
+    }
+
+    adv();
+    return { k: "Null" }; // unknown token — treat as null
+  }
+
+  /** Parse `TypeName(arg1, arg2, ...)` */
+  function parseComp(): ASTNode {
+    const name = cur().v as string;
+    adv();
+    eat(T.LParen);
+    const args: ASTNode[] = [];
+    while (cur().t !== T.RParen && cur().t !== T.EOF) {
+      args.push(parseExpr());
+      if (cur().t === T.Comma) adv();
+    }
+    eat(T.RParen);
+    return { k: "Comp", name, args };
+  }
+
+  /** Parse `[elem1, elem2, ...]` */
+  function parseArr(): ASTNode {
+    adv(); // skip [
+    const els: ASTNode[] = [];
+    while (cur().t !== T.RBrack && cur().t !== T.EOF) {
+      els.push(parseExpr());
+      if (cur().t === T.Comma) adv();
+    }
+    eat(T.RBrack);
+    return { k: "Arr", els };
+  }
+
+  /** Parse `{ key: value, ... }` */
+  function parseObj(): ASTNode {
+    adv(); // skip {
+    const entries: [string, ASTNode][] = [];
+    while (cur().t !== T.RBrace && cur().t !== T.EOF) {
+      const kt = cur();
+      const key =
+        kt.t === T.Ident || kt.t === T.Str || kt.t === T.Type || kt.t === T.Num
+          ? (adv(), String(kt.v))
+          : (adv(), "?");
+      eat(T.Colon);
+      entries.push([key, parseExpr()]);
+      if (cur().t === T.Comma) adv();
+    }
+    eat(T.RBrace);
+    return { k: "Obj", entries };
+  }
+
+  return parseExpr();
+}
+
+function resolveNode(
+  node: ASTNode,
+  syms: Map<string, ASTNode>,
+  unres: string[],
+  visited: Set<string>,
+): ASTNode {
+  if (node.k === "Ref") {
+    const { n } = node;
+    if (visited.has(n)) {
+      unres.push(n);
+      return { k: "Ph", n };
+    } // cycle
+    if (!syms.has(n)) {
+      unres.push(n);
+      return { k: "Ph", n };
+    } // missing
+
+    visited.add(n);
+    const resolved = resolveNode(syms.get(n)!, syms, unres, visited);
+    visited.delete(n);
+    return resolved;
+  }
+
+  if (node.k === "Comp")
+    return {
+      ...node,
+      args: node.args.map((a) => resolveNode(a, syms, unres, visited)),
+    };
+  if (node.k === "Arr")
+    return {
+      ...node,
+      els: node.els.map((e) => resolveNode(e, syms, unres, visited)),
+    };
+  if (node.k === "Obj")
+    return {
+      ...node,
+      entries: node.entries.map(([k, v]) => [k, resolveNode(v, syms, unres, visited)]),
+    };
+
+  // Literals and placeholders pass through unchanged
+  return node;
+}
+
+type JsonVal = string | number | boolean | null | JsonVal[] | { [k: string]: JsonVal };
+
+function toJson(
+  node: ASTNode,
+  partial: boolean,
+  errors: ParseResult["meta"]["validationErrors"],
+  cat: ParamMap | undefined,
+): JsonVal {
+  if (node.k === "Str") return node.v;
+  if (node.k === "Num") return node.v;
+  if (node.k === "Bool") return node.v;
+  if (node.k === "Null") return null;
+  if (node.k === "Arr") {
+    const items: JsonVal[] = [];
+    for (const e of node.els) {
+      // Drop unresolved references from arrays to avoid null entries like [null, element]
+      if (e.k === "Ph") continue;
+      const value = toJson(e, partial, errors, cat);
+      // Drop invalid component entries from arrays (e.g. incomplete required props while streaming)
+      if (e.k === "Comp" && value === null) continue;
+      items.push(value);
+    }
+    return items;
+  }
+  if (node.k === "Obj") {
+    const o: { [k: string]: JsonVal } = {};
+    for (const [k, v] of node.entries) o[k] = toJson(v, partial, errors, cat);
+    return o;
+  }
+  if (node.k === "Comp") return mapNode(node, partial, errors, cat) as unknown as JsonVal;
+  if (node.k === "Ph") return null;
+  return null;
+}
+
+function mapNode(
+  node: ASTNode,
+  partial: boolean,
+  errors: ParseResult["meta"]["validationErrors"],
+  cat: ParamMap | undefined,
+): ParseResult["root"] {
+  if (node.k === "Ph") return null;
+  if (node.k !== "Comp") return null;
+
+  const { name, args } = node;
+  const def = cat?.get(name);
+  const props: { [k: string]: JsonVal } = {};
+
+  if (def) {
+    // Map positional args → named props using library param order
+    for (let i = 0; i < def.params.length && i < args.length; i++)
+      props[def.params[i].name] = toJson(args[i], partial, errors, cat);
+
+    // Validate required props — try defaultValue first before dropping
+    const missingRequired = def.params.filter(
+      (p) => p.required && (!(p.name in props) || props[p.name] === null),
+    );
+    if (missingRequired.length) {
+      const stillInvalid = missingRequired.filter((p) => {
+        if (p.defaultValue !== undefined) {
+          props[p.name] = p.defaultValue as JsonVal;
+          return false;
+        }
+        return true;
+      });
+      if (stillInvalid.length) {
+        for (const p of stillInvalid)
+          errors.push({
+            component: name,
+            path: `/${p.name}`,
+            message:
+              p.name in props
+                ? `required field "${p.name}" cannot be null`
+                : `missing required field "${p.name}"`,
+          });
+        return null;
+      }
+    }
+  } else {
+    // No library entry for this component — preserve all args under _args
+    props._args = args.map((a) => toJson(a, partial, errors, cat));
+  }
+
+  return { type: "element", typeName: name, props, partial };
+}
+
+function emptyResult(incomplete = true): ParseResult {
+  return {
+    root: null,
+    meta: {
+      incomplete,
+      unresolved: [],
+      statementCount: 0,
+      validationErrors: [],
+    },
+  };
+}
+
+function buildResult(
+  syms: Map<string, ASTNode>,
+  firstId: string,
+  wasIncomplete: boolean,
+  stmtCount: number,
+  cat: ParamMap | undefined,
+): ParseResult {
+  if (!syms.has(firstId)) return emptyResult(wasIncomplete);
+
+  const unres: string[] = [];
+  const resolved = resolveNode(syms.get(firstId)!, syms, unres, new Set());
+  const errors: ParseResult["meta"]["validationErrors"] = [];
+  const root = mapNode(resolved, wasIncomplete, errors, cat);
+
+  return {
+    root,
+    meta: {
+      incomplete: wasIncomplete,
+      unresolved: unres,
+      statementCount: stmtCount,
+      validationErrors: errors,
+    },
+  };
+}
+
+/**
+ * Parse a complete openui-lang string in one pass.
+ *
+ * @param input  - Full openui-lang source text (may be partial/streaming)
+ * @param cat    - Optional param map for positional-arg → named-prop mapping
+ * @returns      ParseResult with root ElementNode (or null) and metadata
+ */
+export function parse(input: string, cat?: ParamMap): ParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return emptyResult();
+
+  const { text, wasIncomplete } = autoClose(trimmed);
+  const stmts = split(tokenize(text));
+  if (!stmts.length) return emptyResult(wasIncomplete);
+
+  const syms = new Map<string, ASTNode>();
+  let firstId = "";
+  for (const s of stmts) {
+    syms.set(s.id, parseTokens(s.tokens));
+    if (!firstId) firstId = s.id;
+  }
+
+  return buildResult(syms, firstId, wasIncomplete, stmts.length, cat);
+}
+
+export interface StreamParser {
+  /** Feed the next SSE/stream chunk and get the latest ParseResult. */
+  push(chunk: string): ParseResult;
+  /** Get the latest ParseResult without consuming new data. */
+  getResult(): ParseResult;
+}
+
+export function createStreamParser(cat?: ParamMap): StreamParser {
+  let buf = "";
+  let completedEnd = 0;
+  const completedSyms = new Map<string, ASTNode>();
+
+  let completedCount = 0;
+  let firstId = "";
+
+  function addStmt(text: string) {
+    for (const s of split(tokenize(text))) {
+      completedSyms.set(s.id, parseTokens(s.tokens));
+      completedCount++;
+      if (!firstId) firstId = s.id;
+    }
+  }
+
+  function scanNewCompleted(): number {
+    let depth = 0,
+      inStr = false,
+      esc = false;
+    let stmtStart = completedEnd;
+
+    for (let i = completedEnd; i < buf.length; i++) {
+      const c = buf[i];
+      if (esc) {
+        esc = false;
+        continue;
+      }
+      if (c === "\\" && inStr) {
+        esc = true;
+        continue;
+      }
+      if (c === '"') {
+        inStr = !inStr;
+        continue;
+      }
+      if (inStr) continue;
+
+      if (c === "(" || c === "[" || c === "{") depth++;
+      else if (c === ")" || c === "]" || c === "}") depth--;
+      else if (c === "\n" && depth <= 0) {
+        // Depth-0 newline = end of a statement
+        const t = buf.slice(stmtStart, i).trim();
+        if (t) addStmt(t);
+        stmtStart = i + 1; // next statement begins after this newline
+        completedEnd = i + 1; // advance the "already processed" watermark
+      }
+    }
+
+    return stmtStart; // start of the current pending (incomplete) statement
+  }
+
+  function currentResult(): ParseResult {
+    const pendingStart = scanNewCompleted();
+    const pendingText = buf.slice(pendingStart).trim();
+
+    // No pending text — all statements are complete
+    if (!pendingText) {
+      if (completedCount === 0) return emptyResult();
+      return buildResult(completedSyms, firstId, false, completedCount, cat);
+    }
+
+    // Autoclose the incomplete last statement so it's syntactically valid
+    const { text: closed, wasIncomplete } = autoClose(pendingText);
+    const stmts = split(tokenize(closed));
+
+    if (!stmts.length) {
+      if (completedCount === 0) return emptyResult(wasIncomplete);
+      return buildResult(completedSyms, firstId, wasIncomplete, completedCount, cat);
+    }
+
+    // Merge: completed cache + re-parsed pending statement
+    // (Map spread is cheap since completedSyms only grows by one entry at a time)
+    const allSyms = new Map(completedSyms);
+    for (const s of stmts) allSyms.set(s.id, parseTokens(s.tokens));
+
+    const fid = firstId || stmts[0].id;
+    return buildResult(allSyms, fid, wasIncomplete, completedCount + stmts.length, cat);
+  }
+
+  return {
+    push(chunk) {
+      buf += chunk;
+      return currentResult();
+    },
+    getResult: currentResult,
+  };
+}
+
+export interface Parser {
+  parse(input: string): ParseResult;
+}
+
+function compileSchema(schema: LibraryJSONSchema): ParamMap {
+  const map: ParamMap = new Map();
+  const defs = schema.$defs ?? {};
+
+  for (const [name, def] of Object.entries(defs)) {
+    const properties = def.properties ?? {};
+    const required = def.required ?? [];
+    const params = Object.keys(properties).map((k) => ({
+      name: k,
+      required: required.includes(k),
+      defaultValue: (properties[k] as any)?.default,
+    }));
+    map.set(name, { params });
+  }
+
+  return map;
+}
+
+/**
+ * Create a parser from a library JSON Schema document.
+ * Pass `library.toJSONSchema()` to get the schema.
+ *
+ * @example
+ * ```ts
+ * const parser = createParser(library.toJSONSchema());
+ * const result = parser.parse(openuiLangString);
+ * ```
+ */
+export function createParser(schema: LibraryJSONSchema): Parser {
+  const paramMap = compileSchema(schema);
+  return {
+    parse(input: string): ParseResult {
+      return parse(input, paramMap);
+    },
+  };
+}
+
+/**
+ * Create a streaming parser from a library JSON Schema document.
+ * Pass `library.toJSONSchema()` to get the schema.
+ */
+export function createStreamingParser(schema: LibraryJSONSchema): StreamParser {
+  return createStreamParser(compileSchema(schema));
+}

--- a/packages/svelte-lang/src/parser/prompt.ts
+++ b/packages/svelte-lang/src/parser/prompt.ts
@@ -1,0 +1,336 @@
+import { z } from "zod";
+import type { DefinedComponent, Library, PromptOptions } from "../library";
+
+const PREAMBLE = `You are an AI assistant that responds using openui-lang, a declarative UI language. Your ENTIRE response must be valid openui-lang code — no markdown, no explanations, just openui-lang.`;
+
+function syntaxRules(rootName: string): string {
+  return `## Syntax Rules
+
+1. Each statement is on its own line: \`identifier = Expression\`
+2. \`root\` is the entry point — every program must define \`root = ${rootName}(...)\`
+3. Expressions are: strings ("..."), numbers, booleans (true/false), arrays ([...]), objects ({...}), or component calls TypeName(arg1, arg2, ...)
+4. Use references for readability: define \`name = ...\` on one line, then use \`name\` later
+5. EVERY variable (except root) MUST be referenced by at least one other variable. Unreferenced variables are silently dropped and will NOT render. Always include defined variables in their parent's children/items array.
+6. Arguments are POSITIONAL (order matters, not names)
+7. Optional arguments can be omitted from the end
+8. No operators, no logic, no variables — only declarations
+9. Strings use double quotes with backslash escaping`;
+}
+
+function streamingRules(rootName: string): string {
+  return `## Hoisting & Streaming (CRITICAL)
+
+openui-lang supports hoisting: a reference can be used BEFORE it is defined. The parser resolves all references after the full input is parsed.
+
+During streaming, the output is re-parsed on every chunk. Undefined references are temporarily unresolved and appear once their definitions stream in. This creates a progressive top-down reveal — structure first, then data fills in.
+
+**Recommended statement order for optimal streaming:**
+1. \`root = ${rootName}(...)\` — UI shell appears immediately
+2. Component definitions — fill in as they stream
+3. Data values — leaf content last
+
+Always write the root = ${rootName}(...) statement first so the UI shell appears immediately, even before child data has streamed in.`;
+}
+
+function importantRules(rootName: string): string {
+  return `## Important Rules
+- ALWAYS start with root = ${rootName}(...)
+- Write statements in TOP-DOWN order: root → components → data (leverages hoisting for progressive streaming)
+- Each statement on its own line
+- No trailing text or explanations — output ONLY openui-lang code
+- When asked about data, generate realistic/plausible data
+- Choose components that best represent the content (tables for comparisons, charts for trends, forms for input, etc.)
+- NEVER define a variable without referencing it from the tree. Every variable must be reachable from root, otherwise it will not render.`;
+}
+
+function getZodDef(schema: unknown): any {
+  return (schema as any)?._zod?.def;
+}
+
+function getZodType(schema: unknown): string | undefined {
+  return getZodDef(schema)?.type;
+}
+
+function isOptionalType(schema: unknown): boolean {
+  return getZodType(schema) === "optional";
+}
+
+function unwrapOptional(schema: unknown): unknown {
+  const def = getZodDef(schema);
+  if (def?.type === "optional") return def.innerType;
+  return schema;
+}
+
+/** Strip optional wrapper to reach the core schema. */
+function unwrap(schema: unknown): unknown {
+  return unwrapOptional(schema);
+}
+
+function isArrayType(schema: unknown): boolean {
+  const s = unwrap(schema);
+  return getZodType(s) === "array";
+}
+
+function getArrayInnerType(schema: unknown): unknown | undefined {
+  const s = unwrap(schema);
+  const def = getZodDef(s);
+  if (def?.type === "array") return def.element ?? def.innerType;
+  return undefined;
+}
+
+function getEnumValues(schema: unknown): string[] | undefined {
+  const s = unwrap(schema);
+  const def = getZodDef(s);
+  if (def?.type !== "enum") return undefined;
+  if (Array.isArray(def.values)) return def.values;
+  if (def.entries && typeof def.entries === "object") return Object.keys(def.entries);
+  return undefined;
+}
+
+function getSchemaId(schema: unknown): string | undefined {
+  try {
+    const meta = z.globalRegistry.get(schema as z.ZodType);
+    return meta?.id;
+  } catch {
+    return undefined;
+  }
+}
+
+function getUnionOptions(schema: unknown): unknown[] | undefined {
+  const def = getZodDef(schema);
+  if (def?.type === "union" && Array.isArray(def.options)) return def.options;
+  return undefined;
+}
+
+function getObjectShape(schema: unknown): Record<string, unknown> | undefined {
+  const def = getZodDef(schema);
+  if (def?.type === "object" && def.shape && typeof def.shape === "object")
+    return def.shape as Record<string, unknown>;
+  return undefined;
+}
+
+/**
+ * Resolve the type annotation for a schema field.
+ * Returns a human-readable type string for the schema.
+ *
+ * Examples:
+ *  - z.string()                   → "string"
+ *  - z.number()                   → "number"
+ *  - z.boolean()                  → "boolean"
+ *  - z.enum(["a","b"])            → '"a" | "b"'
+ *  - z.array(TabItemSchema)       → "TabItem[]"
+ *  - z.union([Input, TextArea])   → "Input | TextArea"
+ *  - z.array(z.union([A, B]))     → "(A | B)[]"
+ *  - ButtonGroupSchema            → "ButtonGroup"
+ *  - z.object({src: z.string()})  → "{src: string}" (inline when unregistered)
+ */
+function resolveTypeAnnotation(schema: unknown): string | undefined {
+  const inner = unwrap(schema);
+
+  const directId = getSchemaId(inner);
+  if (directId) return directId;
+
+  const unionOpts = getUnionOptions(inner);
+  if (unionOpts) {
+    const resolved = unionOpts.map((o) => resolveTypeAnnotation(o));
+    const names = resolved.filter(Boolean) as string[];
+    if (names.length > 0) {
+      if (names.length < unionOpts.length) {
+        console.warn(
+          `[prompt] Partially resolved union: ${names.length}/${unionOpts.length} options resolved`,
+        );
+      }
+      return names.join(" | ");
+    }
+  }
+
+  if (isArrayType(schema)) {
+    const arrayInner = getArrayInnerType(schema);
+    if (!arrayInner) return undefined;
+
+    const innerType = resolveTypeAnnotation(arrayInner);
+    if (innerType) {
+      const isUnion = getUnionOptions(unwrap(arrayInner)) !== undefined;
+      return isUnion ? `(${innerType})[]` : `${innerType}[]`;
+    }
+
+    console.warn(
+      `[prompt] Could not resolve array element type (inner zod type: "${getZodType(arrayInner) ?? "unknown"}")`,
+    );
+    return undefined;
+  }
+
+  const zodType = getZodType(inner);
+  if (zodType === "string") return "string";
+  if (zodType === "number") return "number";
+  if (zodType === "boolean") return "boolean";
+
+  const enumVals = getEnumValues(inner);
+  if (enumVals) return enumVals.map((v) => `"${v}"`).join(" | ");
+
+  if (zodType === "literal") {
+    const vals = getZodDef(inner)?.values;
+    if (Array.isArray(vals) && vals.length === 1) {
+      const v = vals[0];
+      return typeof v === "string" ? `"${v}"` : String(v);
+    }
+  }
+
+  const shape = getObjectShape(inner);
+  if (shape) {
+    const fields = Object.entries(shape).map(([name, fieldSchema]) => {
+      const opt = isOptionalType(fieldSchema) ? "?" : "";
+      const fieldType = resolveTypeAnnotation(fieldSchema as z.ZodType);
+      return fieldType ? `${name}${opt}: ${fieldType}` : `${name}${opt}`;
+    });
+    return `{${fields.join(", ")}}`;
+  }
+
+  if (zodType === "lazy") {
+    console.warn(
+      `[prompt] z.lazy() schemas are not resolved — remove z.lazy() wrapper from the schema`,
+    );
+  } else if (zodType) {
+    console.warn(`[prompt] Unresolved schema type: "${zodType}"`);
+  }
+
+  return undefined;
+}
+
+// ─── Field analysis ───
+
+interface FieldInfo {
+  name: string;
+  isOptional: boolean;
+  isArray: boolean;
+  typeAnnotation?: string;
+}
+
+function analyzeFields(shape: Record<string, z.ZodType>): FieldInfo[] {
+  return Object.entries(shape).map(([name, schema]) => ({
+    name,
+    isOptional: isOptionalType(schema),
+    isArray: isArrayType(schema),
+    typeAnnotation: resolveTypeAnnotation(schema),
+  }));
+}
+
+// ─── Signature generation ───
+
+function buildSignature(componentName: string, fields: FieldInfo[]): string {
+  const params = fields.map((f) => {
+    if (f.typeAnnotation) {
+      return f.isOptional ? `${f.name}?: ${f.typeAnnotation}` : `${f.name}: ${f.typeAnnotation}`;
+    }
+    if (f.isArray) {
+      return f.isOptional ? `[${f.name}]?` : `[${f.name}]`;
+    }
+    return f.isOptional ? `${f.name}?` : f.name;
+  });
+  return `${componentName}(${params.join(", ")})`;
+}
+
+function buildComponentLine(componentName: string, def: DefinedComponent): string {
+  const fields = analyzeFields(def.props.shape);
+  const sig = buildSignature(componentName, fields);
+  if (def.description) {
+    return `${sig} — ${def.description}`;
+  }
+  return sig;
+}
+
+// ─── Prompt assembly ───
+
+function generateComponentSignatures(library: Library): string {
+  const lines: string[] = [
+    "## Component Signatures",
+    "",
+    "Arguments marked with ? are optional. Sub-components can be inline or referenced; prefer references for better streaming.",
+    "The `action` prop type accepts: ContinueConversation (sends message to LLM), OpenUrl (navigates to URL), or Custom (app-defined).",
+  ];
+
+  if (library.componentGroups?.length) {
+    const groupedComponents = new Set<string>();
+
+    for (const group of library.componentGroups) {
+      lines.push("");
+      lines.push(`### ${group.name}`);
+      for (const name of group.components) {
+        if (groupedComponents.has(name)) {
+          console.warn(
+            `[prompt] Component "${name}" appears in multiple groups; keeping the first occurrence only.`,
+          );
+          continue;
+        }
+        const def = library.components[name];
+        if (!def) {
+          console.warn(
+            `[prompt] Component "${name}" listed in group "${group.name}" was not found in the library and will be omitted from the prompt.`,
+          );
+          continue;
+        }
+        groupedComponents.add(name);
+        lines.push(buildComponentLine(name, def));
+      }
+      if (group.notes?.length) {
+        for (const note of group.notes) {
+          lines.push(note);
+        }
+      }
+    }
+
+    const ungrouped = Object.keys(library.components).filter(
+      (name) => !groupedComponents.has(name),
+    );
+    if (ungrouped.length) {
+      lines.push("");
+      lines.push("### Ungrouped");
+      for (const name of ungrouped) {
+        const def = library.components[name];
+        lines.push(buildComponentLine(name, def));
+      }
+    }
+  } else {
+    lines.push("");
+    for (const [name, def] of Object.entries(library.components)) {
+      lines.push(buildComponentLine(name, def));
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function generatePrompt(library: Library, options?: PromptOptions): string {
+  const rootName = library.root ?? "Root";
+  const parts: string[] = [];
+
+  parts.push(options?.preamble ?? PREAMBLE);
+  parts.push("");
+  parts.push(syntaxRules(rootName));
+  parts.push("");
+  parts.push(generateComponentSignatures(library));
+  parts.push("");
+  parts.push(streamingRules(rootName));
+
+  const examples = options?.examples;
+  if (examples?.length) {
+    parts.push("");
+    parts.push("## Examples");
+    parts.push("");
+    for (const ex of examples) {
+      parts.push(ex);
+      parts.push("");
+    }
+  }
+
+  parts.push(importantRules(rootName));
+
+  if (options?.additionalRules?.length) {
+    parts.push("");
+    for (const rule of options.additionalRules) {
+      parts.push(`- ${rule}`);
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/packages/svelte-lang/src/parser/types.ts
+++ b/packages/svelte-lang/src/parser/types.ts
@@ -1,0 +1,82 @@
+/**
+ * A fully resolved component node from the parser.
+ *
+ * The parser converts openui-lang text into a tree of these nodes.
+ * Each node represents one component invocation with its positional
+ * arguments mapped into named `props` via the library's Zod key order.
+ */
+export interface ElementNode {
+  type: "element";
+  /** Component name as defined in the library (e.g. "Table", "BarChart"). */
+  typeName: string;
+  /** Named props produced by positional-to-named mapping in the Rust parser. */
+  props: Record<string, unknown>;
+  /**
+   * True when the parser hasn't received all tokens for this node yet
+   * (streaming in progress).
+   */
+  partial: boolean;
+}
+
+/**
+ * A prop validation error from the Rust parser.
+ * When a component has missing required props, it is redacted from the
+ * output tree (dropped as null) and errors are recorded here.
+ */
+export interface ValidationError {
+  /** Component type name, e.g. "Header", "BarChart". */
+  component: string;
+  /** JSON Pointer path within the props object, e.g. "/title", "". */
+  path: string;
+  /** Human-readable error message. */
+  message: string;
+}
+
+/**
+ * Built-in action types for interactive components.
+ */
+export enum BuiltinActionType {
+  ContinueConversation = "continue_conversation",
+  OpenUrl = "open_url",
+}
+
+/**
+ * Structured action event fired by interactive components.
+ */
+export interface ActionEvent {
+  /** Action type. See `BuiltinActionType` for built-in types. */
+  type: string;
+  /** Action-specific params (e.g. { url } for OpenUrl, custom params for Custom). */
+  params: Record<string, any>;
+  /** Human-readable label for the action (displayed as user message in chat). */
+  humanFriendlyMessage: string;
+  /** Raw form state at the time of the action — all field values. */
+  formState?: Record<string, any>;
+  /** The form name that triggered this action, if any. */
+  formName?: string;
+}
+
+/**
+ * The output of a single `parser.parse(text)` call.
+ *
+ * During streaming, each chunk produces a new ParseResult as the
+ * accumulated text is re-parsed. The `root` progressively resolves
+ * from null → partial tree → complete tree.
+ */
+export interface ParseResult {
+  /** The root ElementNode (typically a Root component), or null if parsing hasn't produced one yet. */
+  root: ElementNode | null;
+  meta: {
+    /** True if the parser detected truncated/incomplete input. */
+    incomplete: boolean;
+    /** Names of references used but not yet defined (dropped as null in output). */
+    unresolved: string[];
+    /** Total number of `identifier = Expression` statements parsed. */
+    statementCount: number;
+    /**
+     * Prop validation errors. Components with missing required props are
+     * redacted (dropped as null) and listed here.
+     */
+    validationErrors: ValidationError[];
+  };
+}

--- a/packages/svelte-lang/src/stores/formValidation.svelte.ts
+++ b/packages/svelte-lang/src/stores/formValidation.svelte.ts
@@ -1,0 +1,89 @@
+import { getContext, setContext } from "svelte";
+import { validate, type ParsedRule } from "../utils/validation.js";
+
+export interface FormValidationContextValue {
+  errors: Record<string, string | undefined>;
+  validateField: (name: string, value: unknown, rules: ParsedRule[]) => boolean;
+  registerField: (name: string, rules: ParsedRule[], getValue: () => unknown) => void;
+  unregisterField: (name: string) => void;
+  validateForm: () => boolean;
+  clearFieldError: (name: string) => void;
+}
+
+const FORM_VALIDATION_KEY = Symbol("openui-form-validation");
+
+/**
+ * Set the form validation context. Called by form components.
+ */
+export function setFormValidationContext(value: FormValidationContextValue): void {
+  setContext(FORM_VALIDATION_KEY, value);
+}
+
+/**
+ * Get the form validation context. Returns null if not inside a validated form.
+ */
+export function getFormValidation(): FormValidationContextValue | null {
+  return getContext<FormValidationContextValue | null>(FORM_VALIDATION_KEY) ?? null;
+}
+
+interface FieldRegistration {
+  rules: ParsedRule[];
+  getValue: () => unknown;
+}
+
+/**
+ * Creates a form validation state using Svelte 5 runes.
+ * The Svelte equivalent of React's `useCreateFormValidation`.
+ */
+export function createFormValidation(): FormValidationContextValue {
+  let errors = $state<Record<string, string | undefined>>({});
+  const fields: Record<string, FieldRegistration> = {};
+
+  function validateField(name: string, value: unknown, rules: ParsedRule[]): boolean {
+    const error = validate(value, rules);
+    if (errors[name] !== error) {
+      errors = { ...errors, [name]: error };
+    }
+    return !error;
+  }
+
+  function registerField(name: string, rules: ParsedRule[], getValue: () => unknown): void {
+    fields[name] = { rules, getValue };
+  }
+
+  function unregisterField(name: string): void {
+    delete fields[name];
+  }
+
+  function validateForm(): boolean {
+    let allValid = true;
+    const newErrors: Record<string, string | undefined> = {};
+
+    for (const [name, reg] of Object.entries(fields)) {
+      const value = reg.getValue();
+      const error = validate(value, reg.rules);
+      newErrors[name] = error;
+      if (error) allValid = false;
+    }
+
+    errors = newErrors;
+    return allValid;
+  }
+
+  function clearFieldError(name: string): void {
+    if (errors[name] !== undefined) {
+      errors = { ...errors, [name]: undefined };
+    }
+  }
+
+  return {
+    get errors() {
+      return errors;
+    },
+    validateField,
+    registerField,
+    unregisterField,
+    validateForm,
+    clearFieldError,
+  };
+}

--- a/packages/svelte-lang/src/stores/index.ts
+++ b/packages/svelte-lang/src/stores/index.ts
@@ -1,0 +1,9 @@
+export { createOpenUIState } from "./openui.svelte.js";
+export type { OpenUIStateOptions } from "./openui.svelte.js";
+
+export {
+  createFormValidation,
+  getFormValidation,
+  setFormValidationContext,
+} from "./formValidation.svelte.js";
+export type { FormValidationContextValue } from "./formValidation.svelte.js";

--- a/packages/svelte-lang/src/stores/openui.svelte.ts
+++ b/packages/svelte-lang/src/stores/openui.svelte.ts
@@ -1,0 +1,136 @@
+import type { Snippet } from "svelte";
+import type { OpenUIContextValue } from "../context.js";
+import type { Library } from "../library.js";
+import { createParser } from "../parser/parser.js";
+import type { ActionEvent, ParseResult } from "../parser/types.js";
+import { BuiltinActionType } from "../parser/types.js";
+
+export interface OpenUIStateOptions {
+  response: string | null;
+  library: Library;
+  isStreaming: boolean;
+  onAction?: (event: ActionEvent) => void;
+  onStateUpdate?: (state: Record<string, any>) => void;
+  initialState?: Record<string, any>;
+}
+
+/**
+ * Creates the core OpenUI state using Svelte 5 runes.
+ *
+ * This is the Svelte equivalent of the React `useOpenUIState` hook.
+ * It manages parsing, form state, and context value assembly.
+ */
+export function createOpenUIState(
+  options: () => OpenUIStateOptions,
+  renderDeep: (value: unknown) => Snippet,
+) {
+  const opts = options();
+
+  // Parser created once from library schema
+  const parser = createParser(opts.library.toJSONSchema());
+
+  // Form state
+  let formState = $state<Record<string, any>>(opts.initialState ?? {});
+
+  // Parse result - derived from response
+  const result = $derived.by<ParseResult | null>(() => {
+    const currentOpts = options();
+    if (!currentOpts.response) return null;
+    try {
+      return parser.parse(currentOpts.response);
+    } catch (e) {
+      console.error("[openui] Parse error:", e);
+      return null;
+    }
+  });
+
+  // Track initialState changes
+  let prevInitialState = opts.initialState;
+  $effect(() => {
+    const currentOpts = options();
+    if (prevInitialState !== currentOpts.initialState) {
+      prevInitialState = currentOpts.initialState;
+      formState = currentOpts.initialState ?? {};
+    }
+  });
+
+  // Stable callbacks
+  function getFieldValue(formName: string | undefined, name: string): any {
+    return formName ? formState[formName]?.[name]?.value : formState[name]?.value;
+  }
+
+  function setFieldValue(
+    formName: string | undefined,
+    componentType: string | undefined,
+    name: string,
+    value: any,
+    shouldTriggerSaveCallback: boolean = true,
+  ): void {
+    const newState = { ...formState };
+
+    if (formName) {
+      newState[formName] = {
+        ...newState[formName],
+        [name]: { value, componentType },
+      };
+    } else {
+      newState[name] = { value, componentType };
+    }
+
+    formState = newState;
+
+    if (shouldTriggerSaveCallback) {
+      const currentOpts = options();
+      currentOpts.onStateUpdate?.(newState);
+    }
+  }
+
+  function triggerAction(
+    userMessage: string,
+    formName?: string,
+    action?: { type?: string; params?: Record<string, any> },
+  ): void {
+    const currentOpts = options();
+    const actionType = action?.type || BuiltinActionType.ContinueConversation;
+    const actionParams = action?.params;
+
+    let relevantState: Record<string, any> | undefined;
+    if (formName && formState[formName]) {
+      relevantState = { [formName]: formState[formName] };
+    } else if (Object.keys(formState).length > 0) {
+      relevantState = formState;
+    }
+
+    if (!currentOpts.onAction) return;
+
+    currentOpts.onAction({
+      type: actionType,
+      params: actionParams || {},
+      humanFriendlyMessage: userMessage,
+      formState: relevantState,
+      formName,
+    });
+  }
+
+  // Context value - derived so it updates reactively
+  const contextValue = $derived.by<OpenUIContextValue>(() => {
+    const currentOpts = options();
+    return {
+      library: currentOpts.library,
+      renderNode: renderDeep,
+      triggerAction,
+      isStreaming: currentOpts.isStreaming,
+      getFieldValue,
+      setFieldValue,
+    };
+  });
+
+  return {
+    get result() {
+      return result;
+    },
+    get contextValue() {
+      return contextValue;
+    },
+  };
+}

--- a/packages/svelte-lang/src/utils/index.ts
+++ b/packages/svelte-lang/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { builtInValidators, parseRules, parseStructuredRules, validate } from "./validation.js";
+export type { ValidatorFn } from "./validation.js";

--- a/packages/svelte-lang/src/utils/validation.ts
+++ b/packages/svelte-lang/src/utils/validation.ts
@@ -1,0 +1,150 @@
+export interface ParsedRule {
+  type: string;
+  arg?: number | string;
+}
+
+/**
+ * Parse a rule string into a structured rule.
+ *   "required"       → { type: "required" }
+ *   "min:8"          → { type: "min", arg: 8 }
+ *   "minLength:3"    → { type: "minLength", arg: 3 }
+ *   "pattern:^[a-z]" → { type: "pattern", arg: "^[a-z]" }
+ */
+export function parseRule(rule: string): ParsedRule {
+  const colonIdx = rule.indexOf(":");
+  if (colonIdx === -1) return { type: rule };
+
+  const type = rule.slice(0, colonIdx);
+  const rawArg = rule.slice(colonIdx + 1);
+  const num = Number(rawArg);
+  return { type, arg: Number.isFinite(num) && rawArg !== "" ? num : rawArg };
+}
+
+export function parseRules(rules: unknown): ParsedRule[] {
+  if (!Array.isArray(rules)) return [];
+  return rules.filter((r): r is string => typeof r === "string").map(parseRule);
+}
+
+export type ValidatorFn = (value: unknown, arg?: number | string) => string | undefined;
+
+function isEmpty(value: unknown): boolean {
+  if (value === null || value === undefined || value === "") return true;
+  if (Array.isArray(value) && value.length === 0) return true;
+  return false;
+}
+
+export const builtInValidators: Record<string, ValidatorFn> = {
+  required: (value) => {
+    if (isEmpty(value)) return "This field is required";
+    if (typeof value === "object" && !Array.isArray(value) && value !== null) {
+      const vals = Object.values(value);
+      if (vals.length > 0 && vals.every((v) => typeof v === "boolean") && !vals.some(Boolean)) {
+        return "At least one option is required";
+      }
+    }
+    return undefined;
+  },
+
+  email: (value) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value !== "string") return "Please enter a valid email";
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value) ? undefined : "Please enter a valid email";
+  },
+
+  url: (value) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value !== "string") return "Please enter a valid URL";
+    try {
+      new URL(value);
+      return undefined;
+    } catch {
+      return "Please enter a valid URL";
+    }
+  },
+
+  numeric: (value) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value === "number" && !isNaN(value)) return undefined;
+    if (typeof value === "string" && !isNaN(parseFloat(value)) && value.trim() !== "")
+      return undefined;
+    return "Must be a number";
+  },
+
+  min: (value, arg) => {
+    if (isEmpty(value)) return undefined;
+    const n = typeof value === "number" ? value : parseFloat(String(value));
+    if (isNaN(n)) return undefined;
+    const min = Number(arg);
+    return n >= min ? undefined : `Must be at least ${min}`;
+  },
+
+  max: (value, arg) => {
+    if (isEmpty(value)) return undefined;
+    const n = typeof value === "number" ? value : parseFloat(String(value));
+    if (isNaN(n)) return undefined;
+    const max = Number(arg);
+    return n <= max ? undefined : `Must be no more than ${max}`;
+  },
+
+  minLength: (value, arg) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value !== "string") return undefined;
+    const min = Number(arg);
+    return value.length >= min ? undefined : `Must be at least ${min} characters`;
+  },
+
+  maxLength: (value, arg) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value !== "string") return undefined;
+    const max = Number(arg);
+    return value.length <= max ? undefined : `Must be no more than ${max} characters`;
+  },
+
+  pattern: (value, arg) => {
+    if (isEmpty(value)) return undefined;
+    if (typeof value !== "string" || typeof arg !== "string") return undefined;
+    try {
+      return new RegExp(arg).test(value) ? undefined : "Invalid format";
+    } catch {
+      return undefined;
+    }
+  },
+};
+
+/**
+ * Run all rules against a value. Stop on first error.
+ * Custom validators are checked first, then built-in ones.
+ */
+export function validate(
+  value: unknown,
+  rules: ParsedRule[],
+  customValidators?: Record<string, ValidatorFn>,
+): string | undefined {
+  for (const rule of rules) {
+    const validator = customValidators?.[rule.type] ?? builtInValidators[rule.type];
+    if (!validator) continue;
+    const error = validator(value, rule.arg);
+    if (error) return error;
+  }
+  return undefined;
+}
+
+/**
+ * Parse a structured rules object into ParsedRule[].
+ * Accepts: { required: true, minLength: 5, email: true, max: 100 }
+ * Skips keys with false/undefined values.
+ */
+export function parseStructuredRules(rules: unknown): ParsedRule[] {
+  if (!rules || typeof rules !== "object" || Array.isArray(rules)) return [];
+  const obj = rules as Record<string, any>;
+  const result: ParsedRule[] = [];
+  for (const [key, val] of Object.entries(obj)) {
+    if (val === false || val === undefined || val === null) continue;
+    if (val === true) {
+      result.push({ type: key });
+    } else {
+      result.push({ type: key, arg: val });
+    }
+  }
+  return result;
+}

--- a/packages/svelte-lang/svelte.config.js
+++ b/packages/svelte-lang/svelte.config.js
@@ -1,0 +1,6 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+/** @type {import('@sveltejs/package').Config} */
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/packages/svelte-lang/tsconfig.json
+++ b/packages/svelte-lang/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts"],
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitReturns": false,
+    "noImplicitOverride": false,
+    "verbatimModuleSyntax": true
+  }
+}


### PR DESCRIPTION
## Summary
Adds `@openuidev/svelte-lang` — the Svelte 5 equivalent of `@openuidev/react-lang`. 19 files, 2,405 lines.

## What's included
- **Renderer.svelte** — main streaming renderer component
- **RenderNode/RenderValue** — recursive element rendering
- **defineComponent / createLibrary** — component definition API with Zod schemas
- **Context API** — getOpenUI(), getTriggerAction() via Svelte getContext/setContext
- **Svelte 5 runes** — $state, $derived, $effect for reactive state
- **Parser/prompt** — reused from react-lang (framework-agnostic)
- **Form validation** — reactive state management

## React → Svelte mapping
| React | Svelte |
|-------|--------|
| useOpenUI() | getOpenUI() |
| useState/useMemo | $state/$derived |
| useEffect | $effect |
| createContext | setContext/getContext |

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)