### PR TITLE
Add openui-forge to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,6 +17,7 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 | Organization                                    | Contact                                       | Description of Use                                                                                                  |
 | :---------------------------------------------- | :-------------------------------------------- | :------------------------------------------------------------------------------------------------------------------ |
 | [Standard Metrics](https://standardmetrics.io/) | [Elias Tounzal](https://github.com/eliasinho) | Standard Metrics combines institutional-grade infrastructure with cutting-edge AI to transform portfolio management |
+| [openui-forge](https://github.com/OthmanAdi/openui-forge) | [@OthmanAdi](https://github.com/OthmanAdi)   | Cross-IDE agent skill for OpenUI. Templates for OpenAI, Anthropic, LangChain, Vercel AI SDK, plus FastAPI / Go / Rust backends. Mirrors to 11 agent platforms.                  |
 
 <!--
 Example row, copy and edit:


### PR DESCRIPTION
Adding openui-forge as a community adopter of OpenUI.

What it is: a cross-IDE agent skill that targets areas the canonical scaffold does not cover.

- Adds OpenUI to existing projects (the CLI is create-only)
- Ships non-JS backend templates for Python (FastAPI), Go (net/http), and Rust (Axum)
- Wires up any LLM provider directly: OpenAI, Anthropic, LangChain, Vercel AI SDK
- Routes via OPENAI_BASE_URL for any OpenAI-compatible endpoint (Gemini, OpenRouter, xAI, DeepSeek)
- Mirrors skill content to 11 agent platforms beyond Claude Code (Cursor, Gemini CLI, Codex, Kiro, Continue, Factory, OpenCode, Pi, Mastra, CodeBuddy)

Repo: https://github.com/OthmanAdi/openui-forge
Landing page: https://spruce-prism-8yya.here.now/
skills.sh: https://skills.sh/OthmanAdi/openui-forge