### PR TITLE
refactor: standardize GPT model references to gpt-5.5

### DIFF
--- a/examples/form-generator/src/app/api/chat/route.ts
+++ b/examples/form-generator/src/app/api/chat/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
   ];
 
   const stream = await client.chat.completions.create({
-    model: "gpt-5.4",
+    model: "gpt-5.5",
     messages: chatMessages,
     stream: true,
   });

--- a/examples/hands-on-table-chat/README.md
+++ b/examples/hands-on-table-chat/README.md
@@ -62,7 +62,7 @@ An AI-powered spreadsheet app that pairs a full-featured [Handsontable](https://
 ### Prerequisites
 
 - Node.js 18+
-- An [OpenAI API key](https://platform.openai.com/api-keys) (GPT-4o recommended)
+- An [OpenAI API key](https://platform.openai.com/api-keys) (GPT-5.5 recommended)
 
 ### Setup
 
@@ -87,7 +87,7 @@ Open [http://localhost:3000](http://localhost:3000) to see the spreadsheet with 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `OPENAI_API_KEY` | Yes | — | Your OpenAI API key |
-| `OPENAI_MODEL` | No | `gpt-4o` | Model to use for chat completions |
+| `OPENAI_MODEL` | No | `gpt-5.5` | Model to use for chat completions |
 
 ## Project Structure
 

--- a/examples/hands-on-table-chat/env.example
+++ b/examples/hands-on-table-chat/env.example
@@ -1,5 +1,5 @@
 # OpenAI API Key
 OPENAI_API_KEY=your_openai_api_key_here
 
-# Optional: Override the model (default: gpt-4o)
-# OPENAI_MODEL=gpt-4o
+# Optional: Override the model (default: gpt-)
+# OPENAI_MODEL=gpt-5.5

--- a/examples/hands-on-table-chat/src/app/api/chat/route.ts
+++ b/examples/hands-on-table-chat/src/app/api/chat/route.ts
@@ -203,7 +203,7 @@ export async function POST(req: NextRequest) {
 
       /* eslint-disable @typescript-eslint/no-explicit-any */
       const runner = (client.chat.completions as any).runTools({
-        model: process.env.OPENAI_MODEL || "gpt-4o",
+        model: process.env.OPENAI_MODEL || "gpt-5.5",
         messages: chatMessages,
         tools,
         stream: true,

--- a/examples/mastra-chat/src/app/api/chat/route.ts
+++ b/examples/mastra-chat/src/app/api/chat/route.ts
@@ -58,7 +58,7 @@ const agent = new MastraAgent({
     name: "OpenUI Agent",
     instructions: `You are a helpful assistant. Use tools when relevant and help the user with their requests. Always format your responses cleanly.\n\n${systemPromptFile}`,
     model: {
-      id: (process.env.OPENAI_MODEL as `${string}/${string}`) || "openai/gpt-4o",
+      id: (process.env.OPENAI_MODEL as `${string}/${string}`) || "openai/gpt-5.5",
       apiKey: process.env.OPENAI_API_KEY,
       url: process.env.OPENAI_BASE_URL || "https://api.openai.com/v1",
     },

--- a/examples/multi-agent-chat/README.md
+++ b/examples/multi-agent-chat/README.md
@@ -150,7 +150,7 @@ The API route uses `streamText` with the following configuration:
 
 | Argument   | Value                | Purpose                                                              |
 | ---------- | -------------------- | -------------------------------------------------------------------- |
-| `model`    | `openai("gpt-5.4")`  | The LLM for the main orchestrator                                    |
+| `model`    | `openai("gpt-5.5")`  | The LLM for the main orchestrator                                    |
 | `system`   | orchestrator prompt  | Instructs the agent to delegate visual tasks to `analytics_subagent` |
 | `messages` | conversation history | The full thread from the client                                      |
 | `tools`    | 5 tool definitions   | Sub-agent + 4 helper tools                                           |

--- a/examples/multi-agent-chat/src/app/api/chat/route.ts
+++ b/examples/multi-agent-chat/src/app/api/chat/route.ts
@@ -43,7 +43,7 @@ export async function POST(req: Request) {
   console.info("[Main Agent] Full model chat history:\n", prettyJson(modelMessages));
 
   const result = streamText({
-    model: openai("gpt-5.4"),
+    model: openai("gpt-5.5"),
     system: mainAgentSystemPrompt,
     messages: modelMessages,
     tools,

--- a/examples/multi-agent-chat/src/lib/tools.ts
+++ b/examples/multi-agent-chat/src/lib/tools.ts
@@ -64,7 +64,7 @@ Output contract (strict):
       console.info("[analytics_subagent] Prompt:\n", prompt);
 
       const result = streamText({
-        model: openai("gpt-5.4"),
+        model: openai("gpt-5.5"),
         system: analyticsSubagentSystemPrompt,
         prompt,
         abortSignal,

--- a/examples/openui-artifact-demo/src/app/api/chat/route.ts
+++ b/examples/openui-artifact-demo/src/app/api/chat/route.ts
@@ -202,7 +202,7 @@ export async function POST(req: NextRequest) {
   const client = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  const MODEL = process.env.OPENAI_MODEL || "gpt-5.4-mini";
+  const MODEL = process.env.OPENAI_MODEL || "gpt-5.5";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cleanMessages = (messages as any[])

--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -6,7 +6,7 @@ First, create a `.env` file:
 
 ```env
 OPENAI_API_KEY=sk-your-key-here
-OPENAI_MODEL=gpt-5.4
+OPENAI_MODEL=gpt-5.5
 ```
 
 Then run the development server:
@@ -35,7 +35,7 @@ Example using OpenRouter:
 ```env
 OPENAI_API_KEY=sk-or-v1-...
 OPENAI_BASE_URL=https://openrouter.ai/api/v1
-OPENAI_MODEL=openai/gpt-4.1-mini
+OPENAI_MODEL=openai/gpt-5.5
 ```
 
 This also works with other OpenAI-compatible providers.

--- a/examples/openui-chat/src/app/api/chat/route.ts
+++ b/examples/openui-chat/src/app/api/chat/route.ts
@@ -204,7 +204,7 @@ export async function POST(req: NextRequest) {
     baseURL: process.env.OPENAI_BASE_URL || undefined,
   });
 
-  const MODEL = process.env.OPENAI_MODEL || "gpt-5.4";
+  const MODEL = process.env.OPENAI_MODEL || "gpt-5.5";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cleanMessages = (messages as any[])

--- a/examples/openui-dashboard/src/app/api/chat/route.ts
+++ b/examples/openui-dashboard/src/app/api/chat/route.ts
@@ -23,7 +23,7 @@ export async function POST(req: NextRequest) {
 
   const apiKey = process.env.LLM_API_KEY || process.env.OPENAI_API_KEY || "";
   const baseURL = process.env.LLM_BASE_URL || "https://api.openai.com/v1";
-  const model = process.env.LLM_MODEL || "gpt-5.4";
+  const model = process.env.LLM_MODEL || "gpt-5.5";
 
   if (!apiKey) {
     return new Response(

--- a/examples/openui-react-native/backend/src/app/api/chat/route.ts
+++ b/examples/openui-react-native/backend/src/app/api/chat/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
   if (lastUserMsg) conversationLog.push({ role: "user", content: extractText(lastUserMsg) });
 
   const completion = await openai.chat.completions.create({
-    model: "gpt-4o",
+    model: "gpt-5.5",
     stream: true,
     messages: [{ role: "system", content: SYSTEM_PROMPT }, ...messages],
   });

--- a/examples/react-email/src/app/api/chat/route.ts
+++ b/examples/react-email/src/app/api/chat/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
   ];
 
   const stream = await client.chat.completions.create({
-    model: "gpt-5.4",
+    model: "gpt-5.5",
     messages: chatMessages,
     stream: true,
   });

--- a/examples/shadcn-chat/src/app/api/chat/route.ts
+++ b/examples/shadcn-chat/src/app/api/chat/route.ts
@@ -284,7 +284,7 @@ export async function POST(req: NextRequest) {
   const client = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  const MODEL = "gpt-5.4";
+  const MODEL = "gpt-5.5";
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const cleanMessages = (messages as any[])

--- a/examples/supabase-chat/README.md
+++ b/examples/supabase-chat/README.md
@@ -67,7 +67,7 @@ cp .env.local.example .env.local
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase dashboard → Settings → API → Project URL |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase dashboard → Settings → API → anon/public key |
 | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
-| `OPENROUTER_MODEL` _(optional)_ | Defaults to `openai/gpt-4o-mini` |
+| `OPENROUTER_MODEL` _(optional)_ | Defaults to `openai/gpt-5.5` |
 
 ### 5. Install and run
 

--- a/examples/supabase-chat/src/app/api/chat/route.ts
+++ b/examples/supabase-chat/src/app/api/chat/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
 
-const MODEL = process.env.OPENROUTER_MODEL ?? "openai/gpt-4o-mini";
+const MODEL = process.env.OPENROUTER_MODEL ?? "openai/gpt-5.5";
 
 /**
  * POST /api/chat

--- a/examples/svelte-chat/src/routes/api/chat/+server.ts
+++ b/examples/svelte-chat/src/routes/api/chat/+server.ts
@@ -12,7 +12,7 @@ export async function POST({ request }: { request: Request }) {
   const { messages } = await request.json();
 
   const result = streamText({
-    model: openai("gpt-5.4"),
+    model: openai("gpt-5.5"),
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
     tools,

--- a/examples/vercel-ai-chat/README.md
+++ b/examples/vercel-ai-chat/README.md
@@ -151,7 +151,7 @@ The API route uses the Vercel AI SDK's `streamText` with five arguments:
 
 | Argument | Value | Purpose |
 | -------- | ----- | ------- |
-| `model` | `openai("gpt-5.4")` | The LLM to call |
+| `model` | `openai("gpt-5.5")` | The LLM to call |
 | `system` | contents of `system-prompt.txt` | Teaches the model OpenUI Lang and the available components |
 | `messages` | conversation history from client | The full thread so far |
 | `tools` | four tool definitions | Functions the LLM can call mid-generation |

--- a/examples/vercel-ai-chat/src/app/api/chat/route.ts
+++ b/examples/vercel-ai-chat/src/app/api/chat/route.ts
@@ -49,7 +49,7 @@ export async function POST(req: Request) {
   const modelMessages = await convertToModelMessages(messages);
 
   const result = streamText({
-    model: openai("gpt-5.4"),
+    model: openai("gpt-5.5"),
     system: systemPrompt,
     messages: modelMessages,
     tools,

--- a/examples/vue-chat/server/api/chat.post.ts
+++ b/examples/vue-chat/server/api/chat.post.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
   const { messages } = await readBody(event);
 
   const result = streamText({
-    model: openai("gpt-5.4"),
+    model: openai("gpt-5.5"),
     system: systemPrompt,
     messages: await convertToModelMessages(messages),
     tools,

--- a/packages/react-ui/src/components/OpenUIChat/stories/OpenUIChat.mdx
+++ b/packages/react-ui/src/components/OpenUIChat/stories/OpenUIChat.mdx
@@ -211,7 +211,7 @@ import { ChevronDown, Share, ThumbsUp } from "lucide-react";
   threadHeader={
     <>
       <Button iconLeft={<ChevronDown size={14} />} variant="secondary" size="small">
-        GPT-4o
+        GPT-5.5
       </Button>
       <div style={{ display: "flex", gap: "4px" }}>
         <IconButton icon={<ThumbsUp size={16} />} aria-label="Feedback" size="small" variant="secondary" />

--- a/packages/react-ui/src/components/OpenUIChat/stories/OpenUIChat.stories.tsx
+++ b/packages/react-ui/src/components/OpenUIChat/stories/OpenUIChat.stories.tsx
@@ -173,7 +173,7 @@ export const StandaloneWithThreadHeader = {
         threadHeader={
           <>
             <Button iconLeft={<ChevronDown size={14} />} variant="secondary" size="small">
-              GPT-4o
+              GPT-5.5
             </Button>
             <div style={{ display: "flex", gap: "4px" }}>
               <IconButton

--- a/packages/react-ui/src/components/Shell/stories/Shell.mdx
+++ b/packages/react-ui/src/components/Shell/stories/Shell.mdx
@@ -188,7 +188,7 @@ import { ThreadHeader } from "@openuidev/react-ui/Shell";
   <MobileHeader />
   <ThreadHeader>
     <Button iconLeft={<ChevronDown size={14} />} variant="secondary" size="small">
-      GPT-4o
+      GPT-5.5
     </Button>
     <Button iconLeft={<Share size={14} />} variant="secondary" size="small">
       Share

--- a/packages/react-ui/src/components/Shell/stories/Shell.stories.tsx
+++ b/packages/react-ui/src/components/Shell/stories/Shell.stories.tsx
@@ -209,7 +209,7 @@ export const WithThreadHeader = {
                 fontSize: "13px",
               }}
             >
-              <option>GPT-4o</option>
+              <option>GPT-5.5</option>
               <option>Claude 3.5 Sonnet</option>
               <option>Gemini Pro</option>
             </select>


### PR DESCRIPTION
Update all OpenAI model identifiers across example apps, storybook stories, and README docs to use gpt-5.5. Consolidates prior mix of gpt-4o, gpt-4o-mini, gpt-4.1-mini, gpt-5.4, gpt-5.4-mini, and gpt-5.5-mini into a single model identifier so examples stay consistent for users following the docs.
