### PR TITLE
feat: add Dockerfile for openui-chat example (#303)

### DIFF
--- a/examples/openui-chat/.dockerignore
+++ b/examples/openui-chat/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+.env*
+.vercel
+*.tsbuildinfo
+next-env.d.ts
+.pnpm-debug.log*

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,56 @@
+# Stage 1: Install dependencies and build
+FROM node:20-alpine AS builder
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy workspace configuration first for better layer caching
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+
+# Copy all package.json files for dependency resolution
+COPY packages/react-headless/package.json packages/react-headless/
+COPY packages/react-lang/package.json packages/react-lang/
+COPY packages/react-ui/package.json packages/react-ui/
+COPY packages/cli/package.json packages/cli/
+COPY examples/openui-chat/package.json examples/openui-chat/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy source code for workspace packages and the chat example
+COPY packages/ packages/
+COPY examples/openui-chat/ examples/openui-chat/
+COPY tsconfig.json ./
+
+# Build CLI, generate system prompt, then build the Next.js app
+RUN pnpm --filter @openuidev/cli build
+RUN pnpm --filter openui-chat generate:prompt
+RUN pnpm --filter openui-chat build
+
+# Stage 2: Production runner
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# Copy only what's needed to run the app
+COPY --from=builder --chown=nextjs:nodejs /app/examples/openui-chat/.next ./.next
+COPY --from=builder --chown=nextjs:nodejs /app/examples/openui-chat/package.json ./
+COPY --from=builder --chown=nextjs:nodejs /app/examples/openui-chat/public ./public 2>/dev/null || true
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node_modules/.bin/next", "start"]

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -19,6 +19,34 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `src/app/api/route.ts` and improving your agent
 by adding system prompts or tools.
 
+## Docker
+
+Build and run with a single command:
+
+```bash
+# From the monorepo root
+docker build -t openui-chat -f examples/openui-chat/Dockerfile .
+
+# Run the container
+docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+```
+
+Or from within the example directory:
+
+```bash
+cd examples/openui-chat
+docker build -t openui-chat -f Dockerfile ../..
+docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+```
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `OPENAI_API_KEY` | Your OpenAI API key | Yes |
+| `PORT` | Server port (default: `3000`) | No |
+| `HOSTNAME` | Server hostname (default: `0.0.0.0`) | No |
+
 ## Learn More
 
 To learn more about OpenUI, take a look at the following resources:


### PR DESCRIPTION
## Summary

Adds a production-ready Dockerfile for the  example, enabling users to build and run the chat app with a single command.

Closes #303

## Changes

- **Dockerfile**: Multi-stage build that:
  - Installs pnpm and all monorepo dependencies
  - Builds the CLI and generates the system prompt
  - Builds the Next.js app for production
  - Runs as non-root user for security
- **.dockerignore**: Excludes unnecessary files from the build context
- **README.md**: Added Docker usage section with build/run commands and environment variable docs

## Usage

```bash
# From monorepo root
docker build -t openui-chat -f examples/openui-chat/Dockerfile .
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

## Environment Variables

| Variable | Description | Required |
|----------|-------------|----------|
| `OPENAI_API_KEY` | Your OpenAI API key | Yes |
| `PORT` | Server port (default: 3000) | No |

/cc @algora-io 💎 Bounty #303