### PR TITLE
fix(a11y): improve keyboard accessibility in GalleryModal

### DIFF
--- a/packages/react-ui/src/components/ImageGallery/GalleryModal.tsx
+++ b/packages/react-ui/src/components/ImageGallery/GalleryModal.tsx
@@ -119,8 +119,16 @@ export const GalleryModal: React.FC<GalleryModalProps> = ({
         aria-labelledby="openui-gallery-modal-heading"
       >
         <div className="openui-gallery__modal-header">
-          <span id="openui-gallery-modal-heading" className="openui-gallery__modal-heading">All Photos</span>
-          <IconButton size="small" variant="secondary" icon={<X />} onClick={onClose} aria-label="Close gallery" />
+          <span id="openui-gallery-modal-heading" className="openui-gallery__modal-heading">
+            All Photos
+          </span>
+          <IconButton
+            size="small"
+            variant="secondary"
+            icon={<X />}
+            onClick={onClose}
+            aria-label="Close gallery"
+          />
         </div>
         <div className="openui-gallery__modal-main">
           <img

--- a/packages/react-ui/src/components/ImageGallery/GalleryModal.tsx
+++ b/packages/react-ui/src/components/ImageGallery/GalleryModal.tsx
@@ -111,10 +111,16 @@ export const GalleryModal: React.FC<GalleryModalProps> = ({
 
   return createPortal(
     <div className={clsx("openui-gallery__modal", portalThemeClassName)}>
-      <div className="openui-gallery__modal-content" ref={modalContentRef}>
+      <div
+        className="openui-gallery__modal-content"
+        ref={modalContentRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="openui-gallery-modal-heading"
+      >
         <div className="openui-gallery__modal-header">
-          <span className="openui-gallery__modal-heading">All Photos</span>
-          <IconButton size="small" variant="secondary" icon={<X />} onClick={onClose} />
+          <span id="openui-gallery-modal-heading" className="openui-gallery__modal-heading">All Photos</span>
+          <IconButton size="small" variant="secondary" icon={<X />} onClick={onClose} aria-label="Close gallery" />
         </div>
         <div className="openui-gallery__modal-main">
           <img
@@ -152,9 +158,19 @@ export const GalleryModal: React.FC<GalleryModalProps> = ({
                   "openui-gallery__modal-thumbnail",
                   index === selectedImageIndex && "openui-gallery__modal-thumbnail--active",
                 )}
+                role="button"
+                tabIndex={0}
+                aria-label={image.alt || `Gallery image ${index + 1}`}
+                aria-pressed={index === selectedImageIndex}
                 onClick={handleThumbnailClick(index)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleThumbnailClick(index)();
+                  }
+                }}
               >
-                <img src={image.src} alt={image.alt || `Gallery thumbnail ${index + 1}`} />
+                <img src={image.src} alt="" aria-hidden="true" />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary

Three accessibility issues in `GalleryModal`:

### 1. Modal missing `role="dialog"` and `aria-labelledby`
The modal overlay content had no dialog role or label, so screen readers could not identify it as a modal or announce its title when it opened.

**Fix:** Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` pointing to the "All Photos" heading via `id`.

### 2. Close button missing accessible name
The X icon button had no `aria-label`, failing WCAG 2.1 SC 4.1.2.

**Fix:** Added `aria-label="Close gallery"`.

### 3. Thumbnail `<div>` elements not keyboard accessible
Thumbnail images were clickable `<div>` elements with no `role`, `tabIndex`, or keyboard handler — completely inaccessible to keyboard and screen reader users, failing WCAG 2.1 SC 2.1.1 and SC 4.1.2.

**Fix:**
- Added `role="button"`, `tabIndex={0}` to make them focusable
- Added `aria-label` using the image's alt text (or a generated fallback)
- Added `aria-pressed` to reflect the selected state
- Added `onKeyDown` to handle Enter and Space activation
- Moved the descriptive text to the button label; set `aria-hidden="true"` on the `<img>` to prevent duplicate announcements

## Test plan

- [ ] Open the gallery modal with a screen reader (VoiceOver / NVDA) and verify it announces the dialog title "All Photos"
- [ ] Tab to the close button and verify it announces "Close gallery"
- [ ] Tab through thumbnails and verify each announces its label and selected state
- [ ] Press Enter or Space on a thumbnail and verify it selects that image