### PR TITLE
feat: add Dockerfile for openui-chat example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+.next
+.git
+*.md
+!README.md
+.turbo
+dist
+.DS_Store
+.vscode
+.idea

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,54 @@
+# ── Stage 1: Install & Build ──────────────────────────────────────
+FROM node:20-slim AS base
+
+# pnpm via corepack (built into Node 20)
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+WORKDIR /app
+
+# Copy workspace root config
+COPY package.json pnpm-workspace.yaml ./
+
+# Copy only package.json files first for layer caching
+COPY packages/openui-cli/package.json packages/openui-cli/
+COPY packages/react-headless/package.json packages/react-headless/
+COPY packages/react-lang/package.json packages/react-lang/
+COPY packages/react-ui/package.json packages/react-ui/
+COPY examples/openui-chat/package.json examples/openui-chat/
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile || pnpm install
+
+# Copy full source
+COPY . .
+
+# Build workspace packages (required by openui-chat)
+RUN pnpm --filter @openuidev/cli build
+RUN pnpm --filter @openuidev/react-headless build
+RUN pnpm --filter @openuidev/react-lang build
+RUN pnpm --filter @openuidev/react-ui build
+
+# Generate system prompt & build Next.js app
+WORKDIR /app/examples/openui-chat
+RUN pnpm generate:prompt
+RUN pnpm build
+
+# ── Stage 2: Production ──────────────────────────────────────────
+FROM node:20-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Copy standalone server + server chunks
+COPY --from=base /app/examples/openui-chat/.next/standalone ./
+# Copy static assets
+COPY --from=base /app/examples/openui-chat/.next/static ./examples/openui-chat/.next/static
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "examples/openui-chat/server.js"]

--- a/examples/openui-chat/next.config.ts
+++ b/examples/openui-chat/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   turbopack: {},
   transpilePackages: ["@openuidev/react-ui", "@openuidev/react-headless", "@openuidev/react-lang"],
 };


### PR DESCRIPTION
## Summary

Adds a production-ready Dockerfile for the `openui-chat` example, making it easy to build and run with a single command.

Closes #303

## Changes

- **`examples/openui-chat/Dockerfile`** — Multi-stage build using pnpm and Next.js standalone output
- **`examples/openui-chat/next.config.ts`** — Added `output: "standalone"` for efficient Docker images
- **`.dockerignore`** — Reduces build context size

## Usage

```bash
# Build from repo root
docker build -t openui-chat -f examples/openui-chat/Dockerfile .

# Run
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

## Environment Variables

| Variable | Required | Description |
|----------|----------|-------------|
| `OPENAI_API_KEY` | Yes | OpenAI API key for chat completions |

## Notes

- Uses `output: "standalone"` which only affects `next build` — `next dev` is unaffected
- Two-stage build keeps final image small (no dev dependencies, build tools, or source code)
- Workspace packages (`@openuidev/react-ui`, etc.) are built before the Next.js app
- System prompt is regenerated during the build