### PR TITLE
Fix Windows build compatibility in package scripts

### DIFF
--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -15,7 +15,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "rm -rf dist && mkdir -p dist && esbuild src/entry.js --bundle --format=iife --minify --outfile=dist/openui-bundle.min.js '--define:process.env.NODE_ENV=\"production\"' --target=es2020 && node scripts/concat-css.mjs",
+    "build": "node scripts/prepare-dist.mjs && esbuild src/entry.js --bundle --format=iife --minify --outfile=dist/openui-bundle.min.js '--define:process.env.NODE_ENV=\"production\"' --target=es2020 && node scripts/concat-css.mjs",
     "typecheck": "echo \"(no types to check — IIFE bundle)\"",
     "lint:check": "eslint ./src",
     "lint:fix": "eslint ./src --fix",

--- a/packages/browser-bundle/scripts/prepare-dist.mjs
+++ b/packages/browser-bundle/scripts/prepare-dist.mjs
@@ -1,0 +1,9 @@
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(dirname, "..", "dist");
+
+await rm(distDir, { force: true, recursive: true });
+await mkdir(distDir, { recursive: true });

--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build:cli": "tsc -p .",
-    "build:templates": "rm -rf dist/templates/openui-chat && mkdir -p dist/templates && cp -R src/templates/openui-chat dist/templates/openui-chat",
+    "build:templates": "node scripts/build-templates.mjs",
     "build": "pnpm run build:cli && pnpm run build:templates",
     "build:exec": "node dist/index.js",
     "lint:check": "eslint ./src --ignore-pattern 'src/templates/**'",

--- a/packages/openui-cli/scripts/build-templates.mjs
+++ b/packages/openui-cli/scripts/build-templates.mjs
@@ -1,0 +1,13 @@
+import { cp, mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(dirname, "..");
+const sourceDir = path.join(packageDir, "src", "templates", "openui-chat");
+const templatesDir = path.join(packageDir, "dist", "templates");
+const targetDir = path.join(templatesDir, "openui-chat");
+
+await rm(targetDir, { force: true, recursive: true });
+await mkdir(templatesDir, { recursive: true });
+await cp(sourceDir, targetDir, { recursive: true });

--- a/packages/react-ui/cp-css.js
+++ b/packages/react-ui/cp-css.js
@@ -1,8 +1,9 @@
 import fs from "fs";
 import { camelCase } from "lodash-es";
 import path from "path";
+import { fileURLToPath } from "url";
 
-const dirname = path.dirname(new URL(import.meta.url).pathname);
+const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Create directories if they don't exist
 function ensureDirectoryExists(dirPath) {

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -64,7 +64,7 @@
     "copy-css": "node cp-css.js",
     "generate-scss-index": "node src/scripts/scss-import.js",
     "generate:css-utils": "tsx src/scripts/generate-css-utils.ts",
-    "build": "rm -rf dist && pnpm generate:css-utils && pnpm build:scss && pnpm build:tsc && pnpm build:cjs && pnpm run copy-css",
+    "build": "node scripts/clean-dist.mjs && pnpm generate:css-utils && pnpm build:scss && pnpm build:tsc && pnpm build:cjs && pnpm run copy-css",
     "typecheck": "tsc --noEmit",
     "build:tsc": "tsc -p . || true",
     "build:cjs": "tsdown",

--- a/packages/react-ui/scripts/clean-dist.mjs
+++ b/packages/react-ui/scripts/clean-dist.mjs
@@ -1,0 +1,8 @@
+import { rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const distDir = path.resolve(dirname, "..", "dist");
+
+await rm(distDir, { force: true, recursive: true });


### PR DESCRIPTION
## Summary
- replace Unix-only template/dist cleanup commands with small Node-based scripts in `openui-cli`, `react-ui`, and `browser-bundle`
- fix `packages/react-ui/cp-css.js` to resolve `import.meta.url` with `fileURLToPath`, which works correctly on Windows paths
- keep existing build behavior intact on macOS/Linux while making the same flows work under Windows `pnpm`

## Validation
- ran `node packages/openui-cli/scripts/build-templates.mjs`
- ran `node packages/browser-bundle/scripts/prepare-dist.mjs`
- ran `node packages/react-ui/scripts/clean-dist.mjs`

Closes #445.