### PR TITLE
docs: balance-wrap hero mobile subtitle

### DIFF
--- a/docs/app/(home)/sections/HeroSection/HeroSection.module.css
+++ b/docs/app/(home)/sections/HeroSection/HeroSection.module.css
@@ -46,6 +46,7 @@
   text-align: center;
   font-size: 22px;
   line-height: 1.2;
+  text-wrap: balance;
 }
 
 .tagline {


### PR DESCRIPTION
Adds `text-wrap: balance` to the hero `.mobileSubtitle` so "The Open Standard for Generative UI" breaks more evenly on narrow screens (where the subtitle is not forced to a single line).

https://x.com/argyleink/status/2046579201214751045

Made with [Cursor](https://cursor.com)