### PR TITLE
chore(openui-chat): use OPENAI_MODEL instead of hardcoded model

### DIFF
--- a/examples/openui-chat/src/app/api/chat/route.ts
+++ b/examples/openui-chat/src/app/api/chat/route.ts
@@ -202,7 +202,7 @@ export async function POST(req: NextRequest) {
   const client = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  const MODEL = "gpt-5.4";
+  const MODEL = process.env.OPENAI_MODEL || "gpt-5.4";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cleanMessages = (messages as any[])


### PR DESCRIPTION
## Summary
- replace the hardcoded `gpt-5.4` model in `examples/openui-chat/src/app/api/chat/route.ts` with `process.env.OPENAI_MODEL`
- keep `gpt-5.4` as the fallback to preserve existing behavior when the env var is not set

## Test plan
- [x] Inspect diff to confirm only the model assignment changed
- [x] Run lints for the edited file (`examples/openui-chat/src/app/api/chat/route.ts`)
- [ ] Optionally run the example with `OPENAI_MODEL` set to verify runtime model switching

Made with [Cursor](https://cursor.com)