### PR TITLE
Show hosted demo credits popup

### DIFF
--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -1,7 +1,3 @@
-import {
-  createDemoCreditsErrorPayload,
-  isDemoCreditsExhaustedError,
-} from "@/lib/demo-credits";
 import { readFileSync } from "fs";
 import { NextRequest } from "next/server";
 import OpenAI from "openai";
@@ -375,6 +371,9 @@ export async function POST(req: NextRequest) {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       runner.on("chunk", (chunk: any) => {
+        // Keep credit handling to non-2xx responses. Provider-specific mid-stream
+        // chunks are intentionally ignored because they are harder to maintain
+        // across OpenRouter/OpenAI streaming shape changes.
         const choice = chunk.choices?.[0];
         const delta = choice?.delta;
         if (!delta) return;
@@ -388,6 +387,8 @@ export async function POST(req: NextRequest) {
       });
 
       runner.on("end", () => {
+        if (controllerClosed) return;
+
         conversationLog.push({ role: "assistant", content: fullResponse });
         console.info(
           "[OpenUI Lang] Conversation:\n",
@@ -403,15 +404,7 @@ export async function POST(req: NextRequest) {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       runner.on("error", (err: any) => {
-        if (isDemoCreditsExhaustedError(err)) {
-          enqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ error: createDemoCreditsErrorPayload() })}\n\n`,
-            ),
-          );
-          close();
-          return;
-        }
+        if (controllerClosed) return;
 
         const msg = err instanceof Error ? err.message : "Stream error";
         console.error("Chat route error:", msg);

--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -1,3 +1,7 @@
+import {
+  createDemoCreditsErrorPayload,
+  isDemoCreditsExhaustedError,
+} from "@/lib/demo-credits";
 import { readFileSync } from "fs";
 import { NextRequest } from "next/server";
 import OpenAI from "openai";
@@ -280,8 +284,16 @@ export async function POST(req: NextRequest) {
   const lastUserMsg = (messages as any[]).filter((m: any) => m.role === "user").pop();
   if (lastUserMsg) conversationLog.push({ role: "user", content: extractText(lastUserMsg) });
 
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return Response.json(
+      { error: { message: "OPENROUTER_API_KEY not configured" } },
+      { status: 500 },
+    );
+  }
+
   const client = new OpenAI({
-    apiKey: process.env.OPENROUTER_API_KEY,
+    apiKey,
     baseURL: "https://openrouter.ai/api/v1",
   });
   const MODEL = "openai/gpt-5.4";
@@ -391,6 +403,16 @@ export async function POST(req: NextRequest) {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       runner.on("error", (err: any) => {
+        if (isDemoCreditsExhaustedError(err)) {
+          enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ error: createDemoCreditsErrorPayload() })}\n\n`,
+            ),
+          );
+          close();
+          return;
+        }
+
         const msg = err instanceof Error ? err.message : "Stream error";
         console.error("Chat route error:", msg);
         enqueue(encoder.encode(`data: ${JSON.stringify({ error: msg })}\n\n`));

--- a/docs/app/api/demo/github/stream/route.ts
+++ b/docs/app/api/demo/github/stream/route.ts
@@ -1,4 +1,8 @@
 import { BASE_URL } from "@/lib/source";
+import {
+  createDemoCreditsExhaustedResponse,
+  isDemoCreditsExhaustedError,
+} from "@/lib/demo-credits";
 import { generatePrompt, type PromptSpec } from "@openuidev/lang-core";
 import { readFileSync } from "fs";
 import { type NextRequest } from "next/server";
@@ -82,6 +86,10 @@ export async function POST(req: NextRequest) {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    if (isDemoCreditsExhaustedError(err, res.status)) {
+      return createDemoCreditsExhaustedResponse();
+    }
+
     return Response.json(
       {
         error: (err as { error?: { message?: string } }).error ?? {

--- a/docs/app/api/demo/github/stream/route.ts
+++ b/docs/app/api/demo/github/stream/route.ts
@@ -1,8 +1,8 @@
-import { BASE_URL } from "@/lib/source";
 import {
   createDemoCreditsExhaustedResponse,
   isDemoCreditsExhaustedError,
 } from "@/lib/demo-credits";
+import { BASE_URL } from "@/lib/source";
 import { generatePrompt, type PromptSpec } from "@openuidev/lang-core";
 import { readFileSync } from "fs";
 import { type NextRequest } from "next/server";
@@ -100,6 +100,9 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Keep credit handling to provider 4xx responses. Provider-specific mid-stream
+  // error chunks are intentionally passed through because they are harder to
+  // maintain across OpenRouter/OpenAI streaming shape changes.
   return new Response(res.body, {
     headers: {
       "Content-Type": "text/event-stream",

--- a/docs/app/api/playground/stream/route.ts
+++ b/docs/app/api/playground/stream/route.ts
@@ -1,8 +1,8 @@
-import { BASE_URL } from "@/lib/source";
 import {
   createDemoCreditsExhaustedResponse,
   isDemoCreditsExhaustedError,
 } from "@/lib/demo-credits";
+import { BASE_URL } from "@/lib/source";
 import { readFileSync } from "fs";
 import { type NextRequest } from "next/server";
 import { join } from "path";
@@ -54,6 +54,9 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  // Keep credit handling to provider 4xx responses. Provider-specific mid-stream
+  // error chunks are intentionally passed through because they are harder to
+  // maintain across OpenRouter/OpenAI streaming shape changes.
   const [streamForClient, streamForLog] = res.body!.tee();
 
   const reader = streamForLog.getReader();

--- a/docs/app/api/playground/stream/route.ts
+++ b/docs/app/api/playground/stream/route.ts
@@ -1,4 +1,8 @@
 import { BASE_URL } from "@/lib/source";
+import {
+  createDemoCreditsExhaustedResponse,
+  isDemoCreditsExhaustedError,
+} from "@/lib/demo-credits";
 import { readFileSync } from "fs";
 import { type NextRequest } from "next/server";
 import { join } from "path";
@@ -36,6 +40,10 @@ export async function POST(req: NextRequest) {
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    if (isDemoCreditsExhaustedError(err, res.status)) {
+      return createDemoCreditsExhaustedResponse();
+    }
+
     return Response.json(
       {
         error: (err as { error?: { message?: string } }).error ?? {

--- a/docs/app/demo/github/constants.ts
+++ b/docs/app/demo/github/constants.ts
@@ -1,6 +1,12 @@
 export type Theme = "system" | "light" | "dark";
 export type Status = "idle" | "streaming" | "done" | "error";
 
+export const STREAM_RESULT = {
+  Done: "done",
+  CreditsExhausted: "credits-exhausted",
+} as const;
+export type StreamResult = (typeof STREAM_RESULT)[keyof typeof STREAM_RESULT];
+
 export const GITHUB_DEMO_MODEL = "anthropic/claude-sonnet-4-6";
 export const GITHUB_DEMO_MODEL_LABEL = "Claude Sonnet 4.6";
 

--- a/docs/app/demo/github/page.tsx
+++ b/docs/app/demo/github/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { mergeStatements } from "@openuidev/react-lang";
 import { Button } from "@openuidev/react-ui";
 import { encode } from "gpt-tokenizer";
@@ -18,8 +20,6 @@ import {
 import { useTheme } from "next-themes";
 import { Highlight, themes } from "prism-react-renderer";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
-import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { ConversationPanel } from "./components/ConversationPanel/ConversationPanel";
 import { GitHubConnect } from "./components/GitHubConnect/GitHubConnect";
 import { Header } from "./components/Header/Header";
@@ -179,20 +179,24 @@ async function streamChat(
         onDone();
         return STREAM_RESULT.Done;
       }
+      let parsed: {
+        error?: unknown;
+        choices?: Array<{ delta?: { content?: string }; finish_reason?: string }>;
+      };
       try {
-        const parsed = JSON.parse(data) as {
-          choices: Array<{ delta: { content?: string } }>;
-        };
-        const content = parsed.choices[0]?.delta?.content;
-        if (content) {
-          if (!firstChunkFired) {
-            firstChunkFired = true;
-            onFirstChunk?.();
-          }
-          onChunk(content);
-        }
+        parsed = JSON.parse(data);
       } catch {
         // skip malformed chunks
+        continue;
+      }
+
+      const content = parsed.choices?.[0]?.delta?.content;
+      if (content) {
+        if (!firstChunkFired) {
+          firstChunkFired = true;
+          onFirstChunk?.();
+        }
+        onChunk(content);
       }
     }
   }
@@ -231,7 +235,7 @@ export default function GitHubDemoPage() {
   const [startTime, setStartTime] = useState<number | null>(null);
   const [elapsed, setElapsed] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState("");
-  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
+  const [showGitHubCreditsDialog, setShowGitHubCreditsDialog] = useState(false);
 
   const abortRef = useRef<AbortController | null>(null);
   const responseRef = useRef("");
@@ -308,7 +312,7 @@ export default function GitHubDemoPage() {
     setShowSource(false);
     setParsedJson(null);
     setErrorMsg("");
-    setShowCreditsDialog(false);
+    setShowGitHubCreditsDialog(false);
   };
 
   // ── Send message ─────────────────────────────────────────────────────
@@ -322,7 +326,7 @@ export default function GitHubDemoPage() {
       setStartTime(null);
       setElapsed(null);
       setErrorMsg("");
-      setShowCreditsDialog(false);
+      setShowGitHubCreditsDialog(false);
       responseRef.current = "";
       setStreamingText("");
       setToolCalls([]);
@@ -420,7 +424,7 @@ export default function GitHubDemoPage() {
           abortRef.current = null;
           setStatus("idle");
           setStreamResponseHasCode(false);
-          setShowCreditsDialog(true);
+          setShowGitHubCreditsDialog(true);
         }
       } catch (err: unknown) {
         if (err instanceof Error && err.name === "AbortError") {
@@ -727,8 +731,8 @@ export default function GitHubDemoPage() {
       {/* Error banner */}
       {status === "error" && errorMsg && <div className="error-banner">{errorMsg}</div>}
       <DemoCreditsDialog
-        open={showCreditsDialog}
-        onClose={() => setShowCreditsDialog(false)}
+        open={showGitHubCreditsDialog}
+        onClose={() => setShowGitHubCreditsDialog(false)}
       />
     </div>
   );

--- a/docs/app/demo/github/page.tsx
+++ b/docs/app/demo/github/page.tsx
@@ -18,6 +18,8 @@ import {
 import { useTheme } from "next-themes";
 import { Highlight, themes } from "prism-react-renderer";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { ConversationPanel } from "./components/ConversationPanel/ConversationPanel";
 import { GitHubConnect } from "./components/GitHubConnect/GitHubConnect";
 import { Header } from "./components/Header/Header";
@@ -137,7 +139,7 @@ async function streamChat(
   onDone: () => void,
   signal?: AbortSignal,
   onFirstChunk?: () => void,
-) {
+): Promise<"done" | "credits-exhausted"> {
   const res = await fetch("/api/demo/github/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -147,11 +149,15 @@ async function streamChat(
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
+    if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
+      return "credits-exhausted";
+    }
+
     onChunk(
       `Error: ${(err as { error?: { message?: string } }).error?.message ?? `Server error ${res.status}`}`,
     );
     onDone();
-    return;
+    return "done";
   }
 
   const reader = res.body!.getReader();
@@ -169,7 +175,7 @@ async function streamChat(
       const data = trimmed.slice(5).trim();
       if (data === "[DONE]") {
         onDone();
-        return;
+        return "done";
       }
       try {
         const parsed = JSON.parse(data) as {
@@ -189,6 +195,7 @@ async function streamChat(
     }
   }
   onDone();
+  return "done";
 }
 
 // ── Main Page ────────────────────────────────────────────────────────────
@@ -222,6 +229,7 @@ export default function GitHubDemoPage() {
   const [startTime, setStartTime] = useState<number | null>(null);
   const [elapsed, setElapsed] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState("");
+  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
 
   const abortRef = useRef<AbortController | null>(null);
   const responseRef = useRef("");
@@ -298,6 +306,7 @@ export default function GitHubDemoPage() {
     setShowSource(false);
     setParsedJson(null);
     setErrorMsg("");
+    setShowCreditsDialog(false);
   };
 
   // ── Send message ─────────────────────────────────────────────────────
@@ -311,6 +320,7 @@ export default function GitHubDemoPage() {
       setStartTime(null);
       setElapsed(null);
       setErrorMsg("");
+      setShowCreditsDialog(false);
       responseRef.current = "";
       setStreamingText("");
       setToolCalls([]);
@@ -353,7 +363,7 @@ export default function GitHubDemoPage() {
       abortRef.current = controller;
 
       try {
-        await streamChat(
+        const streamResult = await streamChat(
           {
             prompt: githubContext ? `${githubContext}\n\n${trimmed}` : trimmed,
             messages: apiMessages.slice(0, -1),
@@ -403,6 +413,13 @@ export default function GitHubDemoPage() {
             setStartTime(streamStartTime);
           },
         );
+
+        if (streamResult === "credits-exhausted") {
+          abortRef.current = null;
+          setStatus("idle");
+          setStreamResponseHasCode(false);
+          setShowCreditsDialog(true);
+        }
       } catch (err: unknown) {
         if (err instanceof Error && err.name === "AbortError") {
           setStreamResponseHasCode(false);
@@ -707,6 +724,10 @@ export default function GitHubDemoPage() {
 
       {/* Error banner */}
       {status === "error" && errorMsg && <div className="error-banner">{errorMsg}</div>}
+      <DemoCreditsDialog
+        open={showCreditsDialog}
+        onClose={() => setShowCreditsDialog(false)}
+      />
     </div>
   );
 }

--- a/docs/app/demo/github/page.tsx
+++ b/docs/app/demo/github/page.tsx
@@ -27,9 +27,11 @@ import { PreviewPanel } from "./components/PreviewPanel/PreviewPanel";
 import {
   GITHUB_DEMO_MODEL_LABEL,
   GITHUB_STARTERS,
+  STREAM_RESULT,
   type ChatMessage,
   type GitHubStarterIconKey,
   type Status,
+  type StreamResult,
   type Theme,
   type ToolCallEntry,
 } from "./constants";
@@ -139,7 +141,7 @@ async function streamChat(
   onDone: () => void,
   signal?: AbortSignal,
   onFirstChunk?: () => void,
-): Promise<"done" | "credits-exhausted"> {
+): Promise<StreamResult> {
   const res = await fetch("/api/demo/github/stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -150,14 +152,14 @@ async function streamChat(
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
-      return "credits-exhausted";
+      return STREAM_RESULT.CreditsExhausted;
     }
 
     onChunk(
       `Error: ${(err as { error?: { message?: string } }).error?.message ?? `Server error ${res.status}`}`,
     );
     onDone();
-    return "done";
+    return STREAM_RESULT.Done;
   }
 
   const reader = res.body!.getReader();
@@ -175,7 +177,7 @@ async function streamChat(
       const data = trimmed.slice(5).trim();
       if (data === "[DONE]") {
         onDone();
-        return "done";
+        return STREAM_RESULT.Done;
       }
       try {
         const parsed = JSON.parse(data) as {
@@ -195,7 +197,7 @@ async function streamChat(
     }
   }
   onDone();
-  return "done";
+  return STREAM_RESULT.Done;
 }
 
 // ── Main Page ────────────────────────────────────────────────────────────
@@ -414,7 +416,7 @@ export default function GitHubDemoPage() {
           },
         );
 
-        if (streamResult === "credits-exhausted") {
+        if (streamResult === STREAM_RESULT.CreditsExhausted) {
           abortRef.current = null;
           setStatus("idle");
           setStreamResponseHasCode(false);

--- a/docs/app/playground/page.tsx
+++ b/docs/app/playground/page.tsx
@@ -3,6 +3,8 @@
 import { Send, Square } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useRef, useState } from "react";
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { CodePanel } from "./components/CodePanel/CodePanel";
 import { Header } from "./components/Header/Header";
 import { PreviewPanel } from "./components/PreviewPanel/PreviewPanel";
@@ -16,6 +18,7 @@ export default function PlaygroundPage() {
   const [parsedJson, setParsedJson] = useState<string | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
+  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -48,6 +51,7 @@ export default function PlaygroundPage() {
     setCode("");
     setParsedJson(null);
     setErrorMsg("");
+    setShowCreditsDialog(false);
     setStatus("streaming");
 
     try {
@@ -60,6 +64,12 @@ export default function PlaygroundPage() {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
+        if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
+          setShowCreditsDialog(true);
+          setStatus("idle");
+          return;
+        }
+
         throw new Error(
           (err as { error?: { message?: string } }).error?.message ?? `Server error ${res.status}`,
         );
@@ -197,6 +207,10 @@ export default function PlaygroundPage() {
           </div>
         </div>
       </div>
+      <DemoCreditsDialog
+        open={showCreditsDialog}
+        onClose={() => setShowCreditsDialog(false)}
+      />
     </div>
   );
 }

--- a/docs/app/playground/page.tsx
+++ b/docs/app/playground/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { Send, Square } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useCallback, useRef, useState } from "react";
-import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
-import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 import { CodePanel } from "./components/CodePanel/CodePanel";
 import { Header } from "./components/Header/Header";
 import { PreviewPanel } from "./components/PreviewPanel/PreviewPanel";
@@ -18,7 +18,7 @@ export default function PlaygroundPage() {
   const [parsedJson, setParsedJson] = useState<string | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [errorMsg, setErrorMsg] = useState("");
-  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
+  const [showPlaygroundCreditsDialog, setShowPlaygroundCreditsDialog] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -51,7 +51,7 @@ export default function PlaygroundPage() {
     setCode("");
     setParsedJson(null);
     setErrorMsg("");
-    setShowCreditsDialog(false);
+    setShowPlaygroundCreditsDialog(false);
     setStatus("streaming");
 
     try {
@@ -65,7 +65,7 @@ export default function PlaygroundPage() {
       if (!res.ok) {
         const err = await res.json().catch(() => ({}));
         if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
-          setShowCreditsDialog(true);
+          setShowPlaygroundCreditsDialog(true);
           setStatus("idle");
           return;
         }
@@ -91,15 +91,19 @@ export default function PlaygroundPage() {
             setStatus("done");
             return;
           }
+          let parsed: {
+            error?: unknown;
+            choices?: Array<{ delta?: { content?: string }; finish_reason?: string }>;
+          };
           try {
-            const parsed = JSON.parse(data) as {
-              choices: Array<{ delta: { content?: string } }>;
-            };
-            const content = parsed.choices[0]?.delta?.content;
-            if (content) setCode((prev) => prev + content);
+            parsed = JSON.parse(data);
           } catch {
             // skip malformed chunks
+            continue;
           }
+
+          const content = parsed.choices?.[0]?.delta?.content;
+          if (content) setCode((prev) => prev + content);
         }
       }
       setStatus("done");
@@ -208,8 +212,8 @@ export default function PlaygroundPage() {
         </div>
       </div>
       <DemoCreditsDialog
-        open={showCreditsDialog}
-        onClose={() => setShowCreditsDialog(false)}
+        open={showPlaygroundCreditsDialog}
+        onClose={() => setShowPlaygroundCreditsDialog(false)}
       />
     </div>
   );

--- a/docs/components/DemoCreditsDialog.css
+++ b/docs/components/DemoCreditsDialog.css
@@ -1,0 +1,141 @@
+.demo-credits-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: var(--openui-overlay, rgb(0 0 0 / 40%));
+  backdrop-filter: blur(4px);
+}
+
+.demo-credits-dialog {
+  position: relative;
+  width: min(520px, 100%);
+  border: 1px solid var(--openui-border-default, rgb(0 0 0 / 12%));
+  border-radius: 8px;
+  background: var(--openui-foreground, #fff);
+  box-shadow: var(--openui-shadow-2xl, 0 24px 80px rgb(0 0 0 / 24%));
+  color: var(--openui-text-neutral-primary, #111);
+  padding: 24px;
+}
+
+.demo-credits-dialog-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--openui-text-neutral-tertiary, #666);
+  cursor: pointer;
+}
+
+.demo-credits-dialog-close:hover {
+  background: var(--openui-highlight, rgb(0 0 0 / 6%));
+  color: var(--openui-text-neutral-primary, #111);
+}
+
+.demo-credits-dialog-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background: var(--openui-highlight-subtle, rgb(0 0 0 / 4%));
+  color: var(--openui-text-neutral-primary, #111);
+}
+
+.demo-credits-dialog h2 {
+  margin: 0;
+  color: var(--openui-text-neutral-primary, #111);
+  font-size: 18px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.demo-credits-dialog p {
+  margin: 8px 0 0;
+  color: var(--openui-text-neutral-secondary, #555);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.demo-credits-dialog-commands {
+  margin: 18px 0 0;
+  padding: 14px;
+  overflow-x: auto;
+  border: 1px solid var(--openui-border-default, rgb(0 0 0 / 12%));
+  border-radius: 8px;
+  background: var(--openui-inverted-background, #101010);
+  color: var(--openui-text-accent-primary, #f8f8f8);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.demo-credits-dialog-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.demo-credits-dialog-primary,
+.demo-credits-dialog-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 550;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.demo-credits-dialog-primary {
+  border: 1px solid var(--openui-interactive-accent-default, #111);
+  background: var(--openui-interactive-accent-default, #111);
+  color: var(--openui-text-accent-primary, #fff);
+}
+
+.demo-credits-dialog-secondary {
+  border: 1px solid var(--openui-border-interactive, rgb(0 0 0 / 16%));
+  background: transparent;
+  color: var(--openui-text-neutral-primary, #111);
+}
+
+.demo-credits-dialog-primary:hover {
+  background: var(--openui-interactive-accent-hover, #2a2a2a);
+}
+
+.demo-credits-dialog-secondary:hover {
+  background: var(--openui-highlight, rgb(0 0 0 / 6%));
+}
+
+@media (max-width: 540px) {
+  .demo-credits-dialog-overlay {
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  .demo-credits-dialog {
+    padding: 20px;
+  }
+
+  .demo-credits-dialog-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/docs/components/DemoCreditsDialog.tsx
+++ b/docs/components/DemoCreditsDialog.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Download, X } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+import {
+  DEMO_CREDITS_EXHAUSTED_MESSAGE,
+  DEMO_CREDITS_LOCAL_COMMANDS,
+} from "@/lib/demo-credits";
+import "./DemoCreditsDialog.css";
+
+type DemoCreditsDialogProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export function DemoCreditsDialog({ open, onClose }: DemoCreditsDialogProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    closeButtonRef.current?.focus();
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown, open]);
+
+  if (!open) return null;
+
+  return (
+    <div className="demo-credits-dialog-overlay" onClick={onClose}>
+      <section
+        className="demo-credits-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="demo-credits-dialog-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          ref={closeButtonRef}
+          className="demo-credits-dialog-close"
+          onClick={onClose}
+          aria-label="Close dialog"
+        >
+          <X size={16} />
+        </button>
+
+        <div className="demo-credits-dialog-icon">
+          <Download size={18} />
+        </div>
+
+        <h2 id="demo-credits-dialog-title">Hosted demo credits are recharging</h2>
+        <p>{DEMO_CREDITS_EXHAUSTED_MESSAGE}</p>
+
+        <pre className="demo-credits-dialog-commands">
+          <code>{DEMO_CREDITS_LOCAL_COMMANDS.join("\n")}</code>
+        </pre>
+
+        <div className="demo-credits-dialog-actions">
+          <a
+            className="demo-credits-dialog-primary"
+            href="https://github.com/thesysdev/openui"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <Download size={14} />
+            Download repo
+          </a>
+          <button className="demo-credits-dialog-secondary" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/docs/components/overview-components/chat-modal.tsx
+++ b/docs/components/overview-components/chat-modal.tsx
@@ -3,20 +3,151 @@
 import "@openuidev/react-ui/components.css";
 import "./chat-modal.css";
 
-import { openAIAdapter, openAIMessageFormat } from "@openuidev/react-headless";
+import {
+  EventType,
+  openAIMessageFormat,
+  type AGUIEvent,
+  type StreamProtocolAdapter,
+} from "@openuidev/react-headless";
 import { FullScreen } from "@openuidev/react-ui";
 import { openuiChatLibrary } from "@openuidev/react-ui/genui-lib";
 import { X } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 
 interface ChatModalProps {
   onClose: () => void;
 }
 
+function demoAwareOpenAIAdapter(onCreditsExhausted: () => void): StreamProtocolAdapter {
+  // This intentionally mirrors @openuidev/react-headless's openAIAdapter parser so the
+  // docs demo can intercept structured credit errors that arrive as SSE data frames.
+  // If that adapter gains an error callback, replace this fork with the upstream API.
+  return {
+    async *parse(response: Response): AsyncIterable<AGUIEvent> {
+      const reader = response.body?.getReader();
+      if (!reader) throw new Error("No response body");
+
+      const decoder = new TextDecoder();
+      const messageId = crypto.randomUUID();
+      const toolCallIds: Record<number, string> = {};
+      let messageStarted = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        const lines = chunk.split("\n");
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const data = line.slice(6).trim();
+          if (!data || data === "[DONE]") continue;
+
+          try {
+            const json = JSON.parse(data) as {
+              error?: unknown;
+              choices?: Array<{
+                delta?: {
+                  content?: string;
+                  role?: string;
+                  tool_calls?: Array<{
+                    index: number;
+                    id?: string;
+                    function?: { name?: string; arguments?: string };
+                  }>;
+                };
+                finish_reason?: string;
+              }>;
+            };
+
+            if (isDemoCreditsErrorPayload(json.error)) {
+              onCreditsExhausted();
+              await reader.cancel().catch(() => undefined);
+              return;
+            }
+
+            const choice = json.choices?.[0];
+            const delta = choice?.delta;
+
+            if (!delta) continue;
+
+            if (!messageStarted && (delta.content || delta.role)) {
+              yield {
+                type: EventType.TEXT_MESSAGE_START,
+                messageId,
+                role: "assistant",
+              };
+              messageStarted = true;
+            }
+
+            if (delta.content) {
+              yield {
+                type: EventType.TEXT_MESSAGE_CONTENT,
+                messageId,
+                delta: delta.content,
+              };
+            }
+
+            if (delta.tool_calls) {
+              for (const toolCall of delta.tool_calls) {
+                const index = toolCall.index;
+
+                if (toolCall.id) {
+                  toolCallIds[index] = toolCall.id;
+                  yield {
+                    type: EventType.TOOL_CALL_START,
+                    toolCallId: toolCall.id,
+                    toolCallName: toolCall.function?.name || "",
+                  };
+                }
+
+                if (toolCall.function?.arguments) {
+                  const toolCallId = toolCallIds[index];
+                  if (toolCallId) {
+                    yield {
+                      type: EventType.TOOL_CALL_ARGS,
+                      toolCallId,
+                      delta: toolCall.function.arguments,
+                    };
+                  }
+                }
+              }
+            }
+
+            if (choice?.finish_reason === "stop") {
+              yield {
+                type: EventType.TEXT_MESSAGE_END,
+                messageId,
+              };
+            } else if (choice?.finish_reason === "tool_calls") {
+              for (const toolCallId of Object.values(toolCallIds)) {
+                yield {
+                  type: EventType.TOOL_CALL_END,
+                  toolCallId,
+                };
+              }
+            }
+          } catch (error) {
+            console.error("Failed to parse OpenAI SSE event", error);
+          }
+        }
+      }
+    },
+  };
+}
+
 export function ChatModal({ onClose }: ChatModalProps) {
   const { resolvedTheme } = useTheme();
+  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
+  const streamProtocol = useMemo(
+    () => demoAwareOpenAIAdapter(() => setShowCreditsDialog(true)),
+    [],
+  );
 
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
@@ -44,7 +175,7 @@ export function ChatModal({ onClose }: ChatModalProps) {
           <FullScreen
             welcomeMessage={{ title: "Hello, how can I help you today?" }}
             processMessage={async ({ messages, abortController }) => {
-              return fetch("/api/chat", {
+              const response = await fetch("/api/chat", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -52,8 +183,20 @@ export function ChatModal({ onClose }: ChatModalProps) {
                 }),
                 signal: abortController.signal,
               });
+
+              if (!response.ok) {
+                const err = await response.clone().json().catch(() => ({}));
+                if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
+                  setShowCreditsDialog(true);
+                  return new Response("data: [DONE]\n\n", {
+                    headers: { "Content-Type": "text/event-stream" },
+                  });
+                }
+              }
+
+              return response;
             }}
-            streamProtocol={openAIAdapter()}
+            streamProtocol={streamProtocol}
             componentLibrary={openuiChatLibrary}
             agentName="OpenUI Chat"
             theme={{ mode: (resolvedTheme as "light" | "dark") ?? "light" }}
@@ -84,6 +227,10 @@ export function ChatModal({ onClose }: ChatModalProps) {
             }}
           />
         </div>
+        <DemoCreditsDialog
+          open={showCreditsDialog}
+          onClose={() => setShowCreditsDialog(false)}
+        />
       </div>
     </div>,
     document.body,

--- a/docs/components/overview-components/chat-modal.tsx
+++ b/docs/components/overview-components/chat-modal.tsx
@@ -3,151 +3,23 @@
 import "@openuidev/react-ui/components.css";
 import "./chat-modal.css";
 
-import {
-  EventType,
-  openAIMessageFormat,
-  type AGUIEvent,
-  type StreamProtocolAdapter,
-} from "@openuidev/react-headless";
+import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
+import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
+import { openAIAdapter, openAIMessageFormat } from "@openuidev/react-headless";
 import { FullScreen } from "@openuidev/react-ui";
 import { openuiChatLibrary } from "@openuidev/react-ui/genui-lib";
 import { X } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
-import { isDemoCreditsErrorPayload } from "@/lib/demo-credits";
 
 interface ChatModalProps {
   onClose: () => void;
 }
 
-function demoAwareOpenAIAdapter(onCreditsExhausted: () => void): StreamProtocolAdapter {
-  // This intentionally mirrors @openuidev/react-headless's openAIAdapter parser so the
-  // docs demo can intercept structured credit errors that arrive as SSE data frames.
-  // If that adapter gains an error callback, replace this fork with the upstream API.
-  return {
-    async *parse(response: Response): AsyncIterable<AGUIEvent> {
-      const reader = response.body?.getReader();
-      if (!reader) throw new Error("No response body");
-
-      const decoder = new TextDecoder();
-      const messageId = crypto.randomUUID();
-      const toolCallIds: Record<number, string> = {};
-      let messageStarted = false;
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        const chunk = decoder.decode(value, { stream: true });
-        const lines = chunk.split("\n");
-
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          const data = line.slice(6).trim();
-          if (!data || data === "[DONE]") continue;
-
-          try {
-            const json = JSON.parse(data) as {
-              error?: unknown;
-              choices?: Array<{
-                delta?: {
-                  content?: string;
-                  role?: string;
-                  tool_calls?: Array<{
-                    index: number;
-                    id?: string;
-                    function?: { name?: string; arguments?: string };
-                  }>;
-                };
-                finish_reason?: string;
-              }>;
-            };
-
-            if (isDemoCreditsErrorPayload(json.error)) {
-              onCreditsExhausted();
-              await reader.cancel().catch(() => undefined);
-              return;
-            }
-
-            const choice = json.choices?.[0];
-            const delta = choice?.delta;
-
-            if (!delta) continue;
-
-            if (!messageStarted && (delta.content || delta.role)) {
-              yield {
-                type: EventType.TEXT_MESSAGE_START,
-                messageId,
-                role: "assistant",
-              };
-              messageStarted = true;
-            }
-
-            if (delta.content) {
-              yield {
-                type: EventType.TEXT_MESSAGE_CONTENT,
-                messageId,
-                delta: delta.content,
-              };
-            }
-
-            if (delta.tool_calls) {
-              for (const toolCall of delta.tool_calls) {
-                const index = toolCall.index;
-
-                if (toolCall.id) {
-                  toolCallIds[index] = toolCall.id;
-                  yield {
-                    type: EventType.TOOL_CALL_START,
-                    toolCallId: toolCall.id,
-                    toolCallName: toolCall.function?.name || "",
-                  };
-                }
-
-                if (toolCall.function?.arguments) {
-                  const toolCallId = toolCallIds[index];
-                  if (toolCallId) {
-                    yield {
-                      type: EventType.TOOL_CALL_ARGS,
-                      toolCallId,
-                      delta: toolCall.function.arguments,
-                    };
-                  }
-                }
-              }
-            }
-
-            if (choice?.finish_reason === "stop") {
-              yield {
-                type: EventType.TEXT_MESSAGE_END,
-                messageId,
-              };
-            } else if (choice?.finish_reason === "tool_calls") {
-              for (const toolCallId of Object.values(toolCallIds)) {
-                yield {
-                  type: EventType.TOOL_CALL_END,
-                  toolCallId,
-                };
-              }
-            }
-          } catch (error) {
-            console.error("Failed to parse OpenAI SSE event", error);
-          }
-        }
-      }
-    },
-  };
-}
-
 export function ChatModal({ onClose }: ChatModalProps) {
   const { resolvedTheme } = useTheme();
-  const [showCreditsDialog, setShowCreditsDialog] = useState(false);
-  const streamProtocol = useMemo(
-    () => demoAwareOpenAIAdapter(() => setShowCreditsDialog(true)),
-    [],
-  );
+  const [showOverviewCreditsDialog, setShowOverviewCreditsDialog] = useState(false);
 
   const handleKey = useCallback(
     (e: KeyboardEvent) => {
@@ -185,9 +57,12 @@ export function ChatModal({ onClose }: ChatModalProps) {
               });
 
               if (!response.ok) {
-                const err = await response.clone().json().catch(() => ({}));
+                const err = await response
+                  .clone()
+                  .json()
+                  .catch(() => ({}));
                 if (isDemoCreditsErrorPayload((err as { error?: unknown }).error)) {
-                  setShowCreditsDialog(true);
+                  setShowOverviewCreditsDialog(true);
                   return new Response("data: [DONE]\n\n", {
                     headers: { "Content-Type": "text/event-stream" },
                   });
@@ -196,7 +71,7 @@ export function ChatModal({ onClose }: ChatModalProps) {
 
               return response;
             }}
-            streamProtocol={streamProtocol}
+            streamProtocol={openAIAdapter()}
             componentLibrary={openuiChatLibrary}
             agentName="OpenUI Chat"
             theme={{ mode: (resolvedTheme as "light" | "dark") ?? "light" }}
@@ -228,8 +103,8 @@ export function ChatModal({ onClose }: ChatModalProps) {
           />
         </div>
         <DemoCreditsDialog
-          open={showCreditsDialog}
-          onClose={() => setShowCreditsDialog(false)}
+          open={showOverviewCreditsDialog}
+          onClose={() => setShowOverviewCreditsDialog(false)}
         />
       </div>
     </div>,

--- a/docs/lib/demo-credits.ts
+++ b/docs/lib/demo-credits.ts
@@ -34,26 +34,11 @@ export function isDemoCreditsErrorPayload(value: unknown): value is DemoCreditsE
   );
 }
 
-function errorText(value: unknown): string {
-  if (value instanceof Error) {
-    return `${value.name} ${value.message}`.toLowerCase();
-  }
-  if (typeof value === "string") return value.toLowerCase();
-  try {
-    return JSON.stringify(value).toLowerCase();
-  } catch {
-    return "";
-  }
-}
-
 function hasPaymentRequiredCode(value: unknown, depth = 0): boolean {
   if (depth > 4 || typeof value !== "object" || value === null) return false;
 
   for (const [key, child] of Object.entries(value)) {
-    if (
-      ["code", "status", "statusCode"].includes(key) &&
-      (child === 402 || child === "402")
-    ) {
+    if (["code", "status", "statusCode"].includes(key) && (child === 402 || child === "402")) {
       return true;
     }
 
@@ -65,30 +50,9 @@ function hasPaymentRequiredCode(value: unknown, depth = 0): boolean {
   return false;
 }
 
-function hasSignal(text: string, signal: string): boolean {
-  return new RegExp(`(^|[^a-z0-9_])${signal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([^a-z0-9_]|$)`).test(
-    text,
-  );
-}
-
 export function isDemoCreditsExhaustedError(error: unknown, status?: number): boolean {
   if (status === 402) return true;
-  if (hasPaymentRequiredCode(error)) return true;
-
-  const text = errorText(error);
-  if (!text) return false;
-
-  return [
-    DEMO_CREDITS_EXHAUSTED_CODE,
-    "insufficient_quota",
-    "insufficient credits",
-    "insufficient quota",
-    "insufficient balance",
-    "requires more credits",
-    "can only afford",
-    "payment required",
-    "out of credits",
-  ].some((signal) => hasSignal(text, signal));
+  return hasPaymentRequiredCode(error);
 }
 
 export function createDemoCreditsExhaustedResponse(): Response {

--- a/docs/lib/demo-credits.ts
+++ b/docs/lib/demo-credits.ts
@@ -1,0 +1,96 @@
+export const DEMO_CREDITS_EXHAUSTED_CODE = "demo_credits_exhausted";
+
+export const DEMO_CREDITS_EXHAUSTED_MESSAGE =
+  "We're recharging the hosted demo credits. Until then, please download the repo and run it locally to see the live demo.";
+
+export const DEMO_CREDITS_LOCAL_COMMANDS = [
+  "git clone https://github.com/thesysdev/openui.git",
+  "cd openui",
+  "pnpm install",
+  'echo "OPENAI_API_KEY=sk-your-key-here" > examples/openui-chat/.env.local',
+  "pnpm --filter openui-chat dev",
+] as const;
+
+export type DemoCreditsErrorPayload = {
+  code: typeof DEMO_CREDITS_EXHAUSTED_CODE;
+  message: string;
+  instructions: readonly string[];
+};
+
+export function createDemoCreditsErrorPayload(): DemoCreditsErrorPayload {
+  return {
+    code: DEMO_CREDITS_EXHAUSTED_CODE,
+    message: DEMO_CREDITS_EXHAUSTED_MESSAGE,
+    instructions: DEMO_CREDITS_LOCAL_COMMANDS,
+  };
+}
+
+export function isDemoCreditsErrorPayload(value: unknown): value is DemoCreditsErrorPayload {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "code" in value &&
+    (value as { code?: unknown }).code === DEMO_CREDITS_EXHAUSTED_CODE
+  );
+}
+
+function errorText(value: unknown): string {
+  if (value instanceof Error) {
+    return `${value.name} ${value.message}`.toLowerCase();
+  }
+  if (typeof value === "string") return value.toLowerCase();
+  try {
+    return JSON.stringify(value).toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function hasPaymentRequiredCode(value: unknown, depth = 0): boolean {
+  if (depth > 4 || typeof value !== "object" || value === null) return false;
+
+  for (const [key, child] of Object.entries(value)) {
+    if (
+      ["code", "status", "statusCode"].includes(key) &&
+      (child === 402 || child === "402")
+    ) {
+      return true;
+    }
+
+    if (hasPaymentRequiredCode(child, depth + 1)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasSignal(text: string, signal: string): boolean {
+  return new RegExp(`(^|[^a-z0-9_])${signal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}([^a-z0-9_]|$)`).test(
+    text,
+  );
+}
+
+export function isDemoCreditsExhaustedError(error: unknown, status?: number): boolean {
+  if (status === 402) return true;
+  if (hasPaymentRequiredCode(error)) return true;
+
+  const text = errorText(error);
+  if (!text) return false;
+
+  return [
+    DEMO_CREDITS_EXHAUSTED_CODE,
+    "insufficient_quota",
+    "insufficient credits",
+    "insufficient quota",
+    "insufficient balance",
+    "requires more credits",
+    "can only afford",
+    "payment required",
+    "out of credits",
+  ].some((signal) => hasSignal(text, signal));
+}
+
+export function createDemoCreditsExhaustedResponse(): Response {
+  return Response.json({ error: createDemoCreditsErrorPayload() }, { status: 402 });
+}


### PR DESCRIPTION
## Summary
- detect hosted demo credit exhaustion in docs LLM routes and normalize it to a structured payload
- show a shared DemoCreditsDialog on the playground, GitHub demo, and docs chat modal
- handle OpenRouter 402 responses plus SDK-flattened credit messages from streaming routes

Closes #575

## Verification
- pnpm --filter @openuidev/docs types:check
- pnpm --dir docs exec eslint components/DemoCreditsDialog.tsx components/overview-components/chat-modal.tsx lib/demo-credits.ts
- smoke-tested /playground and /docs/openui-lang locally with an exhausted OpenRouter key
