### PR TITLE
docs(home): shorten OpenClaw-OS banner text on mobile

### DIFF
--- a/docs/app/(home)/sections/HeroSection/HeroSection.tsx
+++ b/docs/app/(home)/sections/HeroSection/HeroSection.tsx
@@ -163,7 +163,7 @@ function AnnouncementBanner({ className = "" }: { className?: string }) {
       >
         <span className={styles.heroBannerLabel}>
           <span className={styles.heroBannerBadge}>New</span>
-          <span>The default workspace for OpenClaw. Meet OpenClaw-OS.</span>
+          <span>Meet OpenClaw-OS</span>
         </span>
       </Link>
     </>


### PR DESCRIPTION
## Summary
- Use a concise "Meet OpenClaw-OS" label in the mobile announcement banner so it fits comfortably on smaller screens
- Desktop banner is unchanged and still shows the full "The default workspace for OpenClaw. Meet OpenClaw-OS." message

## Test plan
- [ ] Verify the mobile hero banner displays "Meet OpenClaw-OS" without overflow on small viewports
- [ ] Verify the desktop hero banner still shows the full message
- [ ] Tap the mobile banner and confirm it still navigates to the OpenClaw-OS page

Made with [Cursor](https://cursor.com)