### PR TITLE
docs: use correct package name `@openuidev/react-ui` in Storybook import snippets

### DIFF
--- a/packages/react-ui/src/components/Accordion/stories/accordion.stories.tsx
+++ b/packages/react-ui/src/components/Accordion/stories/accordion.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<AccordionStoryProps> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@openui-ui/react-ui';\n```",
+          "```tsx\nimport { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Button/stories/Button.stories.tsx
+++ b/packages/react-ui/src/components/Button/stories/Button.stories.tsx
@@ -86,7 +86,7 @@ const meta: Meta<typeof Button> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Button } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Button } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Buttons/stories/buttons.stories.tsx
+++ b/packages/react-ui/src/components/Buttons/stories/buttons.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Buttons> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Buttons } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Buttons } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Calendar/stories/Calendar.stories.tsx
+++ b/packages/react-ui/src/components/Calendar/stories/Calendar.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Calendar> = {
 A flexible \`calendar\` component built on top of [react-day-picker](https://react-day-picker.js.org/).
 
 \`\`\`tsx
-import { Calendar } from '@openui-ui/react-ui';
+import { Calendar } from '@openuidev/react-ui';
 \`\`\`
 `,
       },

--- a/packages/react-ui/src/components/Callout/stories/callout.stories.tsx
+++ b/packages/react-ui/src/components/Callout/stories/callout.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<CalloutProps> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Callout } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Callout } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Card/stories/card.stories.tsx
+++ b/packages/react-ui/src/components/Card/stories/card.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof Card> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Card } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Card } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/CardHeader/stories/cardHeader.stories.tsx
+++ b/packages/react-ui/src/components/CardHeader/stories/cardHeader.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof CardHeader> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { CardHeader } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { CardHeader } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Carousel/stories/carousel.stories.tsx
+++ b/packages/react-ui/src/components/Carousel/stories/carousel.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta<typeof Carousel> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { Carousel,CarouselContent,CarouselItem,CarouselNext,CarouselPrevious } from '@openui-ui/react-ui';\n```",
+          "```tsx\nimport { Carousel,CarouselContent,CarouselItem,CarouselNext,CarouselPrevious } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Charts/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/HorizontalBarChart/stories/HorizontalBarChart.stories.tsx
@@ -436,7 +436,7 @@ const meta: Meta<HorizontalBarChartProps<typeof horizontalBarChartData>> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { HorizontalBarChart } from '@openui-ui/react-ui/Charts/HorizontalBarChart';
+import { HorizontalBarChart } from '@openuidev/react-ui/Charts/HorizontalBarChart';
 
 const salesData = [
   { region: "North America", sales: 150000, profit: 45000 },

--- a/packages/react-ui/src/components/Charts/MiniAreaChart/stories/MiniAreaChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/MiniAreaChart/stories/MiniAreaChart.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof MiniAreaChart> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { MiniAreaChart } from '@openui-ui/react-ui/Charts/AreaCharts/MiniAreaChart';\n```\n\nA responsive mini area chart component that accepts 1D data (numbers or objects with value/label) with automatic data filtering for space-constrained containers. Features linear gradient fills from color to transparent.",
+          "```tsx\nimport { MiniAreaChart } from '@openuidev/react-ui/Charts/AreaCharts/MiniAreaChart';\n```\n\nA responsive mini area chart component that accepts 1D data (numbers or objects with value/label) with automatic data filtering for space-constrained containers. Features linear gradient fills from color to transparent.",
       },
     },
   },

--- a/packages/react-ui/src/components/Charts/MiniBarChart/stories/MiniBarChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/MiniBarChart/stories/MiniBarChart.stories.tsx
@@ -40,7 +40,7 @@ const meta: Meta<MiniBarChartProps> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { MiniBarChart } from '@openui-ui/react-ui/Charts/BarCharts/MiniBarChart';\n```",
+          "```tsx\nimport { MiniBarChart } from '@openuidev/react-ui/Charts/BarCharts/MiniBarChart';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Charts/MiniLineChart/stories/MiniLineChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/MiniLineChart/stories/MiniLineChart.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta<typeof MiniLineChart> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { MiniLineChart } from '@openui-ui/react-ui/Charts/LineCharts/MiniLineChart';\n```\n\nA responsive mini line chart component that accepts 1D data (numbers or objects with value/label) with automatic data filtering for space-constrained containers. Features smooth line interpolation and customizable styling.",
+          "```tsx\nimport { MiniLineChart } from '@openuidev/react-ui/Charts/LineCharts/MiniLineChart';\n```\n\nA responsive mini line chart component that accepts 1D data (numbers or objects with value/label) with automatic data filtering for space-constrained containers. Features smooth line interpolation and customizable styling.",
       },
     },
   },

