### PR TITLE
docs: refresh package readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Try it yourself in the [Playground](https://www.openui.com/playground): generate
 | [`@openuidev/react-headless`](./packages/react-headless) | Headless chat state, streaming adapters, message format converters |
 | [`@openuidev/react-ui`](./packages/react-ui) | Prebuilt chat layouts and two built-in component libraries |
 | [`@openuidev/cli`](./packages/openui-cli) | CLI for scaffolding apps and generating system prompts |
+| [`@openuidev/openclaw-os-plugin`](https://github.com/thesysdev/openclaw-os/tree/main/packages/claw-plugin) | OpenClaw OS plugin for serving OpenUI-powered OpenClaw workspaces |
 
 ```bash
 npm install @openuidev/react-lang @openuidev/react-ui

--- a/packages/browser-bundle/README.md
+++ b/packages/browser-bundle/README.md
@@ -1,8 +1,10 @@
 # @openuidev/browser-bundle
 
-Prebuilt IIFE browser bundle of [`@openuidev/react-lang`](../react-lang) + [`@openuidev/react-ui`](../react-ui) plus all their runtime dependencies (React, ReactDOM, Radix, Recharts, date-fns, react-markdown, etc.) in a single file, plus a combined stylesheet.
+Prebuilt browser bundle for OpenUI's React renderer and UI library. It packages `@openuidev/react-lang`, `@openuidev/react-ui`, React, ReactDOM, and runtime dependencies into one script plus one stylesheet.
 
 Intended for **iframe, CDN, and no-build-pipeline** contexts where ESM/CJS module resolution isn't available and you just want a `<script>` tag that gives you the OpenUI renderer and component library.
+
+**Links:** [OpenUI docs](https://openui.com/docs) | [GitHub repo](https://github.com/thesysdev/openui)
 
 Example consumers:
 
@@ -14,7 +16,7 @@ For any build-pipeline project, use `@openuidev/react-lang` and `@openuidev/reac
 
 ## Install
 
-You almost certainly want to use the CDN — that's the point of this package. jsDelivr and unpkg both auto-publish from npm:
+You almost certainly want to use the CDN. jsDelivr and unpkg both auto-publish from npm:
 
 ```html
 <link
@@ -57,8 +59,8 @@ This shape is a **stable public contract**. Any change to the keys or their expo
 
 ## Size
 
-- `openui-bundle.min.js` — ~2.2 MB raw / ~650 KB gzipped
-- `openui-styles.css` — ~150 KB raw
+- `openui-bundle.min.js`: ~2.2 MB raw / ~650 KB gzipped
+- `openui-styles.css`: ~150 KB raw
 
 All dependencies are inlined; there are no runtime fetches beyond the two files above.
 
@@ -70,3 +72,9 @@ pnpm --filter @openuidev/browser-bundle build
 ```
 
 This produces `dist/openui-bundle.min.js` and `dist/openui-styles.css`.
+
+## Documentation
+
+- [OpenUI docs](https://openui.com/docs)
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/browser-bundle)

--- a/packages/lang-core/README.md
+++ b/packages/lang-core/README.md
@@ -1,9 +1,11 @@
 # @openuidev/lang-core
 
-Framework-agnostic core for [OpenUI Lang](https://openui.com): parser, prompt generation, runtime evaluator, and type definitions.
+Framework-agnostic core for OpenUI Lang. This is the parser, prompt-generation, runtime-evaluation, and type layer used by the framework packages.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/lang-core)](https://www.npmjs.com/package/@openuidev/lang-core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [OpenUI Lang docs](https://openui.com/docs/openui-lang) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -15,7 +17,7 @@ pnpm add @openuidev/lang-core
 
 ## What this package does
 
-`@openuidev/lang-core` is the framework-agnostic foundation that powers OpenUI Lang. It has no React or other framework dependencies. Use it when you need to:
+`@openuidev/lang-core` has no React, Vue, or Svelte dependency. Use it when you need to:
 
 - **Parse** OpenUI Lang text into a typed element tree (one-shot or streaming)
 - **Generate system prompts** from a component spec + tool definitions
@@ -131,7 +133,9 @@ import type {
 
 ## Documentation
 
-Full documentation, guides, and the language specification are available at **[openui.com](https://openui.com)**.
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Language specification](https://openui.com/docs/openui-lang/specification-v05)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/lang-core)
 
 ## License
 

--- a/packages/openui-cli/README.md
+++ b/packages/openui-cli/README.md
@@ -1,9 +1,11 @@
 # @openuidev/cli
 
-Command-line tool for [OpenUI](https://openui.com) — scaffold AI-powered generative UI chat apps and generate LLM system prompts from your React component libraries.
+Command-line tools for starting OpenUI projects and generating model instructions from component libraries.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/cli)](https://www.npmjs.com/package/@openuidev/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [CLI docs](https://openui.com/docs/api-reference/cli) | [GitHub repo](https://github.com/thesysdev/openui)
 
 It currently supports two workflows:
 
@@ -159,7 +161,9 @@ node dist/index.js generate --help
 
 ## Documentation
 
-Full documentation and guides are available at **[openui.com](https://openui.com)**.
+- [CLI API reference](https://openui.com/docs/api-reference/cli)
+- [Chat quick start](https://openui.com/docs/chat/quick-start)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/openui-cli)
 
 ## License
 

--- a/packages/react-email/README.md
+++ b/packages/react-email/README.md
@@ -1,10 +1,12 @@
 # @openuidev/react-email
 
-React Email components for [OpenUI](https://openui.com) — API reference for the pre-built email templates library and prompt options, ready for LLM-driven email generation.
+React Email component definitions for OpenUI Lang. Use this package when a model should generate email layouts that can be previewed, rendered, and converted to HTML.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/react-email)](https://www.npmjs.com/package/@openuidev/react-email)
 [![npm downloads](https://img.shields.io/npm/dm/@openuidev/react-email)](https://www.npmjs.com/package/@openuidev/react-email)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [Package docs](https://openui.com/docs/api-reference/react-email) | [OpenUI Lang guide](https://openui.com/docs/openui-lang) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -65,7 +67,9 @@ const html = await render(
 
 ## Documentation
 
-Full documentation, guides, and the language specification are available at **[openui.com](https://openui.com)**.
+- [React Email API reference](https://openui.com/docs/api-reference/react-email)
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/react-email)
 
 ## License
 

--- a/packages/react-headless/README.md
+++ b/packages/react-headless/README.md
@@ -1,10 +1,12 @@
 # @openuidev/react-headless
 
-Headless React primitives for [OpenUI](https://openui.com) — chat state management, streaming adapters, and message format converters. Build any chat UI while OpenUI handles the streaming, threading, and state.
+Headless React state and streaming primitives for OpenUI chat experiences. Bring your own UI; this package handles threads, messages, adapters, and message format conversion.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/react-headless)](https://www.npmjs.com/package/@openuidev/react-headless)
 [![npm downloads](https://img.shields.io/npm/dm/@openuidev/react-headless)](https://www.npmjs.com/package/@openuidev/react-headless)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [Package docs](https://openui.com/docs/api-reference/react-headless) | [Chat docs](https://openui.com/docs/chat) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -18,18 +20,18 @@ pnpm add @openuidev/react-headless
 
 ## Overview
 
-`@openuidev/react-headless` gives you everything needed to build a chat experience without imposing any UI. It provides:
+Use `@openuidev/react-headless` when you want OpenUI's chat behavior without OpenUI's visual components:
 
-- **`ChatProvider`** — A React context provider that manages threads, messages, and streaming state via a Zustand store.
-- **Selector hooks** — `useThread()` and `useThreadList()` to read and interact with chat state.
-- **Streaming adapters** — Parse SSE or SDK responses from OpenAI, AG-UI, or custom backends.
-- **Message formats** — Convert between your API's message format and the internal AG-UI format.
+- **`ChatProvider`** manages threads, messages, and streaming state through a Zustand store.
+- **Selector hooks** expose thread and thread-list state without coupling you to a layout.
+- **Streaming adapters** parse SSE or SDK responses from OpenAI, AG-UI, or custom backends.
+- **Message formats** convert between your API shape and OpenUI's internal AG-UI shape.
 
 ## Quick Start
 
 ### URL-based setup
 
-The simplest configuration — point to your API and the provider handles REST calls and streaming automatically:
+The simplest configuration points to your API and lets the provider handle REST calls and streaming automatically:
 
 ```tsx
 import { ChatProvider } from "@openuidev/react-headless";
@@ -185,7 +187,7 @@ import { ChatProvider, openAIAdapter } from "@openuidev/react-headless";
 
 | Adapter | Description |
 | :--- | :--- |
-| `agUIAdapter` | Default — parses AG-UI SSE events (`data: {json}\n`) |
+| `agUIAdapter` | Default adapter for AG-UI SSE events (`data: {json}\n`) |
 | `openAIAdapter` | Parses OpenAI Chat Completions streaming (`ChatCompletionChunk`) |
 | `openAIResponsesAdapter` | Parses OpenAI Responses API streaming (`ResponseStreamEvent`) |
 | `openAIReadableStreamAdapter` | Parses OpenAI SDK's `Stream.toReadableStream()` NDJSON output |
@@ -218,7 +220,7 @@ import { ChatProvider, openAIMessageFormat } from "@openuidev/react-headless";
 
 | Format | Description |
 | :--- | :--- |
-| `identityMessageFormat` | Default — no conversion (messages are already AG-UI format) |
+| `identityMessageFormat` | Default format when messages are already AG-UI shaped |
 | `openAIMessageFormat` | Converts to/from OpenAI `ChatCompletionMessageParam[]` |
 | `openAIConversationMessageFormat` | Converts to/from OpenAI Responses API `ResponseInputItem[]` |
 
@@ -263,7 +265,9 @@ import type {
 
 ## Documentation
 
-Full documentation and guides are available at **[openui.com](https://openui.com)**.
+- [React Headless API reference](https://openui.com/docs/api-reference/react-headless)
+- [Chat guides](https://openui.com/docs/chat)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/react-headless)
 
 ## License
 

--- a/packages/react-lang/README.md
+++ b/packages/react-lang/README.md
@@ -1,10 +1,12 @@
 # @openuidev/react-lang
 
-Core runtime for [OpenUI](https://openui.com) — define component libraries, generate model prompts, and render structured UI from streaming LLM output.
+React bindings for OpenUI Lang. Use this package when your model needs to emit structured UI and your React app needs to render it while the response is still streaming.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/react-lang)](https://www.npmjs.com/package/@openuidev/react-lang)
 [![npm downloads](https://img.shields.io/npm/dm/@openuidev/react-lang)](https://www.npmjs.com/package/@openuidev/react-lang)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [Package docs](https://openui.com/docs/api-reference/react-lang) | [OpenUI Lang guide](https://openui.com/docs/openui-lang) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -18,11 +20,11 @@ pnpm add @openuidev/react-lang
 
 ## Overview
 
-`@openuidev/react-lang` provides three core capabilities:
+`@openuidev/react-lang` is the React runtime layer for OpenUI Lang. It covers the loop most apps need:
 
-1. **Define components** — Use `defineComponent` and `createLibrary` to declare what the model is allowed to generate, with typed props via Zod schemas.
-2. **Generate prompts** — Call `library.prompt()` to produce a system prompt that instructs the model how to emit OpenUI Lang output.
-3. **Render output** — Use `<Renderer>` to parse and progressively render streamed OpenUI Lang into React components.
+1. **Define components** that a model is allowed to use, with Zod schemas for props.
+2. **Generate prompts** from that component library so the model knows the exact output language.
+3. **Render streamed output** with `<Renderer>` as OpenUI Lang arrives from your backend.
 
 ## Quick Start
 
@@ -139,7 +141,7 @@ After the stream ends, check `meta.unresolved` for any identifiers that were ref
 | `unknown-component` | Component name not found in the library schema |
 | `excess-args` | More positional args passed than the schema defines |
 
-Errors do not affect rendering — the parser stays permissive and renders what it can. Use `code` to decide how to surface or log errors:
+Errors do not affect rendering. The parser stays permissive and renders what it can. Use `code` to decide how to surface or log errors:
 
 ```ts
 const result = parser.parse(output);
@@ -212,7 +214,9 @@ const schema = library.toJSONSchema();
 
 ## Documentation
 
-Full documentation, guides, and the language specification are available at **[openui.com](https://openui.com)**.
+- [React API reference](https://openui.com/docs/api-reference/react-lang)
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/react-lang)
 
 ## License
 

--- a/packages/react-ui/README.md
+++ b/packages/react-ui/README.md
@@ -1,10 +1,12 @@
 # @openuidev/react-ui
 
-React UI components, chat layouts, and component libraries for [OpenUI](https://openui.com). Drop-in chat surfaces with theming, or use individual components in your own layout.
+React components and chat layouts for OpenUI. Use the ready-made chat surfaces, the built-in model-renderable component library, or the individual UI primitives in your own layout.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/react-ui)](https://www.npmjs.com/package/@openuidev/react-ui)
 [![npm downloads](https://img.shields.io/npm/dm/@openuidev/react-ui)](https://www.npmjs.com/package/@openuidev/react-ui)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [Package docs](https://openui.com/docs/api-reference/react-ui) | [Chat docs](https://openui.com/docs/chat) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -26,9 +28,9 @@ import "@openuidev/react-ui/components.css";
 
 This package provides three layers:
 
-1. **Chat layouts** — Ready-to-use chat surfaces (`FullScreen`, `Copilot`, `BottomTray`) that wire up the provider, streaming, and rendering automatically.
-2. **Component library** — A built-in set of UI components (charts, tables, forms, cards, etc.) that models can generate via OpenUI Lang.
-3. **Individual components** — Use `Button`, `Card`, `Table`, `Charts`, and 30+ components directly in your own UI.
+1. **Chat layouts** for full-screen chat, copilots, and bottom-tray experiences.
+2. **Model-renderable components** for charts, tables, forms, cards, and other OpenUI Lang output.
+3. **Standalone UI primitives** such as `Button`, `Card`, `Table`, `Charts`, and the chat shell pieces.
 
 ## Quick Start
 
@@ -79,7 +81,7 @@ The package ships with two preconfigured OpenUI Lang libraries:
 
 | Export | Description |
 | :--- | :--- |
-| `openuiLibrary` | Full component library — charts, tables, forms, cards, images, and more |
+| `openuiLibrary` | Full component library for charts, tables, forms, cards, images, and more |
 | `openuiChatLibrary` | Chat-optimized subset with follow-ups, steps, and callouts |
 
 Use them directly when building custom chat experiences:
@@ -175,7 +177,9 @@ import { Charts } from "@openuidev/react-ui/Charts";
 
 ## Documentation
 
-Full documentation, component guides, and live examples are available at **[openui.com](https://openui.com)**.
+- [React UI API reference](https://openui.com/docs/api-reference/react-ui)
+- [Chat guides](https://openui.com/docs/chat)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/react-ui)
 
 
 ## License

--- a/packages/svelte-lang/README.md
+++ b/packages/svelte-lang/README.md
@@ -1,8 +1,10 @@
 # @openuidev/svelte-lang
 
-Svelte 5 runtime for [OpenUI](https://openui.com) — define component libraries, generate model prompts, and render structured UI from streaming LLM output.
+Svelte 5 bindings for OpenUI Lang. Define model-renderable Svelte components, generate prompts from those definitions, and render streamed OpenUI Lang in a Svelte app.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [OpenUI Lang docs](https://openui.com/docs/openui-lang) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -16,11 +18,11 @@ pnpm add @openuidev/svelte-lang
 
 ## Overview
 
-`@openuidev/svelte-lang` provides three core capabilities:
+`@openuidev/svelte-lang` brings the OpenUI Lang runtime to Svelte:
 
-1. **Define components** — Use `defineComponent` and `createLibrary` to declare what the model is allowed to generate, with typed props via Zod schemas.
-2. **Generate prompts** — Call `library.prompt()` to produce a system prompt that instructs the model how to emit OpenUI Lang output.
-3. **Render output** — Use `<Renderer>` to parse and progressively render streamed OpenUI Lang into Svelte components.
+1. **Define Svelte components** that a model is allowed to call, with Zod schemas for props.
+2. **Generate prompts** from the component library.
+3. **Render streamed output** with `<Renderer>` as OpenUI Lang arrives.
 
 ## Quick Start
 
@@ -166,7 +168,7 @@ After the stream ends, check `meta.unresolved` for any identifiers that were ref
 | `unknown-component` | Component name not found in the library schema      |
 | `excess-args`       | More positional args passed than the schema defines |
 
-Errors do not affect rendering — the parser stays permissive and renders what it can:
+Errors do not affect rendering. The parser stays permissive and renders what it can:
 
 ```ts
 const result = parser.parse(output);
@@ -180,7 +182,7 @@ Use these inside component renderers to interact with the rendering context:
 | Function                   | Returns               | Description                                                                    |
 | :------------------------- | :-------------------- | :----------------------------------------------------------------------------- |
 | `getOpenUIContext()`       | `OpenUIContextValue`  | Access the full context object (library, streaming state, field accessors)     |
-| `getIsStreaming()`         | `() => boolean`       | Returns a getter for the streaming state — call it reactively: `isStreaming()` |
+| `getIsStreaming()`         | `() => boolean`       | Returns a getter for the streaming state. Call it reactively: `isStreaming()` |
 | `getTriggerAction()`       | `Function`            | Trigger an action event                                                        |
 | `getGetFieldValue()`       | `Function`            | Get a form field's current value                                               |
 | `getSetFieldValue()`       | `Function`            | Set a form field's value                                                       |
@@ -251,7 +253,9 @@ const schema = library.toJSONSchema();
 
 ## Documentation
 
-Full documentation, guides, and the language specification are available at **[openui.com](https://openui.com)**.
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Language specification](https://openui.com/docs/openui-lang/specification-v05)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/svelte-lang)
 
 ## License
 

--- a/packages/vue-lang/README.md
+++ b/packages/vue-lang/README.md
@@ -1,10 +1,12 @@
 # @openuidev/vue-lang
 
-Core runtime for [OpenUI](https://openui.com) in Vue 3 — define component libraries, generate model prompts, and render structured UI from streaming LLM output.
+Vue 3 bindings for OpenUI Lang. Define model-renderable Vue components, generate prompts from those definitions, and render streamed OpenUI Lang in a Vue app.
 
 [![npm](https://img.shields.io/npm/v/@openuidev/vue-lang)](https://www.npmjs.com/package/@openuidev/vue-lang)
 [![npm downloads](https://img.shields.io/npm/dm/@openuidev/vue-lang)](https://www.npmjs.com/package/@openuidev/vue-lang)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/thesysdev/openui/blob/main/LICENSE)
+
+**Links:** [OpenUI Lang docs](https://openui.com/docs/openui-lang) | [GitHub repo](https://github.com/thesysdev/openui)
 
 ## Install
 
@@ -18,11 +20,11 @@ pnpm add @openuidev/vue-lang
 
 ## Overview
 
-`@openuidev/vue-lang` provides three core capabilities:
+`@openuidev/vue-lang` brings the OpenUI Lang runtime to Vue:
 
-1. **Define components** — Use `defineComponent` and `createLibrary` to declare what the model is allowed to generate, with typed props via Zod schemas.
-2. **Generate prompts** — Call `library.prompt()` to produce a system prompt that instructs the model how to emit OpenUI Lang output.
-3. **Render output** — Use `<Renderer>` to parse and progressively render streamed OpenUI Lang into Vue components.
+1. **Define Vue components** that a model is allowed to call, with Zod schemas for props.
+2. **Generate prompts** from the component library.
+3. **Render streamed output** with `<Renderer>` as OpenUI Lang arrives.
 
 ## Quick Start
 
@@ -129,7 +131,7 @@ import { Renderer } from "@openuidev/vue-lang";
 | `unknown-component` | Component name not found in the library schema      |
 | `excess-args`       | More positional args passed than the schema defines |
 
-Errors do not affect rendering — the parser stays permissive and renders what it can. Use `code` to decide how to surface or log errors:
+Errors do not affect rendering. The parser stays permissive and renders what it can. Use `code` to decide how to surface or log errors:
 
 ```ts
 const result = parser.parse(output);
@@ -200,7 +202,9 @@ const schema = library.toJSONSchema();
 
 ## Documentation
 
-Full documentation, guides, and the language specification are available at **[openui.com](https://openui.com)**.
+- [OpenUI Lang guide](https://openui.com/docs/openui-lang)
+- [Language specification](https://openui.com/docs/openui-lang/specification-v05)
+- [Source on GitHub](https://github.com/thesysdev/openui/tree/main/packages/vue-lang)
 
 ## License
 


### PR DESCRIPTION
Fixes #529 

## Summary

- Refreshes the package-level README copy across `packages/*`.
- Adds links to relevant OpenUI docs pages and GitHub source locations.
- Adds the OpenClaw OS plugin as an external package link in the top-level package table.



