### PR TITLE
fix(react-ui): fix ESM compatibility with webpack 5

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/react-ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/react-ui/src/components/CodeBlock/CodeBlock.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import { CheckCheck, Copy } from "lucide-react";
 import { useState } from "react";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { IconButton } from "../IconButton";
 
 export interface CodeBlockProps {

--- a/packages/react-ui/src/components/MarkDownRenderer/MarkDownRenderer.tsx
+++ b/packages/react-ui/src/components/MarkDownRenderer/MarkDownRenderer.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
 import { memo } from "react";
 import ReactMarkdown, { Components, type Options } from "react-markdown";
-import { oneLight, vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { oneLight, vscDarkPlus } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { CodeBlock } from "../CodeBlock";
 import {
   Table,

--- a/packages/react-ui/tsdown.config.ts
+++ b/packages/react-ui/tsdown.config.ts
@@ -1,6 +1,22 @@
 import { existsSync, readdirSync, statSync } from "fs";
 import { join } from "path";
 import { defineConfig } from "tsdown";
+import type { Plugin } from "rolldown";
+
+// Rewrite external import paths in ESM output so they are fully-specified.
+// webpack 5 (CRA) treats .mjs as strict ESM and requires explicit extensions.
+const fixEsmExternalPaths: Plugin = {
+  name: "fix-esm-external-paths",
+  renderChunk(code: string) {
+    const result = code
+      .replace(/from "lodash-es\/([^"]+?)(?:\.js)?"/g, 'from "lodash-es/$1.js"')
+      .replace(
+        /"react-syntax-highlighter\/dist\/cjs\/styles\/prism"/g,
+        '"react-syntax-highlighter/dist/cjs/styles/prism/index.js"',
+      );
+    return { code: result };
+  },
+};
 
 const componentEntries = Object.fromEntries(
   readdirSync("src/components")
@@ -27,7 +43,7 @@ export default defineConfig([
   // Main index — CJS + bundled .d.cts
   { ...shared, format: ["cjs"], dts: true, entry: { index: "src/index.ts" } },
   // Main index — ESM + bundled .d.mts
-  { ...shared, format: ["esm"], dts: true, entry: { index: "src/index.ts" } },
+  { ...shared, format: ["esm"], dts: true, entry: { index: "src/index.ts" }, plugins: [fixEsmExternalPaths] },
   // genui-lib — CJS + .d.cts (own outDir so dts lands at dist/genui-lib/index.d.cts)
   {
     ...shared,
@@ -43,6 +59,7 @@ export default defineConfig([
     dts: true,
     outDir: "dist/genui-lib",
     entry: { index: "src/genui-lib/index.ts" },
+    plugins: [fixEsmExternalPaths],
   },
   // Individual components — CJS only
   { ...shared, format: ["cjs"], entry: componentEntries },


### PR DESCRIPTION
Summary:

  - CodeBlock and MarkDownRenderer were importing from react-syntax-highlighter/dist/esm/styles/prism — switched to /dist/cjs/styles/prism to align with type declarations
  - Added a renderChunk plugin to tsdown that rewrites specific external import paths in the ESM output (.mjs) to be fully-specified — webpack 5 treats .mjs as strict ESM and requires explicit file
  extensions on all imports
    - lodash-es/debounce → lodash-es/debounce.js
    - react-syntax-highlighter/dist/cjs/styles/prism → react-syntax-highlighter/dist/cjs/styles/prism/index.js
  - Added rolldown as an explicit devDependency since its Plugin type is referenced in tsdown.config.ts
  - Bumped package version to 0.11.2

  Test plan

  - Built and verified dist/index.mjs has fully-specified import paths
  - Tested with CRA (webpack 5), Vite, and Next.js
  - All 12 examples build successfully