### PR TITLE
fix(a11y): add role and aria-live to MessageLoading component

### DIFF
--- a/packages/react-ui/src/components/MessageLoading/MessageLoading.tsx
+++ b/packages/react-ui/src/components/MessageLoading/MessageLoading.tsx
@@ -2,7 +2,12 @@ import clsx from "clsx";
 
 export const MessageLoading = ({ className }: { className?: string }) => {
   return (
-    <div className={clsx("openui-message-loading-container", className)}>
+    <div
+      className={clsx("openui-message-loading-container", className)}
+      role="status"
+      aria-live="polite"
+      aria-label="Loading message"
+    >
       <div className="openui-message-loading" />
     </div>
   );


### PR DESCRIPTION
## Summary

The `MessageLoading` component — shown while the assistant is generating a response — had no semantic role or live region, so screen reader users received no indication that a message was loading.

Added:
- `role="status"` — identifies this as a status message container
- `aria-live="polite"` — announces the loading state without interrupting the user
- `aria-label="Loading message"` — provides a meaningful text description for the animated dots

This follows [WCAG 2.1 SC 4.1.3 (Status Messages)](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html).

## Test plan

- [ ] Open a chat with a screen reader (VoiceOver / NVDA)
- [ ] Send a message and verify the screen reader announces "Loading message" when the loading indicator appears