### PR TITLE
feat: add Dockerfile for openui-chat example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+*.md
+LICENSE
+.turbo
+.env*.local

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,52 @@
+# ── Build Stage ──────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy workspace manifests (cache-friendly layer)
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY packages/openui-cli/package.json   packages/openui-cli/
+COPY packages/react-ui/package.json     packages/react-ui/
+COPY packages/react-headless/package.json packages/react-headless/
+COPY packages/react-lang/package.json   packages/react-lang/
+COPY examples/openui-chat/package.json  examples/openui-chat/
+
+RUN pnpm install --frozen-lockfile
+
+# Copy source
+COPY packages/ packages/
+COPY examples/openui-chat/ examples/openui-chat/
+
+# Build workspace packages the chat app depends on
+RUN pnpm --filter @openuidev/cli build
+RUN pnpm --filter @openuidev/react-ui build
+RUN pnpm --filter @openuidev/react-headless build
+RUN pnpm --filter @openuidev/react-lang build
+
+# Generate the system prompt used by the chat app
+RUN cd examples/openui-chat && pnpm generate:prompt
+
+# Build Next.js with standalone output
+RUN cd examples/openui-chat && pnpm build
+
+# ── Runtime Stage ───────────────────────────────────────────
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser  --system --uid 1001 nextjs
+
+# Next.js standalone output
+COPY --from=builder /app/examples/openui-chat/.next/standalone ./
+# Static assets (not included in standalone)
+COPY --from=builder /app/examples/openui-chat/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000 HOSTNAME="0.0.0.0"
+
+CMD ["node", "server.js"]

--- a/examples/openui-chat/next.config.ts
+++ b/examples/openui-chat/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   turbopack: {},
   transpilePackages: ["@openuidev/react-ui", "@openuidev/react-headless", "@openuidev/react-lang"],
 };


### PR DESCRIPTION
Fixes #303

## Summary

Add a production-ready Dockerfile for the openui-chat example so users can build and run it with a single command:

```bash
docker build -t openui-chat .
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

## Changes

- **Dockerfile**: Multi-stage build (builder + runner) that handles the pnpm monorepo workspace dependencies, builds the CLI + workspace packages, generates the system prompt, and produces a minimal production image
- **next.config.ts**: Enable `output: "standalone"` for efficient Docker builds
- **.dockerignore**: Exclude node_modules, .next, .git from build context

## Architecture

The Dockerfile uses a two-stage approach:

1. **Builder**: Installs workspace deps, builds all required packages (`@openuidev/cli`, `@openuidev/react-ui`, `@openuidev/react-headless`, `@openuidev/react-lang`), generates the system prompt, and builds the Next.js app in standalone mode
2. **Runner**: Copies only the standalone output + static assets into a minimal Node.js image, runs as non-root user

## Environment Variables

| Variable | Description | Required |
|----------|-------------|----------|
| `OPENAI_API_KEY` | OpenAI API key for LLM calls | Yes |
| `PORT` | Server port (default: 3000) | No |
| `HOSTNAME` | Server hostname (default: 0.0.0.0) | No |