### PR TITLE
docs: redesign /projects page

### DIFF
--- a/docs/app/(home)/projects/page.module.css
+++ b/docs/app/(home)/projects/page.module.css
@@ -5,7 +5,7 @@
 }
 
 .heroSection {
-  padding: 8rem var(--home-section-padding-inline, 1.25rem) 4rem;
+  padding: 6rem var(--home-section-padding-inline, 1.25rem) 4rem;
 }
 
 .heroInner,
@@ -24,10 +24,11 @@
   display: flex;
   max-width: 46rem;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
+  margin-inline: auto;
+  text-align: center;
 }
 
-.eyebrow,
 .sectionKicker {
   margin: 0;
   color: var(--openui-text-neutral-secondary);
@@ -38,17 +39,18 @@
 }
 
 .title {
-  max-width: 40rem;
-  margin: 1rem 0 0;
+  margin: 0;
   font-family: "Inter Display", sans-serif;
-  font-size: clamp(2.75rem, 6vw, 5rem);
+  font-size: clamp(40px, 10vw, 52px);
   font-weight: 600;
   line-height: 1;
+  letter-spacing: -1px;
+  color: var(--openui-text-neutral-primary);
 }
 
 .subtitle {
   max-width: 40rem;
-  margin: 1.5rem 0 0;
+  margin: 1.5rem auto 0;
   color: var(--openui-text-neutral-secondary);
   font-size: 1.125rem;
   line-height: 1.65;
@@ -57,6 +59,7 @@
 .heroActions {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
   gap: 0.75rem;
   margin-top: 2rem;
 }
@@ -69,37 +72,45 @@
   justify-content: center;
   gap: 0.5rem;
   min-height: 2.5rem;
-  border-radius: 999px;
+  border-radius: var(--openui-radius-full, 999px);
   text-decoration: none;
   transition:
-    transform 0.18s ease,
-    background-color 0.18s ease,
-    border-color 0.18s ease;
+    transform 0.2s ease,
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.primaryAction,
+.secondaryAction {
+  height: 3rem;
+  min-height: 3rem;
+  padding-inline: 1.25rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  box-shadow: var(--openui-shadow-l);
 }
 
 .primaryAction {
-  padding-inline: 1.25rem;
   background: var(--openui-text-neutral-primary);
   color: var(--openui-foreground);
-  font-weight: 600;
 }
 
 .secondaryAction {
-  padding-inline: 1.25rem;
-  border: 1px solid var(--openui-border-default);
+  border-color: var(--openui-border-default);
+  background: var(--openui-foreground);
   color: var(--openui-text-neutral-primary);
-  font-weight: 600;
 }
 
 .primaryAction:hover,
-.secondaryAction:hover,
-.cardLink:hover {
-  transform: translateY(-1px);
+.secondaryAction:hover {
+  transform: scale(0.99);
+  box-shadow: none;
 }
 
-.secondaryAction:hover,
 .cardLink:hover {
-  background: var(--openui-highlight);
+  border-color: var(--openui-border-interactive, var(--openui-text-neutral-primary));
+  box-shadow: var(--openui-shadow-m);
 }
 
 .actionIcon,
@@ -113,6 +124,7 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   width: min(100%, 31rem);
+  margin: 1rem auto 0;
   gap: 0.75rem;
 }
 
@@ -213,8 +225,13 @@
   font-size: 0.8125rem;
 }
 
+.contentSection {
+  position: relative;
+  background: var(--openui-background);
+}
+
 .directorySection {
-  padding: 4rem var(--home-section-padding-inline, 1.25rem) 2rem;
+  padding: 2rem var(--home-section-padding-inline, 1.25rem) 2rem;
 }
 
 .sectionHeader {
@@ -232,11 +249,13 @@
 }
 
 .sectionDescription {
-  max-width: 34rem;
   margin: 0;
   color: var(--openui-text-neutral-secondary);
-  font-size: 1rem;
-  line-height: 1.65;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1;
+  text-align: right;
+  justify-self: end;
 }
 
 .grid {
@@ -247,13 +266,13 @@
 .card {
   --card-accent: var(--openui-text-neutral-primary);
   display: flex;
-  min-height: 17rem;
+  min-height: 18rem;
   flex-direction: column;
   border: 1px solid var(--openui-border-default);
-  border-radius: 8px;
-  padding: 1.125rem;
+  border-radius: var(--openui-radius-4xl);
+  padding: 1.25rem;
   background: var(--openui-foreground);
-  box-shadow: 0 1px 0 rgb(0 0 0 / 3%);
+  box-shadow: var(--openui-shadow-m);
 }
 
 .card[data-accent="blue"],
@@ -281,68 +300,59 @@
   --card-accent: #475569;
 }
 
