### PR TITLE
refactor(react-ui): simplify Accordion auto-open logic

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/react-ui/src/genui-lib/Accordion/index.tsx
+++ b/packages/react-ui/src/genui-lib/Accordion/index.tsx
@@ -28,38 +28,16 @@ export const Accordion = defineComponent({
   description: "Collapsible sections",
   component: ({ props, renderNode }) => {
     const items = props.items ?? [];
-    const [openItem, setOpenItem] = React.useState("");
+    const [openItem, setOpenItem] = React.useState<string>("");
     const userHasInteracted = React.useRef(false);
-    const prevContentSizes = React.useRef<Record<string, number>>({});
+    const prevItemCount = React.useRef(0);
 
-    React.useEffect(() => {
-      const first = items[0];
-      if (items.length && !openItem && first) {
-        setOpenItem(first.props.value);
-      }
-    }, [items.length, openItem]);
-
-    React.useEffect(() => {
-      if (userHasInteracted.current) return;
-
-      let candidate: string | null = null;
-      const nextSizes: Record<string, number> = {};
-
-      for (const item of items) {
-        const size = JSON.stringify(item.props.content).length;
-        const prevSize = prevContentSizes.current[item.props.value] ?? 0;
-        nextSizes[item.props.value] = size;
-        if (size > prevSize) {
-          candidate = item.props.value;
-        }
-      }
-
-      prevContentSizes.current = nextSizes;
-
-      if (candidate && candidate !== openItem) {
-        setOpenItem(candidate);
-      }
-    });
+    // Auto-open: only when a NEW item arrives during streaming
+    if (!userHasInteracted.current && items.length > prevItemCount.current) {
+      const newest = items[items.length - 1];
+      if (newest) setOpenItem(newest.props.value);
+    }
+    prevItemCount.current = items.length;
 
     const handleValueChange = (value: string) => {
       userHasInteracted.current = true;


### PR DESCRIPTION
Updated the Accordion component to streamline the auto-open functionality. Removed the previous content size tracking and replaced it with a simpler check that opens the newest item when a new item arrives during streaming. This enhances performance and reduces complexity in state management.

https://github.com/user-attachments/assets/f985eb30-c87f-4452-8038-2fb023097447


