### PR TITLE
fix(a11y): use aria-labelledby instead of aria-label on Modal dialog

### DIFF
--- a/packages/react-ui/src/components/Modal/Modal.tsx
+++ b/packages/react-ui/src/components/Modal/Modal.tsx
@@ -63,7 +63,9 @@ export const Modal: React.FC<ModalProps> = ({
         tabIndex={-1}
       >
         <div className="openui-modal-header">
-          <h2 id="openui-modal-title" className="openui-modal-title">{title}</h2>
+          <h2 id="openui-modal-title" className="openui-modal-title">
+            {title}
+          </h2>
           <button className="openui-modal-close" aria-label="Close" onClick={handleClose}>
             <X size={18} />
           </button>

--- a/packages/react-ui/src/components/Modal/Modal.tsx
+++ b/packages/react-ui/src/components/Modal/Modal.tsx
@@ -59,11 +59,11 @@ export const Modal: React.FC<ModalProps> = ({
         className={clsx("openui-modal-content", sizeClass[size])}
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-labelledby="openui-modal-title"
         tabIndex={-1}
       >
         <div className="openui-modal-header">
-          <h2 className="openui-modal-title">{title}</h2>
+          <h2 id="openui-modal-title" className="openui-modal-title">{title}</h2>
           <button className="openui-modal-close" aria-label="Close" onClick={handleClose}>
             <X size={18} />
           </button>


### PR DESCRIPTION
## Summary

The modal `role="dialog"` element used `aria-label={title}`, which duplicates the text already rendered in the visible `<h2>` heading. The [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) recommends using `aria-labelledby` to reference a visible heading element instead.

**Changes:**
- Added `id="openui-modal-title"` to the existing `<h2>` element
- Replaced `aria-label={title}` on the dialog `div` with `aria-labelledby="openui-modal-title"`

This ensures screen readers read the actual rendered heading text rather than a separate hidden string that could drift out of sync.

## Test plan

- [ ] Open a modal with a screen reader (VoiceOver / NVDA)
- [ ] Verify the dialog is announced with its title when it opens