-.cardTop {
+.cardHeader {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
   gap: 1rem;
 }
 
-.iconFrame {
+.cardHeaderContent {
   display: flex;
-  width: 2.25rem;
-  height: 2.25rem;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--card-accent) 12%, transparent);
-  color: var(--card-accent);
-}
-
-.cardIcon {
-  width: 1.125rem;
-  height: 1.125rem;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
 .tags {
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 0.375rem;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.5rem;
 }
 
-.typeTag,
-.statusTag {
+.typeTag {
   display: inline-flex;
-  height: 1.5rem;
+  height: 1.625rem;
   align-items: center;
-  border-radius: 999px;
-  padding-inline: 0.625rem;
+  gap: 0.3rem;
+  border-radius: 8px;
+  padding-inline: 0.5rem;
+  background: color-mix(in srgb, var(--card-accent) 14%, transparent);
+  color: var(--card-accent);
   font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
 }
 
-.typeTag {
-  border: 1px solid var(--openui-border-default);
+.statusMeta {
+  display: inline-flex;
+  align-items: center;
   color: var(--openui-text-neutral-secondary);
-}
-
-.statusTag {
-  background: var(--openui-highlight);
-  color: var(--openui-text-neutral-primary);
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1;
 }
 
 .cardTitle {
-  margin: 1.125rem 0 0;
+  margin: 0;
   font-size: 1.0625rem;
   font-weight: 650;
   line-height: 1.3;
 }
 
 .cardDescription {
-  margin: 0.875rem 0 0;
+  margin: 1.75rem 0 0;
   color: var(--openui-text-neutral-secondary);
   font-size: 0.9375rem;
   line-height: 1.65;
@@ -353,16 +363,37 @@
   flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: auto;
-  padding-top: 1.25rem;
+  padding-top: 1.5rem;
 }
 
 .cardLink {
   min-height: 2rem;
-  padding-inline: 0.75rem;
+  padding-inline: 0.875rem;
   border: 1px solid var(--openui-border-default);
+  background: var(--openui-foreground);
+  box-shadow: var(--openui-shadow-s);
   color: var(--openui-text-neutral-primary);
   font-size: 0.875rem;
-  font-weight: 600;
+  font-weight: 500;
+}
+
+.cardLinkArrow {
+  width: 0.875rem;
+  height: 0.875rem;
+  margin-inline-start: -0.125rem;
+  max-width: 0;
+  opacity: 0;
+  transform: translateX(-4px);
+  transition:
+    opacity 0.18s ease,
+    transform 0.18s ease,
+    max-width 0.18s ease;
+}
+
+.cardLink:hover .cardLinkArrow {
+  max-width: 1rem;
+  opacity: 1;
+  transform: translateX(0);
 }
 
 .submitSection {
@@ -378,6 +409,63 @@
   max-width: 42rem;
 }
 
+.submitDescription {
+  margin: 0.75rem 0 0;
+  color: var(--openui-text-neutral-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.submitSteps {
+  margin: 1.25rem 0 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: submit-step;
+}
+
+.submitSteps li {
+  position: relative;
+  margin-top: 0.625rem;
+  padding-inline-start: 2rem;
+  color: var(--openui-text-neutral-primary);
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  counter-increment: submit-step;
+}
+
+.submitSteps li:first-child {
+  margin-top: 0;
+}
+
+.submitSteps li::before {
+  content: counter(submit-step);
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-flex;
+  width: 1.375rem;
+  height: 1.375rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--openui-border-default);
+  border-radius: 999px;
+  background: var(--openui-highlight);
+  color: var(--openui-text-neutral-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.stepDetail {
+  color: var(--openui-text-neutral-secondary);
+}
+
+.submitActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
 @media (min-width: 720px) {
   .grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -391,16 +479,12 @@
 
 @media (min-width: 1024px) {
   .heroSection {
-    padding-top: 9rem;
+    padding-top: 7rem;
   }
 
-  .heroInner {
-    grid-template-columns: minmax(0, 1.05fr) minmax(23rem, 0.75fr);
-    align-items: end;
-  }
-
-  .heroPanel {
-    padding-top: 0;
+  .title {
+    font-size: 6rem;
+    letter-spacing: -2px;
   }
 
   .grid {
@@ -416,11 +500,7 @@
 
 @media (max-width: 640px) {
   .heroSection {
-    padding-top: 6rem;
-  }
-
-  .title {
-    font-size: 2.875rem;
+    padding-top: 4rem;
   }
 
   .heroPanel {

--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -1,25 +1,36 @@
 import {
+  ArrowUpRight,
   BookOpen,
   Bot,
-  Boxes,
   Code2,
-  ExternalLink,
   Github,
   MonitorSmartphone,
   Package,
   PlugZap,
+  Plus,
   Server,
   Sparkles,
-  Users,
   Wrench,
 } from "lucide-react";
 import type { Metadata } from "next";
 import type { ComponentType } from "react";
 import { PillLink } from "../components/Button/Button";
 import { Footer } from "../sections/Footer/Footer";
+import { GradientDivider } from "../sections/GradientDivider/GradientDivider";
 import styles from "./page.module.css";
 
 type ProjectStatus = "Official" | "Community";
+
+const TYPE_ACCENT: Record<string, "blue" | "green" | "purple" | "orange" | "slate"> = {
+  Tool: "purple",
+  Plugin: "blue",
+  Provider: "green",
+  Extension: "blue",
+  Package: "purple",
+  Framework: "orange",
+  Example: "slate",
+  Article: "purple",
+};
 
 interface ProjectLink {
   label: string;
@@ -224,23 +235,7 @@ const projects: ProjectItem[] = [
   },
 ];
 
-const highlights = [
-  {
-    label: "Community projects",
-    value: projects.filter((item) => item.status === "Community").length.toString(),
-    accent: "purple",
-    icon: Users,
-  },
-  { label: "Featured projects", value: projects.length.toString(), accent: "slate", icon: Boxes },
-  {
-    label: "Discord",
-    value: "Share your projects with the community",
-    accent: "blue",
-    icon: DiscordIcon,
-    kind: "cta",
-    href: "https://discord.gg/suzHfJnpw",
-  },
-];
+const DISCORD_URL = "https://discord.gg/suzHfJnpw";
 
 export const metadata: Metadata = {
   title: "OpenUI Projects",
@@ -259,20 +254,7 @@ export const metadata: Metadata = {
   },
 };
 
-function ExternalIndicator({ external }: { external?: boolean }) {
-  if (!external) return null;
-  return <ExternalLink className={styles.linkIcon} strokeWidth={1.8} aria-hidden="true" />;
-}
-
-function LinkIcon({ label }: { label: string }) {
-  if (label === "GitHub") {
-    return <Github className={styles.linkIcon} strokeWidth={1.8} aria-hidden="true" />;
-  }
-
-  return <ExternalIndicator external />;
-}
-
-function DiscordIcon({ className }: { className?: string; strokeWidth?: number }) {
+function DiscordIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
       <path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
@@ -286,11 +268,11 @@ export default function ProjectsPage() {
       <section className={styles.heroSection}>
         <div className={styles.heroInner}>
           <div className={styles.heroCopy}>
-            <div className={styles.eyebrow}>OpenUI projects</div>
             <h1 className={styles.title}>OpenUI Projects</h1>
             <p className={styles.subtitle}>
-              Official and community projects that extend OpenUI across plugins, framework packages,
-              local-model workflows, editor tools, and starter examples.
+              Tools, packages, plugins, and examples
+              <br />
+              for building with OpenUI across the stack.
             </p>
             <div className={styles.heroActions}>
               <PillLink
@@ -298,87 +280,46 @@ export default function ProjectsPage() {
                 href="https://github.com/thesysdev/openui/issues"
                 external
               >
+                <Plus className={styles.actionIcon} strokeWidth={2} aria-hidden="true" />
                 Submit a project
-                <ExternalLink className={styles.actionIcon} strokeWidth={1.8} aria-hidden="true" />
+              </PillLink>
+              <PillLink className={styles.secondaryAction} href={DISCORD_URL} external>
+                <DiscordIcon className={styles.actionIcon} />
+                Share on Discord
               </PillLink>
             </div>
-          </div>
-
-          <div className={styles.heroPanel} aria-label="Projects summary">
-            {highlights.map((item) => {
-              const Icon = item.icon;
-              const content = (
-                <>
-                  <div className={styles.metricTop}>
-                    <span className={styles.metricIconFrame}>
-                      <Icon className={styles.metricIcon} strokeWidth={1.8} aria-hidden="true" />
-                    </span>
-                    <span className={styles.metricValue}>{item.value}</span>
-                  </div>
-                  <span className={styles.metricLabel}>{item.label}</span>
-                </>
-              );
-
-              if (item.href) {
-                return (
-                  <a
-                    className={styles.metricTile}
-                    data-accent={item.accent}
-                    data-kind={item.kind}
-                    href={item.href}
-                    key={item.label}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {content}
-                  </a>
-                );
-              }
-
-              return (
-                <div
-                  className={styles.metricTile}
-                  data-accent={item.accent}
-                  data-kind={item.kind}
-                  key={item.label}
-                >
-                  {content}
-                </div>
-              );
-            })}
           </div>
         </div>
       </section>
 
-      <section className={styles.directorySection} id="directory">
+      <div className={styles.contentSection}>
+        <GradientDivider direction="down" compact />
+
+        <section className={styles.directorySection} id="directory">
         <div className={styles.sectionHeader}>
           <div>
-            <p className={styles.sectionKicker}>Directory</p>
             <h2 className={styles.sectionTitle}>Featured projects</h2>
           </div>
-          <p className={styles.sectionDescription}>
-            A curated starting point for projects that extend OpenUI beyond the core SDK.
-          </p>
+          <p className={styles.sectionDescription}>{projects.length} projects</p>
         </div>
 
         <div className={styles.grid}>
           {projects.map((item) => {
-            const Icon = item.icon;
-
             return (
-              <article className={styles.card} data-accent={item.accent} key={item.name}>
-                <div className={styles.cardTop}>
-                  <div className={styles.iconFrame}>
-                    <Icon className={styles.cardIcon} strokeWidth={1.8} aria-hidden="true" />
-                  </div>
-                  <div className={styles.tags}>
-                    <span className={styles.statusTag} data-status={item.status}>
-                      {item.status}
-                    </span>
-                    <span className={styles.typeTag}>{item.type}</span>
+              <article
+                className={styles.card}
+                data-accent={TYPE_ACCENT[item.type] ?? "slate"}
+                key={item.name}
+              >
+                <div className={styles.cardHeader}>
+                  <div className={styles.cardHeaderContent}>
+                    <h3 className={styles.cardTitle}>{item.name}</h3>
+                    <div className={styles.tags}>
+                      <span className={styles.typeTag}>{item.type}</span>
+                      <span className={styles.statusMeta}>by {item.status}</span>
+                    </div>
                   </div>
                 </div>
-                <h3 className={styles.cardTitle}>{item.name}</h3>
                 <p className={styles.cardDescription}>{item.description}</p>
                 <div className={styles.cardLinks}>
                   {item.links.map((link) => (
@@ -388,12 +329,19 @@ export default function ProjectsPage() {
                       key={`${item.name}-${link.label}`}
                       {...(link.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
                     >
-                      {link.label === "GitHub" ? (
-                        <LinkIcon label={link.label} />
-                      ) : (
-                        <ExternalIndicator external={link.external} />
+                      {link.label === "GitHub" && (
+                        <Github
+                          className={styles.linkIcon}
+                          strokeWidth={1.8}
+                          aria-hidden="true"
+                        />
                       )}
                       {link.label}
+                      <ArrowUpRight
+                        className={styles.cardLinkArrow}
+                        strokeWidth={1.8}
+                        aria-hidden="true"
+                      />
                     </a>
                   ))}
                 </div>
@@ -401,26 +349,41 @@ export default function ProjectsPage() {
             );
           })}
         </div>
-      </section>
+        </section>
+
+        <GradientDivider direction="up" compact />
+      </div>
 
       <section className={styles.submitSection}>
         <div className={styles.submitCopy}>
-          <p className={styles.sectionKicker}>Contribute</p>
           <h2 className={styles.sectionTitle}>Add your project</h2>
-          <p className={styles.sectionDescription}>
-            Open an issue or PR with the package link, a short description, install steps,
-            maintainer contact, license, and whether it is official, community-maintained, or
-            experimental.
+          <p className={styles.submitDescription}>
+            Open an issue or PR with the items below, or share it in our Discord.
           </p>
+          <ol className={styles.submitSteps}>
+            <li>Package link &amp; description</li>
+            <li>Install steps</li>
+            <li>Maintainer contact &amp; license</li>
+            <li>
+              Status:&nbsp;
+              <span className={styles.stepDetail}>Official, Community, or Experimental</span>
+            </li>
+          </ol>
         </div>
-        <PillLink
-          className={styles.primaryAction}
-          href="https://github.com/thesysdev/openui/issues"
-          external
-        >
-          Submit a project
-          <ExternalLink className={styles.actionIcon} strokeWidth={1.8} aria-hidden="true" />
-        </PillLink>
+        <div className={styles.submitActions}>
+          <PillLink
+            className={styles.primaryAction}
+            href="https://github.com/thesysdev/openui/issues"
+            external
+          >
+            <Plus className={styles.actionIcon} strokeWidth={2} aria-hidden="true" />
+            Submit a project
+          </PillLink>
+          <PillLink className={styles.secondaryAction} href={DISCORD_URL} external>
+            <DiscordIcon className={styles.actionIcon} />
+            Share on Discord
+          </PillLink>
+        </div>
       </section>
 
       <Footer />

--- a/docs/app/(home)/sections/GradientDivider/GradientDivider.tsx
+++ b/docs/app/(home)/sections/GradientDivider/GradientDivider.tsx
@@ -16,8 +16,15 @@ const BAR_HEIGHT_CLASSES = [
   styles.barHeight1047,
 ];
 
-export function GradientDivider({ direction = "down" }: { direction?: "down" | "up" }) {
-  const bars = direction === "up" ? [...BAR_HEIGHT_CLASSES].reverse() : BAR_HEIGHT_CLASSES;
+export function GradientDivider({
+  direction = "down",
+  compact = false,
+}: {
+  direction?: "down" | "up";
+  compact?: boolean;
+}) {
+  const source = compact ? BAR_HEIGHT_CLASSES.slice(2) : BAR_HEIGHT_CLASSES;
+  const bars = direction === "up" ? [...source].reverse() : source;
 
   return (
     <div className={styles.divider}>


### PR DESCRIPTION
## Summary

A visual + structural pass on the `/projects` page so it feels like part of the rest of `openui.com`:

- **Hero**: centered, single-column, matches the OpenClaw OS title scale (Inter Display 600, 6rem desktop / clamp(40, 10vw, 52px) mobile, -2px / -1px letter-spacing). Drops the side stats panel. Adds a `Share on Discord` secondary CTA next to a `+ Submit a project` primary, both styled like the home page CTAs (3rem height, soft drop shadow, scale-on-hover).
- **Gradient divider**: new optional `compact` prop on the shared `GradientDivider` skips the two tallest bars. Used on /projects only; home page and OpenClaw OS stay on the full divider.
- **Directory section**: wrapped in the home page's gray `contentSection` between `direction="down"` and `direction="up"` dividers. Removed the "DIRECTORY" eyebrow and the verbose description; the right column is now a small "11 projects" count.
- **Project cards**:
  - Type-driven accent color via a `TYPE_ACCENT` map, so all `Framework` chips are the same color, all `Plugin` chips are the same color, etc.
  - Filled squircle type chip (text only) + `by Official` / `by Community` as muted meta text.
  - Larger border-radius and shadow matched to home page cards (`--openui-radius-4xl`, `--openui-shadow-m`).
  - Link buttons: only `GitHub` keeps its leading icon; all others are text-only with a small `↗` arrow that slides in on hover. Subtle resting shadow with a heavier shadow + border darken on hover.
- **Submit section**: dropped the "CONTRIBUTE" eyebrow, rewrote the copy as a numbered checklist, and added the `Share on Discord` CTA next to `+ Submit a project`.

## Files changed

- `docs/app/(home)/projects/page.tsx`
- `docs/app/(home)/projects/page.module.css`
- `docs/app/(home)/sections/GradientDivider/GradientDivider.tsx` (new `compact` prop, opt-in)

## Test plan

- [ ] `pnpm -C docs dev` and visit `/projects`
- [ ] Switch between `/projects` and `/openclaw-os` and verify the H1 stays visually aligned (size, weight, position)
- [ ] Hover each card link button and confirm the `↗` arrow slides in and the shadow deepens
- [ ] Confirm all `Framework` chips render orange, all `Plugin` chips render blue, etc.
- [ ] Confirm home page (`/`) and `/openclaw-os` still render with the full-height GradientDivider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #585 