### PR TITLE
Remove padding-right from StepsSection styles

### DIFF
--- a/docs/app/(home)/components/StepsSection/StepsSection.module.css
+++ b/docs/app/(home)/components/StepsSection/StepsSection.module.css
@@ -126,7 +126,6 @@
   flex: 1;
   flex-direction: column;
   gap: 1.5rem;
-  padding-right: 60px;
 }
 
 .desktopStepTitle {


### PR DESCRIPTION
Removed right padding from StepsSection.

## What

A fix for this:

<img width="2118" height="1776" alt="CleanShot 2026-03-19 at 11 44 28@2x" src="https://github.com/user-attachments/assets/105a0bc5-6058-406a-ae2d-c452bfe63709" />

## Changes

- Removed right padding from StepsSection.

## Test Plan

Describe how you validated this change.

- [ ] Not applicable (explain why)
- [x] Verified locally

## Checklist

- [x] I linked a related issue, if applicable
- [x] I updated docs/README when needed
- [x] I considered backwards compatibility
