### PR TITLE
feat: add Dockerfile for openui-chat example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.gitignore
+*.md
+LICENSE
+.eslintrc*
+.prettierrc*
+tsconfig*.json
+*.tsbuildinfo
+dist

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,60 @@
+# ──────────────────────────────────────────────
+# Dockerfile for openui-chat
+# Build context: monorepo root (../../)
+#
+#   docker build -f examples/openui-chat/Dockerfile -t openui-chat .
+#   docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+# ──────────────────────────────────────────────
+
+# ── Stage 1: Install & Build ─────────────────
+FROM node:20-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy workspace metadata for layer caching
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+
+# Copy package.json files for each workspace package
+COPY packages/react-lang/package.json     packages/react-lang/
+COPY packages/react-headless/package.json packages/react-headless/
+COPY packages/react-ui/package.json       packages/react-ui/
+COPY packages/openui-cli/package.json     packages/openui-cli/
+
+# Copy the chat example source
+COPY examples/openui-chat/ examples/openui-chat/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Build workspace packages (order matters — deps first)
+RUN pnpm --filter @openuidev/react-lang run build \
+ && pnpm --filter @openuidev/react-headless run build \
+ && pnpm --filter @openuidev/react-ui run build
+
+# Build the Next.js app
+WORKDIR /app/examples/openui-chat
+RUN pnpm run build
+
+# ── Stage 2: Production ─────────────────────
+FROM node:20-alpine AS runner
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy the full built /app (node_modules, .next, workspace packages)
+# This preserves pnpm's symlink structure and workspace resolution
+COPY --from=builder /app /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+EXPOSE 3000
+
+WORKDIR /app/examples/openui-chat
+
+CMD ["pnpm", "start"]

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -19,6 +19,26 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `src/app/api/route.ts` and improving your agent
 by adding system prompts or tools.
 
+## Docker
+
+Build and run the chat app with a single command (from the **monorepo root**):
+
+```bash
+# Build the image
+docker build -f examples/openui-chat/Dockerfile -t openui-chat .
+
+# Run it
+docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+```
+
+Open [http://localhost:3000](http://localhost:3000) to use the chat interface.
+
+### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `OPENAI_API_KEY` | Yes | Your OpenAI API key |
+
 ## Learn More
 
 To learn more about OpenUI, take a look at the following resources:


### PR DESCRIPTION
## Summary

Adds a production-ready Dockerfile for the `openui-chat` example so users can build and run it with a single command — no need to clone the repo, install dependencies, or configure the environment manually.

### Usage

```bash
# From monorepo root
docker build -f examples/openui-chat/Dockerfile -t openui-chat .
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

Open [http://localhost:3000](http://localhost:3000) to use the chat interface.

### What's included

- **Multi-stage Dockerfile** (`examples/openui-chat/Dockerfile`)
  - Stage 1 (builder): Installs deps via pnpm, builds workspace packages (`react-lang`, `react-headless`, `react-ui`), then builds the Next.js app
  - Stage 2 (runner): Copies the built `/app` with production config, runs on port 3000
- **`.dockerignore`** at repo root to exclude `.git`, `node_modules`, build artifacts
- **README update** with Docker build & run instructions and env var documentation

### Environment Variables

| Variable | Required | Description |
|---|---|---|
| `OPENAI_API_KEY` | Yes | Your OpenAI API key |

Closes #303