### PR TITLE
fix(a11y): add aria-labels to icon-only buttons in Shell components

### DIFF
--- a/packages/react-ui/src/components/CopilotShell/components/Composer.tsx
+++ b/packages/react-ui/src/components/CopilotShell/components/Composer.tsx
@@ -70,6 +70,7 @@ export const Composer = ({ className, placeholder = "Type your message..." }: Co
             icon={isRunning ? <Square size="1em" fill="currentColor" /> : <ArrowUp size="1em" />}
             size="medium"
             variant="primary"
+            aria-label={isRunning ? "Cancel message" : "Send message"}
             className="openui-copilot-shell-thread-composer__submit-button"
           />
         </div>

--- a/packages/react-ui/src/components/Shell/MobileHeader.tsx
+++ b/packages/react-ui/src/components/Shell/MobileHeader.tsx
@@ -25,6 +25,7 @@ export const MobileHeader = ({ className, rightChildren }: MobileHeaderProps) =>
         icon={<Menu size="1em" />}
         onClick={() => setIsSidebarOpen(true)}
         variant="secondary"
+        aria-label="Open sidebar"
       />
       <div className="openui-shell-mobile-header-logo-container">
         <img className="openui-shell-mobile-header-logo" src={logoUrl} alt="Logo" />
@@ -37,6 +38,7 @@ export const MobileHeader = ({ className, rightChildren }: MobileHeaderProps) =>
           icon={<Plus size="1em" />}
           onClick={switchToNewThread}
           variant="secondary"
+          aria-label="New chat"
         />
       </div>
     </div>

--- a/packages/react-ui/src/components/Shell/NewChatButton.tsx
+++ b/packages/react-ui/src/components/Shell/NewChatButton.tsx
@@ -18,6 +18,7 @@ export const NewChatButton = ({ className }: { className?: string }) => {
         onClick={switchToNewThread}
         variant="primary"
         size="small"
+        aria-label="New chat"
         className={clsx("openui-shell-new-chat-button_collapsed", className)}
       />
     );

--- a/packages/react-ui/src/components/Shell/Sidebar.tsx
+++ b/packages/react-ui/src/components/Shell/Sidebar.tsx
@@ -91,6 +91,7 @@ export const SidebarHeader = ({
           }}
           size="small"
           variant="secondary"
+          aria-label={isSidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
           className="openui-shell-sidebar-header__toggle-button"
         />
       </div>

--- a/packages/react-ui/src/components/Shell/components/Composer.tsx
+++ b/packages/react-ui/src/components/Shell/components/Composer.tsx
@@ -70,6 +70,7 @@ export const Composer = ({ className, placeholder = "Type your query here" }: Co
             icon={isRunning ? <Square size="1em" fill="currentColor" /> : <ArrowUp size="1em" />}
             size="medium"
             variant="primary"
+            aria-label={isRunning ? "Cancel message" : "Send message"}
             className="openui-shell-thread-composer__submit-button"
           />
         </div>


### PR DESCRIPTION
## Summary

Icon-only buttons in the Shell and CopilotShell components had no accessible name, failing [WCAG 2.1 SC 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). Screen readers would announce these as unlabelled buttons, making the UI unusable for assistive technology users.

**Files changed:**
- `Shell/components/Composer.tsx` — send/cancel button: dynamic label reflects running state (`"Send message"` / `"Cancel message"`)
- `CopilotShell/components/Composer.tsx` — same fix
- `Shell/NewChatButton.tsx` — collapsed sidebar new-chat button: `aria-label="New chat"`
- `Shell/MobileHeader.tsx` — menu button (`"Open sidebar"`) and new-chat button (`"New chat"`)
- `Shell/Sidebar.tsx` — toggle button: dynamic label (`"Collapse sidebar"` / `"Expand sidebar"`)

## Test plan

- [ ] Open with a screen reader (VoiceOver / NVDA) and verify each button announces its accessible name
- [ ] Verify send button label changes between "Send message" and "Cancel message" during/after message submission
- [ ] Verify sidebar toggle label changes between "Collapse sidebar" and "Expand sidebar"