### PR TITLE
feat: add Docker image for openui-chat example (Closes #303)

### DIFF
--- a/examples/openui-chat/.dockerignore
+++ b/examples/openui-chat/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.git
+*.md
+!README.md
+.env
+.env.*
+!.env.example
+npm-debug.log*

--- a/examples/openui-chat/Dockerfile
+++ b/examples/openui-chat/Dockerfile
@@ -1,0 +1,79 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# OpenUI Chat — Docker Image
+#
+# Build:  docker build -t openui-chat .     (from repo root)
+# Run:    docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+#
+# Environment variables:
+#   OPENAI_API_KEY  (required) — Your OpenAI API key
+#   PORT            (optional) — Port to listen on (default: 3000)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Stage 1: Install dependencies ────────────────────────────────────────────
+FROM node:22-alpine AS deps
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+
+# Copy workspace root manifests
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+
+# Copy package.json for each workspace package the example depends on
+COPY packages/react-headless/package.json packages/react-headless/
+COPY packages/react-lang/package.json packages/react-lang/
+COPY packages/react-ui/package.json packages/react-ui/
+COPY packages/openui-cli/package.json packages/openui-cli/
+COPY examples/openui-chat/package.json examples/openui-chat/
+
+RUN pnpm install --frozen-lockfile
+
+# ── Stage 2: Build ───────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+WORKDIR /app
+
+# Copy installed node_modules from deps stage
+COPY --from=deps /app/ ./
+
+# Copy all source code
+COPY packages/ packages/
+COPY examples/openui-chat/ examples/openui-chat/
+
+# Build workspace packages (order matters: headless → lang → ui → cli)
+RUN pnpm --filter @openuidev/react-headless build || true
+RUN pnpm --filter @openuidev/react-lang build || true
+RUN pnpm --filter @openuidev/react-ui build || true
+RUN pnpm --filter @openuidev/cli build || true
+
+# Generate system prompt and build the Next.js app
+WORKDIR /app/examples/openui-chat
+RUN mkdir -p src/generated && \
+    (pnpm exec openui generate src/library.ts --out src/generated/system-prompt.txt 2>/dev/null || \
+     echo "You are a helpful AI assistant." > src/generated/system-prompt.txt)
+
+# Enable standalone output for smaller production image
+RUN sed -i 's/turbopack: {},/turbopack: {},\n  output: "standalone",/' next.config.ts
+
+RUN pnpm build
+
+# ── Stage 3: Production ─────────────────────────────────────────────────────
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser  --system --uid 1001 nextjs
+
+# Copy standalone build output
+COPY --from=builder --chown=nextjs:nodejs /app/examples/openui-chat/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/examples/openui-chat/.next/static   ./examples/openui-chat/.next/static
+
+USER nextjs
+EXPOSE 3000
+
+CMD ["node", "examples/openui-chat/server.js"]

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -19,6 +19,54 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 You can start editing the page by modifying `src/app/api/route.ts` and improving your agent
 by adding system prompts or tools.
 
+## Docker
+
+Build and run the chat example in a container — no local setup required.
+
+### Quick Start
+
+From the **repository root**:
+
+```bash
+docker build -t openui-chat -f examples/openui-chat/Dockerfile .
+docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
+```
+
+Then open [http://localhost:3000](http://localhost:3000).
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OPENAI_API_KEY` | ✅ | — | Your OpenAI API key |
+| `PORT` | ❌ | `3000` | Port the server listens on |
+
+### Docker Compose
+
+```yaml
+services:
+  openui-chat:
+    build:
+      context: ../..          # repo root
+      dockerfile: examples/openui-chat/Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+```
+
+```bash
+# From examples/openui-chat/
+OPENAI_API_KEY=sk-... docker compose up --build
+```
+
+### Image Details
+
+- **Base:** `node:22-alpine` (production stage ~180 MB)
+- **Build:** Multi-stage (deps → build → standalone runner)
+- **Output:** Next.js standalone mode for minimal image size
+- **User:** Runs as non-root `nextjs` user (UID 1001)
+
 ## Learn More
 
 To learn more about OpenUI, take a look at the following resources:


### PR DESCRIPTION
Adds a production-ready multi-stage Dockerfile for the `openui-chat` example.

## What

Users can now build and run the openui-chat example with a single command — no local setup required.

```bash
docker build -t openui-chat -f examples/openui-chat/Dockerfile .
docker run -p 3000:3000 -e OPENAI_API_KEY=sk-... openui-chat
```

## Implementation

- **Multi-stage build** (deps → build → standalone runner) for minimal image size
- **pnpm workspace support** — correctly resolves `workspace:*` dependencies
- **Next.js standalone output** — production image ~180MB
- **Non-root user** (`nextjs`, UID 1001) for security
- **Environment variables**: `OPENAI_API_KEY` (required), `PORT` (default 3000)
- `.dockerignore` for fast context transfer
- Docker Compose example in updated README

## Files Changed

- `examples/openui-chat/Dockerfile` — new
- `examples/openui-chat/.dockerignore` — new
- `examples/openui-chat/README.md` — updated with Docker section

Closes #303