### PR TITLE
fix(a11y): add aria-labels to chart scroll buttons

### DIFF
--- a/packages/react-ui/src/components/Charts/shared/ScrollButtonsHorizontal/ScrollButtonsHorizontal.tsx
+++ b/packages/react-ui/src/components/Charts/shared/ScrollButtonsHorizontal/ScrollButtonsHorizontal.tsx
@@ -41,6 +41,7 @@ export const ScrollButtonsHorizontal = React.memo(
           onClick={onScrollLeft}
           size="2-extra-small"
           disabled={!canScrollLeft}
+          aria-label="Scroll left"
         />
 
         <IconButton
@@ -56,6 +57,7 @@ export const ScrollButtonsHorizontal = React.memo(
           size="2-extra-small"
           onClick={onScrollRight}
           disabled={!canScrollRight}
+          aria-label="Scroll right"
         />
       </div>
     );

--- a/packages/react-ui/src/components/Charts/shared/ScrollButtonsVertical/ScrollButtonsVertical.tsx
+++ b/packages/react-ui/src/components/Charts/shared/ScrollButtonsVertical/ScrollButtonsVertical.tsx
@@ -41,6 +41,7 @@ export const ScrollButtonsVertical = React.memo(
           onClick={onScrollUp}
           size="extra-small"
           disabled={!canScrollUp}
+          aria-label="Scroll up"
         />
 
         <IconButton
@@ -56,6 +57,7 @@ export const ScrollButtonsVertical = React.memo(
           size="extra-small"
           onClick={onScrollDown}
           disabled={!canScrollDown}
+          aria-label="Scroll down"
         />
       </div>
     );


### PR DESCRIPTION
## Summary

The chart scroll buttons (horizontal left/right and vertical up/down) used icon-only `IconButton` components with no accessible name, failing [WCAG 2.1 SC 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

Screen readers would announce these as unlabelled buttons, giving users no indication of what they do.

**Files changed:**
- `Charts/shared/ScrollButtonsHorizontal/ScrollButtonsHorizontal.tsx` — added `aria-label="Scroll left"` and `aria-label="Scroll right"`
- `Charts/shared/ScrollButtonsVertical/ScrollButtonsVertical.tsx` — added `aria-label="Scroll up"` and `aria-label="Scroll down"`

## Test plan

- [ ] Open a chart with overflow content using a screen reader (VoiceOver / NVDA)
- [ ] Verify the scroll buttons announce "Scroll left", "Scroll right", "Scroll up", "Scroll down" respectively