### PR TITLE
fix:  Debounce streamed message updates in ChatStore

### DIFF
--- a/packages/react-headless/src/stream/processStreamedMessage.ts
+++ b/packages/react-headless/src/stream/processStreamedMessage.ts
@@ -35,6 +35,15 @@ export const processStreamedMessage = async ({
 
   let isFirst = true;
 
+  let rafId: number | null = null;
+  const debouncedUpdate = (msg: AssistantMessage) => {
+    if (rafId !== null) cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(() => {
+      updateMessage(msg);
+      rafId = null;
+    });
+  };
+
   for await (const event of adapter.parse(response)) {
     switch (event.type) {
       case EventType.TEXT_MESSAGE_CONTENT:
@@ -101,8 +110,15 @@ export const processStreamedMessage = async ({
       createMessage(currentMessage);
       isFirst = false;
     } else {
-      updateMessage(currentMessage);
+      // debounce the message update using raf
+      debouncedUpdate(currentMessage);
     }
+  }
+
+  if (rafId !== null) {
+    // flush any update
+    cancelAnimationFrame(rafId);
+    updateMessage(currentMessage);
   }
 
   return currentMessage;


### PR DESCRIPTION
## What

Debounce streamed message updates in ChatStore using RAF to prevent React max update depth error.

<img width="698" height="183" alt="image" src="https://github.com/user-attachments/assets/878e0ec5-5fc8-4112-82b8-65da6429e1e6" />

## Changes

Add debouncing in updateMessage call in `processStreamedMessage`.

## Test Plan

- [X] Verified locally by creating a synthetic stream