### PR TITLE
fix: Windows compatibility for cp-css.js and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,18 @@ Thank you for considering contributing to _openui_! This document provides guide
 4. Update the README.md & autogenerate docs if needed.
 5. Open a Pull Request
 
+## Windows Setup
+
+If you are setting up the project on Windows, the `build:templates` script in `openui-cli` uses Unix shell commands (`rm -rf`, `mkdir -p`, `cp -R`) which fail when pnpm defaults to CMD as its shell.
+
+To fix this, point pnpm to Git Bash before running `pnpm install`:
+
+```bash
+pnpm config set script-shell "C:\Program Files\Git\bin\bash.exe"
+```
+
+> **Note:** This assumes Git is installed at the default location. If not, run `where git` to find the correct path and replace accordingly.
+
 ## Bug Reports
 
 Use Github Issues to report bugs. When reporting bugs, please include:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,18 +10,6 @@ Thank you for considering contributing to _openui_! This document provides guide
 4. Update the README.md & autogenerate docs if needed.
 5. Open a Pull Request
 
-## Windows Setup
-
-If you are setting up the project on Windows, the `build:templates` script in `openui-cli` uses Unix shell commands (`rm -rf`, `mkdir -p`, `cp -R`) which fail when pnpm defaults to CMD as its shell.
-
-To fix this, point pnpm to Git Bash before running `pnpm install`:
-
-```bash
-pnpm config set script-shell "C:\Program Files\Git\bin\bash.exe"
-```
-
-> **Note:** This assumes Git is installed at the default location. If not, run `where git` to find the correct path and replace accordingly.
-
 ## Bug Reports
 
 Use Github Issues to report bugs. When reporting bugs, please include:

--- a/packages/react-ui/cp-css.js
+++ b/packages/react-ui/cp-css.js
@@ -1,8 +1,9 @@
 import fs from "fs";
 import { camelCase } from "lodash-es";
 import path from "path";
+import {fileURLToPath} from "url"
 
-const dirname = path.dirname(new URL(import.meta.url).pathname);
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Create directories if they don't exist
 function ensureDirectoryExists(dirPath) {


### PR DESCRIPTION
What
Closes #445
On Windows/Git Bash, ```cp-css.js```crashes due to an invalid path produced by new URL(import.meta.url).pathname. This fix replaces it with fileURLToPath which correctly resolves file:// URLs across all platforms. 
Additionally, a Windows setup section is added to CONTRIBUTING.md documenting the pnpm script-shell fix for users hitting shell command failures during pnpm install.

Changes
Replace new URL(import.meta.url).pathname with fileURLToPath(import.meta.url) in cp-css.js
Add Windows setup section in CONTRIBUTING.md with instructions to set pnpm script-shell to Git Bash

Test Plan

 Verified locally on Windows 11 with Git Bash
 Confirmed node cp-css.js runs without errors after the fix
 Confirmed pnpm install completes successfully with the script-shell config set

Checklist
 I linked a related issue, if applicable
 I updated docs/README when needed
 I considered backwards compatibility — fileURLToPath is a Node.js built-in available since v10, no breaking changes