--- a/packages/react-ui/src/components/Charts/PieChart/stories/PieChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/PieChart/stories/PieChart.stories.tsx
@@ -74,7 +74,7 @@ const meta: Meta<PieChartProps<typeof monthlySalesData>> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { PieChart } from '@openui-ui/react-ui/Charts/PieChart';
+import { PieChart } from '@openuidev/react-ui/Charts/PieChart';
 
 // Basic implementation
 <PieChart

--- a/packages/react-ui/src/components/Charts/RadarChart/stories/RadarChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/RadarChart/stories/RadarChart.stories.tsx
@@ -95,7 +95,7 @@ const meta: Meta<RadarChartProps<typeof radarChartData>> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { RadarChart } from '@openui-ui/react-ui/Charts/RadarChart';
+import { RadarChart } from '@openuidev/react-ui/Charts/RadarChart';
 
 // Basic implementation
 <RadarChart

--- a/packages/react-ui/src/components/Charts/RadialChart/stories/RadialChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/RadialChart/stories/RadialChart.stories.tsx
@@ -101,7 +101,7 @@ const meta: Meta<RadialChartProps<typeof monthlyRevenueData>> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { RadialChart } from '@openui-ui/react-ui/Charts/RadialChart';
+import { RadialChart } from '@openuidev/react-ui/Charts/RadialChart';
 
 // Basic implementation
 <RadialChart

