### PR TITLE
feat(cli): prompt for OpenAI API key in interactive mode

### DIFF
--- a/packages/openui-cli/src/commands/create-chat-app.ts
+++ b/packages/openui-cli/src/commands/create-chat-app.ts
@@ -117,9 +117,7 @@ export async function runCreateChatApp(options: CreateChatAppOptions): Promise<v
     ).trim();
 
     if (apiKey) {
-      const envPath = path.join(targetDir, ".env");
-      fs.writeFileSync(envPath, `OPENAI_API_KEY=${apiKey}\n`);
-      console.info("\n✅ .env file created with your API key.\n");
+      fs.writeFileSync(path.join(targetDir, ".env"), `OPENAI_API_KEY=${apiKey}\n`);
       apiKeyWritten = true;
     }
   }
@@ -134,24 +132,24 @@ const getStartedMessage = (
   apiKeyWritten: boolean,
 ) => {
   const envInstructions = apiKeyWritten
-    ? ""
-    : `
-touch .env
+    ? "✅ .env file created with your API key."
+    : `touch .env
 
 Add your API key to .env:
-OPENAI_API_KEY=sk-your-key-here
-`;
+OPENAI_API_KEY=sk-your-key-here`;
 
   const skillMessage = skillInstalled
-    ? "\nThe OpenUI agent skill was installed.\nAI coding assistants will use it to help you build with OpenUI.\n"
+    ? "The OpenUI agent skill was installed.\nAI coding assistants will use it to help you build with OpenUI."
     : "";
 
-  return `
+  return `${skillMessage}
+
 Done!
 Get started:
 
-cd ${name}
 ${envInstructions}
-${devCmd} run dev
-${skillMessage}`;
+
+> cd ${name}
+> ${devCmd} run dev
+`;
 };


### PR DESCRIPTION
## Summary

When running `create-chat-app` interactively, prompt the user for their OpenAI API key instead of printing manual instructions. If a key is provided, the CLI creates the `.env` file automatically and simplifies the getting-started output. In non-interactive mode, behavior is unchanged.

## Changes

- **`packages/openui-cli/src/commands/create-chat-app.ts`**: After installing dependencies, prompt for the OpenAI API key using the existing `resolveArgs` helper. If provided, write `.env` and show a streamlined message. If skipped (blank input) or non-interactive, show the original instructions.

Closes #399