### PR TITLE
fix: prevent recharts crash during streaming with schema validation +…

### DIFF
--- a/packages/react-ui/src/genui-lib/Charts/AreaChartCondensed.ts
+++ b/packages/react-ui/src/genui-lib/Charts/AreaChartCondensed.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -21,8 +22,15 @@ export const AreaChartCondensed = defineComponent({
   description: "Filled area under lines; use for cumulative totals or volume trends over time",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "labels", "series")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.labels) || !Array.isArray(props.series)) return null;
+
     const data = buildChartData(props.labels, props.series);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(AreaChartCondensedComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/BarChartCondensed.ts
+++ b/packages/react-ui/src/genui-lib/Charts/BarChartCondensed.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -21,8 +22,15 @@ export const BarChartCondensed = defineComponent({
   description: "Vertical bars; use for comparing values across categories with one or more series",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "labels", "series")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.labels) || !Array.isArray(props.series)) return null;
+
     const data = buildChartData(props.labels, props.series);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(BarChartCondensedComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/HorizontalBarChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/HorizontalBarChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -21,8 +22,15 @@ export const HorizontalBarChart = defineComponent({
   description: "Horizontal bars; prefer when category labels are long or for ranked lists",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "labels", "series")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.labels) || !Array.isArray(props.series)) return null;
+
     const data = buildChartData(props.labels, props.series);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(HorizontalBarChartComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/LineChartCondensed.ts
+++ b/packages/react-ui/src/genui-lib/Charts/LineChartCondensed.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -21,8 +22,15 @@ export const LineChartCondensed = defineComponent({
   description: "Lines over categories; use for trends and continuous data over time",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "labels", "series")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.labels) || !Array.isArray(props.series)) return null;
+
     const data = buildChartData(props.labels, props.series);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(LineChartCondensedComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/PieChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/PieChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -18,8 +19,15 @@ export const PieChart = defineComponent({
   description: "Circular slices showing part-to-whole proportions; supports pie and donut variants",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "slices")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.slices)) return null;
+
     const data = buildSliceData(props.slices);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(PieChartComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/RadarChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/RadarChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -18,8 +19,15 @@ export const RadarChart = defineComponent({
   description: "Spider/web chart; use for comparing multiple variables across one or more entities",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "labels", "series")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray(props.labels) || !Array.isArray(props.series)) return null;
+
     const data = buildChartData(props.labels, props.series);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(RadarChartComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/RadialChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/RadialChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -17,8 +18,15 @@ export const RadialChart = defineComponent({
   description: "Radial bars showing proportional distribution across named segments",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "slices")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray((props as any).slices)) return null;
+
     const data = buildSliceData((props as any).slices);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(RadialChartComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/ScatterChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/ScatterChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -21,10 +22,18 @@ export const ScatterChart = defineComponent({
   description: "X/Y scatter plot; use for correlations, distributions, and clustering",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "datasets")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray((props as any).datasets)) return null;
+
     const rawDatasets = asArray((props as any).datasets);
+
     const data = rawDatasets.map((ds: any) => {
       const dsProps = unwrap(ds);
-      const rawPoints = asArray(dsProps?.points);
+
+      // FIX: ensure points is always array
+      const rawPoints = Array.isArray(dsProps?.points) ? dsProps.points : [];
+
       return {
         name: (dsProps?.name ?? "") as string,
         data: rawPoints.map((pt: any) => {
@@ -37,7 +46,10 @@ export const ScatterChart = defineComponent({
         }),
       };
     });
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(ScatterChartComponent, {
       data,
       xAxisDataKey: "x",

--- a/packages/react-ui/src/genui-lib/Charts/SingleStackedBarChart.ts
+++ b/packages/react-ui/src/genui-lib/Charts/SingleStackedBarChart.ts
@@ -1,3 +1,4 @@
+
 "use client";
 
 import { defineComponent } from "@openuidev/react-lang";
@@ -18,8 +19,15 @@ export const SingleStackedBarChart = defineComponent({
     "Single horizontal stacked bar; use for showing part-to-whole proportions in one row",
   component: ({ props }) => {
     if (!hasAllProps(props as Record<string, unknown>, "slices")) return null;
+
+    // FIX: guard against partial streaming data
+    if (!Array.isArray((props as any).slices)) return null;
+
     const data = buildSliceData((props as any).slices);
-    if (!data.length) return null;
+
+    // FIX: ensure valid data before rendering (prevents recharts crash)
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     return React.createElement(SingleStackedBarChartComponent, {
       data,
       categoryKey: "category",

--- a/packages/react-ui/src/genui-lib/Charts/dataSchemas.ts
+++ b/packages/react-ui/src/genui-lib/Charts/dataSchemas.ts
@@ -1,3 +1,4 @@
+
 import { z } from "zod";
 
 export const chart1DDataSchema = z.array(
@@ -16,19 +17,25 @@ export const chart2DDataSchema = z.object({
         values: z.array(z.number()),
       }),
     )
+    // FIX: allow missing/undefined and fallback to []
+    .optional()
     .default([]),
 });
 
 export const scatterDataSchema = z.array(
   z.object({
     name: z.string(),
-    series: z.array(
-      z.object({
-        x: z.number(),
-        y: z.number(),
-        z: z.number().optional(),
-      }),
-    ),
+    series: z
+      .array(
+        z.object({
+          x: z.number(),
+          y: z.number(),
+          z: z.number().optional(),
+        }),
+      )
+      // FIX: ensure safe default for streaming cases
+      .optional()
+      .default([]),
   }),
 );
 
@@ -40,10 +47,16 @@ export type ScatterData = z.infer<typeof scatterDataSchema>;
 export type MiniChartData = z.infer<typeof miniChartDataSchema>;
 
 export function transform2DData(data: Chart2DData): Array<Record<string, string | number>> {
-  return data.labels.map((label, i) => {
+  // FIX: ensure labels is always array
+  const labels = Array.isArray(data.labels) ? data.labels : [];
+
+  // FIX: ensure series is always array
+  const series = Array.isArray(data.series) ? data.series : [];
+
+  return labels.map((label, i) => {
     const row: Record<string, string | number> = { category: label };
-    for (const s of data.series) {
-      row[s.category] = s.values[i] ?? 0;
+    for (const s of series) {
+      row[s.category] = s.values?.[i] ?? 0;
     }
     return row;
   });
@@ -56,8 +69,11 @@ export function transform1DData(data: Chart1DData): Array<Record<string, string 
 export function transformScatterData(
   data: ScatterData,
 ): Array<{ name: string; data: Array<{ x: number; y: number; z?: number }> }> {
-  return data.map((dataset) => ({
+  // FIX: ensure safe iteration
+  const safeData = Array.isArray(data) ? data : [];
+
+  return safeData.map((dataset) => ({
     name: dataset.name,
-    data: dataset.series,
+    data: Array.isArray(dataset.series) ? dataset.series : [],
   }));
 }


### PR DESCRIPTION
Fixes crash in chart components during streaming when partial data is passed.

- Enforces stricter schema validation for chart data
- Adds runtime guards before processing data

This prevents Recharts from receiving null/undefined data during streaming.