### PR TITLE
docs: add Standard Metrics contact to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,9 +14,9 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 
 ## OpenUI Adopters
 
-| Organization | Contact | Description of Use |
-| :--- | :--- | :--- |
-| [Standard Metrics](https://standardmetrics.io/) | - | Standard Metrics combines institutional-grade infrastructure with cutting-edge AI to transform portfolio management |
+| Organization                                    | Contact                                       | Description of Use                                                                                                  |
+| :---------------------------------------------- | :-------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
+| [Standard Metrics](https://standardmetrics.io/) | [Elias Tounzal](https://github.com/eliasinho) | Standard Metrics combines institutional-grade infrastructure with cutting-edge AI to transform portfolio management |
 
 <!--
 Example row, copy and edit:


### PR DESCRIPTION
## Summary
- Add Elias Tounzal as the contact for Standard Metrics in `ADOPTERS.md`
- Align the adopters table column formatting for readability

## Test plan
- [x] Verified markdown table renders correctly
- [x] Confirmed GitHub profile link for contact is valid


Made with [Cursor](https://cursor.com)