### PR TITLE
docs: add live README badges

### DIFF
--- a/.github/workflows/update-npm-downloads-badge.yml
+++ b/.github/workflows/update-npm-downloads-badge.yml
@@ -1,0 +1,41 @@
+name: Update npm downloads badge
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_run:
+    workflows: [ "Publish NPM packages" ]
+    types: [ completed ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Update README badge
+        run: node scripts/update-npm-downloads-badge.mjs
+
+      - name: Commit README badge
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "npm downloads badge is already up to date."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore: update npm downloads badge"
+          git push

--- a/README.md
+++ b/README.md
@@ -11,9 +11,12 @@
 
 # OpenUI - The Open Standard for Generative UI
 
-[![Build](https://github.com/thesysdev/openui/actions/workflows/build-js.yml/badge.svg)](https://github.com/thesysdev/openui/actions/workflows/build-js.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
-[![Discord](https://img.shields.io/badge/Discord-Chat-7289da?logo=discord&logoColor=white)](https://discord.com/invite/Pbv5PsqUSv)
+<p align="center">
+  <a href="https://github.com/thesysdev/openui/actions/workflows/build-js.yml"><img alt="Build" src="https://github.com/thesysdev/openui/actions/workflows/build-js.yml/badge.svg"></a>
+  <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
+  <a href="https://discord.com/invite/Pbv5PsqUSv"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Fv10%2Finvites%2FPbv5PsqUSv%3Fwith_counts%3Dtrue&query=%24.approximate_presence_count&label=Discord&suffix=%20online&logo=discord&logoColor=white&color=5865F2"></a>
+  <a href="https://www.npmjs.com/search?q=%40openuidev"><img alt="npm downloads" src="https://img.shields.io/badge/npm%20downloads-358%2C370-CB3837?logo=npm&logoColor=white"></a>
+</p>
 
 <a href="https://trendshift.io/repositories/22357" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22357" alt="thesysdev%2Fopenui | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "The open standard for generative UI — a streaming-first language, React runtime, and component libraries for building AI-powered chat and copilot interfaces",
   "main": "index.js",
   "scripts": {
+    "update:npm-downloads-badge": "node scripts/update-npm-downloads-badge.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/scripts/update-npm-downloads-badge.mjs
+++ b/scripts/update-npm-downloads-badge.mjs
@@ -1,0 +1,117 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const NPM_SCOPE = "openuidev";
+const README_PATH = resolve("README.md");
+const END_DATE = new Date().toISOString().slice(0, 10);
+const MAX_WINDOW_DAYS = 365;
+
+async function getJson(url) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`Request failed (${response.status}): ${url}`);
+  }
+
+  return response.json();
+}
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function toDateString(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+async function getScopedPackages() {
+  const searchUrl = new URL("https://registry.npmjs.org/-/v1/search");
+  searchUrl.searchParams.set("text", `@${NPM_SCOPE}`);
+  searchUrl.searchParams.set("size", "250");
+
+  const results = await getJson(searchUrl);
+
+  return results.objects
+    .map((result) => result.package.name)
+    .filter((name) => name.startsWith(`@${NPM_SCOPE}/`))
+    .sort();
+}
+
+async function getPackageCreatedDate(packageName) {
+  const metadata = await getJson(
+    `https://registry.npmjs.org/${encodeURIComponent(packageName)}`,
+  );
+
+  return metadata.time.created.slice(0, 10);
+}
+
+async function getPackageDownloads(packageName, startDate, endDate) {
+  let total = 0;
+  let currentStart = new Date(`${startDate}T00:00:00.000Z`);
+  const finalEnd = new Date(`${endDate}T00:00:00.000Z`);
+  const encodedName = encodeURIComponent(packageName);
+
+  while (currentStart <= finalEnd) {
+    const currentEnd = new Date(
+      Math.min(addDays(currentStart, MAX_WINDOW_DAYS - 1), finalEnd),
+    );
+    const range = `${toDateString(currentStart)}:${toDateString(currentEnd)}`;
+    const downloads = await getJson(
+      `https://api.npmjs.org/downloads/point/${range}/${encodedName}`,
+    );
+
+    total += downloads.downloads ?? 0;
+    currentStart = addDays(currentEnd, 1);
+  }
+
+  return total;
+}
+
+async function main() {
+  const packages = await getScopedPackages();
+
+  if (packages.length === 0) {
+    throw new Error(`No @${NPM_SCOPE} packages found on npm.`);
+  }
+
+  let totalDownloads = 0;
+
+  for (const packageName of packages) {
+    const createdDate = await getPackageCreatedDate(packageName);
+    totalDownloads += await getPackageDownloads(
+      packageName,
+      createdDate,
+      END_DATE,
+    );
+  }
+
+  const badgeUrl = `https://img.shields.io/badge/npm%20downloads-${encodeURIComponent(
+    totalDownloads.toLocaleString("en-US"),
+  )}-CB3837?logo=npm&logoColor=white`;
+  const badgeMarkdown = `[![npm downloads](${badgeUrl})](https://www.npmjs.com/search?q=%40openuidev)`;
+  const readme = await readFile(README_PATH, "utf8");
+  const markdownBadgePattern =
+    /^\[!\[npm downloads\]\(.+\)\]\(https:\/\/www\.npmjs\.com\/search\?q=%40openuidev\)$/m;
+  const htmlBadgePattern =
+    /<img alt="npm downloads" src="https:\/\/img\.shields\.io\/badge\/npm%20downloads-[^"]+">/;
+  const htmlBadge = `<img alt="npm downloads" src="${badgeUrl}">`;
+
+  if (htmlBadgePattern.test(readme)) {
+    await writeFile(README_PATH, readme.replace(htmlBadgePattern, htmlBadge));
+    return;
+  }
+
+  if (!markdownBadgePattern.test(readme)) {
+    throw new Error("Could not find npm downloads badge in README.md.");
+  }
+
+  const updatedReadme = readme.replace(markdownBadgePattern, badgeMarkdown);
+  await writeFile(README_PATH, updatedReadme);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes #528 
- Add a live Discord badge that shows the current online count from the Discord invite API.
- Add an npm downloads badge showing cumulative downloads across `@openuidev/*` packages.
- Add a scheduled/manual GitHub Action to refresh the npm downloads badge in `README.md`.
- Center the README badge row with explicit HTML for more reliable rendering.