--- a/packages/react-ui/src/components/Charts/ScatterChart/stories/ScatterChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/ScatterChart/stories/ScatterChart.stories.tsx
@@ -454,7 +454,7 @@ const meta: Meta<ScatterChartProps> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { ScatterChart } from '@openui-ui/react-ui/Charts/ScatterChart';
+import { ScatterChart } from '@openuidev/react-ui/Charts/ScatterChart';
 
 const scatterData = [
   { x: 100, y: 200, category: "A" },

--- a/packages/react-ui/src/components/Charts/SingleStackedBarChart/stories/SingleStackedBarChart.stories.tsx
+++ b/packages/react-ui/src/components/Charts/SingleStackedBarChart/stories/SingleStackedBarChart.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<SingleStackedBarProps<any>> = {
 ## Installation and Basic Usage
 
 \`\`\`tsx
-import { SingleStackedBar } from '@openui-ui/react-ui/Charts/SingleStackedBar';
+import { SingleStackedBar } from '@openuidev/react-ui/Charts/SingleStackedBar';
 
 // Basic implementation
 <SingleStackedBar

--- a/packages/react-ui/src/components/CheckBoxItem/stories/CheckBoxItem.stories.tsx
+++ b/packages/react-ui/src/components/CheckBoxItem/stories/CheckBoxItem.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof CheckBoxItem> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { CheckBoxItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { CheckBoxItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
+++ b/packages/react-ui/src/components/DatePicker/stories/DatePicker.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof DatePicker> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { DatePicker } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { DatePicker } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/FollowUpBlock/stories/FollowUpBlock.stories.tsx
+++ b/packages/react-ui/src/components/FollowUpBlock/stories/FollowUpBlock.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof FollowUpBlock> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { FollowUpBlock, FollowUpItem } from '@openui-ui/react-ui';\n```",
+          "```tsx\nimport { FollowUpBlock, FollowUpItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/FollowUpItem/stories/FollowUpItem.stories.tsx
+++ b/packages/react-ui/src/components/FollowUpItem/stories/FollowUpItem.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof FollowUpItem> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { FollowUpItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { FollowUpItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/FormControl/stories/FormControl.stories.tsx
+++ b/packages/react-ui/src/components/FormControl/stories/FormControl.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof FormControl> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { FormControl, Hint } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { FormControl, Hint } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/IconButton/stories/iconButton.stories.tsx
+++ b/packages/react-ui/src/components/IconButton/stories/iconButton.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof IconButton> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { IconButton } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { IconButton } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Image/stories/Image.stories.tsx
+++ b/packages/react-ui/src/components/Image/stories/Image.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof Image> = {
   parameters: {
     docs: {
       description: {
-        component: "```tsx\nimport { Image } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Image } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/ImageGallery/stories/imsgeGallery.stories.tsx
+++ b/packages/react-ui/src/components/ImageGallery/stories/imsgeGallery.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof ImageGallery> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { ImageGallery } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { ImageGallery } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Input/stories/Input.stories.tsx
+++ b/packages/react-ui/src/components/Input/stories/Input.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Input> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Input } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Input } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/ListBlock/stories/ListBlock.stories.tsx
+++ b/packages/react-ui/src/components/ListBlock/stories/ListBlock.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof ListBlock> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { ListBlock, ListItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { ListBlock, ListItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/ListItem/stories/ListItem.stories.tsx
+++ b/packages/react-ui/src/components/ListItem/stories/ListItem.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof ListItem> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { ListItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { ListItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/MessageLoading/stories/MessageLoading.stories.tsx
+++ b/packages/react-ui/src/components/MessageLoading/stories/MessageLoading.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof MessageLoading> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { MessageLoading } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { MessageLoading } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/RadioGroup/stories/RadioGroup.stories.tsx
+++ b/packages/react-ui/src/components/RadioGroup/stories/RadioGroup.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof RadioGroup> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { RadioGroup, RadioItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { RadioGroup, RadioItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Select/stories/select.stories.tsx
+++ b/packages/react-ui/src/components/Select/stories/select.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<SelectStoryProps> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@openui-ui/react-ui';\n```",
+          "```tsx\nimport { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Separator/stories/Separator.stories.tsx
+++ b/packages/react-ui/src/components/Separator/stories/Separator.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Separator> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Separator } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Separator } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Slider/stories/slider.stories.tsx
+++ b/packages/react-ui/src/components/Slider/stories/slider.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<SliderBlockProps> = {
     docs: {
       description: {
         component:
-          "A slider component with a label, inline value editing (text input for continuous, select dropdown for discrete), range support, and validation.\n\n```tsx\nimport { SliderBlock } from '@openui-ui/react-ui';\n```",
+          "A slider component with a label, inline value editing (text input for continuous, select dropdown for discrete), range support, and validation.\n\n```tsx\nimport { SliderBlock } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Steps/stories/steps.stories.tsx
+++ b/packages/react-ui/src/components/Steps/stories/steps.stories.tsx
@@ -32,7 +32,7 @@ const meta: Meta<StepsProps> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Steps, StepsItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Steps, StepsItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
+++ b/packages/react-ui/src/components/SwitchGroup/stories/SwitchGroup.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof SwitchGroup> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { SwitchGroup, SwitchItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { SwitchGroup, SwitchItem } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Tabs/stories/tabs.stories.tsx
+++ b/packages/react-ui/src/components/Tabs/stories/tabs.stories.tsx
@@ -15,7 +15,7 @@ const meta: Meta<typeof Tabs> = {
     docs: {
       description: {
         component:
-          "```tsx\nimport { Tabs, TabsContent, TabsList, TabsTrigger } from '@openui-ui/react-ui';\n```",
+          "```tsx\nimport { Tabs, TabsContent, TabsList, TabsTrigger } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/Tag/stories/Tag.stories.tsx
+++ b/packages/react-ui/src/components/Tag/stories/Tag.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Tag> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { Tag } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { Tag } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/TagBlock/stories/TagBlock.stories.tsx
+++ b/packages/react-ui/src/components/TagBlock/stories/TagBlock.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof TagBlock> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { TagBlock, Tag } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { TagBlock, Tag } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/TextArea/stories/TextArea.stories.tsx
+++ b/packages/react-ui/src/components/TextArea/stories/TextArea.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { TextArea } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { TextArea } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/TextCallout/stories/TextCallout.stories.tsx
+++ b/packages/react-ui/src/components/TextCallout/stories/TextCallout.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<TextCalloutProps> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { TextCallout } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { TextCallout } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/TextContent/stories/TextContent.stories.tsx
+++ b/packages/react-ui/src/components/TextContent/stories/TextContent.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof TextContent> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { TextContent } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { TextContent } from '@openuidev/react-ui';\n```",
       },
     },
   },

--- a/packages/react-ui/src/components/ToggleGroup/stories/ToggleGroup.stories.tsx
+++ b/packages/react-ui/src/components/ToggleGroup/stories/ToggleGroup.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof ToggleGroup> = {
     layout: "centered",
     docs: {
       description: {
-        component: "```tsx\nimport { ToggleGroup, ToggleItem } from '@openui-ui/react-ui';\n```",
+        component: "```tsx\nimport { ToggleGroup, ToggleItem } from '@openuidev/react-ui';\n```",
       },
     },
   },


### PR DESCRIPTION
## What

Fixes the package name shown in Storybook docs "import" snippets across `@openuidev/react-ui`. 42 story files referenced **`@openui-ui/react-ui`** — a package that does not exist on npm — instead of the real name **`@openuidev/react-ui`** (per `packages/react-ui/package.json`).

Closes #592.

## Why

The wrong name lives in each story's `parameters.docs.description.component` code block — the import snippet shown on the component's autodocs page. It's **documentation-only**: the stories' real imports use relative paths, so nothing changes at build or runtime. But anyone copying the import line from Storybook gets a non-resolvable package.

## Change

- Replaced `@openui-ui/react-ui` → `@openuidev/react-ui` in **42** `*.stories.tsx` files under `packages/react-ui/src`.
- Mechanical string-only change (1 line per file); no code, props, or formatting touched.
- Scope is entirely within `packages/react-ui` — there were zero occurrences of `@openui-ui` anywhere else in the repo.

## Verification

```bash
# 0 remaining occurrences in source
grep -rn "@openui-ui" packages/react-ui/src        # → none

pnpm --filter @openuidev/react-ui format:check     # All matched files use Prettier code style
pnpm --filter @openuidev/react-ui lint:check       # 0 errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
