### PR TITLE
feat: add Dockerfile for openui-chat example

### DIFF
--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,45 @@
+# Dockerfile for openui-chat example
+# Build from the monorepo root context:
+#   docker build -f examples/openui-chat/Dockerfile -t openui-chat .
+
+# --- Stage 1: Install & Build ---
+FROM node:20-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy workspace config and package manifests first for better layer caching
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/ packages/
+COPY examples/openui-chat/ examples/openui-chat/
+
+# Enable standalone output for Docker deployment (does not modify source)
+RUN sed -i 's/nextConfig: NextConfig = {/nextConfig: NextConfig = { output: "standalone",/' \
+    examples/openui-chat/next.config.ts
+
+# Install dependencies (frozen lockfile for reproducibility)
+RUN pnpm install --frozen-lockfile
+
+# Generate system prompt (required at runtime) and build the chat app
+WORKDIR /app/examples/openui-chat
+RUN pnpm generate:prompt && pnpm build
+
+# --- Stage 2: Production ---
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+# Copy standalone output and static assets
+COPY --from=builder /app/examples/openui-chat/.next/standalone ./
+COPY --from=builder /app/examples/openui-chat/.next/static ./examples/openui-chat/.next/static
+COPY --from=builder /app/examples/openui-chat/public ./examples/openui-chat/public
+COPY --from=builder /app/examples/openui-chat/src/generated ./examples/openui-chat/src/generated
+
+EXPOSE 3000
+
+CMD ["node", "examples/openui-chat/server.js"]

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -2,19 +2,36 @@ This is an [OpenUI](https://openui.com) Agent Chat project bootstrapped with [`o
 
 ## Getting Started
 
-First, run the development server:
+### Development
+
+First, run the development server (from the monorepo root):
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install
+pnpm --filter openui-chat dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+### Docker
+
+Build and run the example with a single command:
+
+```bash
+# Build from the monorepo root
+docker build -f examples/openui-chat/Dockerfile -t openui-chat .
+
+# Run (requires OPENAI_API_KEY)
+docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+```
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | Yes | Your OpenAI API key |
+| `PORT` | No | Server port (default: `3000`) |
+| `HOSTNAME` | No | Server hostname (default: `0.0.0.0`) |
 
 You can start editing the page by modifying `src/app/api/route.ts` and improving your agent
 by adding system prompts or tools.


### PR DESCRIPTION
## Summary

Adds a production-ready multi-stage Dockerfile for the openui-chat example, addressing #303.

## Usage

```bash
# Build from the monorepo root
docker build -f examples/openui-chat/Dockerfile -t openui-chat .

# Run
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

## Features

- **Multi-stage build** — builder stage compiles, runner stage is a slim production image
- **pnpm frozen lockfile** — reproducible dependency resolution
- **Next.js standalone output** — output: "standalone" injected at build time (does not modify source)
- **System prompt auto-generated** — pnpm generate:prompt runs during build
- **Environment variable configuration** — documented in README

## Changes

- `examples/openui-chat/Dockerfile` — new file
- `examples/openui-chat/README.md` — added Docker section with build/run instructions