### PR TITLE
fix(a11y): add dynamic aria-label to CodeBlock copy button

### DIFF
--- a/packages/react-ui/src/components/CodeBlock/CodeBlock.tsx
+++ b/packages/react-ui/src/components/CodeBlock/CodeBlock.tsx
@@ -32,6 +32,7 @@ export const CodeBlock = ({ language, codeString, theme }: CodeBlockProps) => {
           "openui-code-block-copy-button-copied": copied,
         })}
         icon={copied ? <CheckCheck /> : <Copy />}
+        aria-label={copied ? "Copied to clipboard" : "Copy code"}
       />
       <SyntaxHighlighter
         style={theme ?? vscDarkPlus}


### PR DESCRIPTION
## Summary

The copy button in `CodeBlock` was an icon-only button with no accessible name, failing [WCAG 2.1 SC 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

Added a dynamic `aria-label` that:
- Reads **"Copy code"** in the default state
- Changes to **"Copied to clipboard"** immediately after the user copies

This gives screen reader users both the button's purpose and confirmation that the copy action succeeded — without needing to rely on the visual icon change.

## Test plan

- [ ] Open a page with a `CodeBlock` using a screen reader (VoiceOver / NVDA)
- [ ] Verify the button announces "Copy code" before clicking
- [ ] Click the button and verify it announces "Copied to clipboard"