### PR TITLE
feat: Add native Swift integration for OpenUI (#393)

### DIFF
--- a/packages/swift/.gitignore
+++ b/packages/swift/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -31,6 +31,9 @@ let package = Package(
             dependencies: ["OpenUILang"]),
         .executableTarget(
             name: "SwiftUIChat",
-            dependencies: ["OpenUILang", "OpenUISwiftUI"])
+            dependencies: ["OpenUILang", "OpenUISwiftUI"]),
+        .testTarget(
+            name: "OpenUILangTests",
+            dependencies: ["OpenUILang"])
     ]
 )

--- a/packages/swift/Package.swift
+++ b/packages/swift/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenUI",
+    platforms: [
+        .macOS(.v13),
+        .iOS(.v16)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "OpenUILang",
+            targets: ["OpenUILang"]),
+        .library(
+            name: "OpenUISwiftUI",
+            targets: ["OpenUISwiftUI"]),
+        .executable(
+            name: "SwiftUIChat",
+            targets: ["SwiftUIChat"])
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "OpenUILang"),
+        .target(
+            name: "OpenUISwiftUI",
+            dependencies: ["OpenUILang"]),
+        .executableTarget(
+            name: "SwiftUIChat",
+            dependencies: ["OpenUILang", "OpenUISwiftUI"])
+    ]
+)

--- a/packages/swift/Sources/OpenUILang/AST.swift
+++ b/packages/swift/Sources/OpenUILang/AST.swift
@@ -1,0 +1,40 @@
+public indirect enum ASTNode {
+    case comp(name: String, args: [ASTNode], mappedProps: [String: ASTNode]?)
+    case str(String)
+    case num(Double)
+    case bool(Bool)
+    case null
+    case arr([ASTNode])
+    case obj([(String, ASTNode)])
+    case ref(String)
+    case ph(String)
+    case stateRef(String)
+    case runtimeRef(name: String, refType: String)
+    case binOp(op: String, left: ASTNode, right: ASTNode)
+    case unaryOp(op: String, operand: ASTNode)
+    case ternary(cond: ASTNode, then: ASTNode, `else`: ASTNode)
+    case member(obj: ASTNode, field: String)
+    case index(obj: ASTNode, index: ASTNode)
+    case assign(target: String, value: ASTNode)
+
+    public var isRuntimeExpr: Bool {
+        switch self {
+        case .stateRef, .runtimeRef, .binOp, .unaryOp, .ternary, .member, .index, .assign:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+public struct CallNode {
+    public let callee: String
+    public let args: [ASTNode]
+}
+
+public enum Statement {
+    case value(id: String, expr: ASTNode)
+    case state(id: String, initExpr: ASTNode)
+    case query(id: String, call: CallNode, expr: ASTNode, deps: [String]?)
+    case mutation(id: String, call: CallNode, expr: ASTNode)
+}

--- a/packages/swift/Sources/OpenUILang/Library.swift
+++ b/packages/swift/Sources/OpenUILang/Library.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public struct ComponentDef {
+    public let name: String
+    public let description: String
+    public let signature: String
+    
+    public init(name: String, description: String, signature: String) {
+        self.name = name
+        self.description = description
+        self.signature = signature
+    }
+}
+
+public protocol AnyComponentRenderer {
+    // In OpenUISwiftUI we will cast this to AnyView
+    func render(props: [String: Any], children: [Any]) -> Any
+}
+
+public class ComponentLibrary {
+    public private(set) var components: [String: ComponentDef] = [:]
+    public var root: String?
+    
+    public init() {}
+    
+    public func register(component: ComponentDef) {
+        components[component.name] = component
+    }
+    
+    public func setRoot(_ root: String) {
+        self.root = root
+    }
+}

--- a/packages/swift/Sources/OpenUILang/Library.swift
+++ b/packages/swift/Sources/OpenUILang/Library.swift
@@ -4,11 +4,33 @@ public struct ComponentDef {
     public let name: String
     public let description: String
     public let signature: String
+    public let params: [String]
     
     public init(name: String, description: String, signature: String) {
         self.name = name
         self.description = description
         self.signature = signature
+        
+        // Extract parameter names from signature, e.g., "Button(label: String, action: String)" -> ["label", "action"]
+        // "VStack(children: [Any])" -> ["children"]
+        var extractedParams: [String] = []
+        if let startRange = signature.range(of: "("), let endRange = signature.range(of: ")", options: .backwards, range: startRange.upperBound..<signature.endIndex) {
+            let argsString = String(signature[startRange.upperBound..<endRange.lowerBound])
+            let args = argsString.split(separator: ",")
+            for arg in args {
+                let trimmed = arg.trimmingCharacters(in: .whitespaces)
+                if let colonRange = trimmed.range(of: ":") {
+                    let paramName = String(trimmed[..<colonRange.lowerBound]).trimmingCharacters(in: .whitespaces)
+                    extractedParams.append(paramName)
+                } else {
+                    let parts = trimmed.split(separator: " ")
+                    if let first = parts.first {
+                        extractedParams.append(String(first).trimmingCharacters(in: .whitespaces))
+                    }
+                }
+            }
+        }
+        self.params = extractedParams
     }
 }
 

--- a/packages/swift/Sources/OpenUILang/Library.swift
+++ b/packages/swift/Sources/OpenUILang/Library.swift
@@ -5,11 +5,13 @@ public struct ComponentDef {
     public let description: String
     public let signature: String
     public let params: [String]
+    public let renderer: AnyComponentRenderer?
     
-    public init(name: String, description: String, signature: String) {
+    public init(name: String, description: String, signature: String, renderer: AnyComponentRenderer? = nil) {
         self.name = name
         self.description = description
         self.signature = signature
+        self.renderer = renderer
         
         // Extract parameter names from signature, e.g., "Button(label: String, action: String)" -> ["label", "action"]
         // "VStack(children: [Any])" -> ["children"]
@@ -37,6 +39,16 @@ public struct ComponentDef {
 public protocol AnyComponentRenderer {
     // In OpenUISwiftUI we will cast this to AnyView
     func render(props: [String: Any], children: [Any]) -> Any
+}
+
+public struct ClosureComponentRenderer: AnyComponentRenderer {
+    public let closure: ([String: Any], [Any]) -> Any
+    public init(_ closure: @escaping ([String: Any], [Any]) -> Any) {
+        self.closure = closure
+    }
+    public func render(props: [String: Any], children: [Any]) -> Any {
+        return closure(props, children)
+    }
 }
 
 public class ComponentLibrary {

--- a/packages/swift/Sources/OpenUILang/Parser.swift
+++ b/packages/swift/Sources/OpenUILang/Parser.swift
@@ -3,10 +3,12 @@ import Foundation
 public class Parser {
     private var input: String
     private var index: String.Index
+    public var library: ComponentLibrary?
     
-    public init() {
+    public init(library: ComponentLibrary? = nil) {
         self.input = ""
         self.index = "".startIndex
+        self.library = library
     }
     
     public func parse(_ text: String) -> ParseResult {
@@ -14,17 +16,37 @@ public class Parser {
         self.index = text.startIndex
         
         var statements: [Statement] = []
+        var context: [String: ASTNode] = [:]
         
         while index < input.endIndex {
             skipWhitespace()
             guard index < input.endIndex else { break }
             
-            if let id = parseIdentifier() {
+            if input[index] == "$" {
+                advance()
+                if let id = parseIdentifier() {
+                    skipWhitespace()
+                    if match("=") {
+                        skipWhitespace()
+                        if let expr = parseExpression() {
+                            statements.append(.state(id: id, initExpr: expr))
+                            context[id] = expr
+                        }
+                    }
+                }
+            } else if let id = parseIdentifier() {
                 skipWhitespace()
                 if match("=") {
                     skipWhitespace()
                     if let expr = parseExpression() {
-                        statements.append(.value(id: id, expr: expr))
+                        if case let .comp(name, _, _) = expr, name == "Query" {
+                            statements.append(.query(id: id, call: CallNode(callee: name, args: []), expr: expr, deps: nil))
+                        } else if case let .comp(name, _, _) = expr, name == "Mutation" {
+                            statements.append(.mutation(id: id, call: CallNode(callee: name, args: []), expr: expr))
+                        } else {
+                            statements.append(.value(id: id, expr: expr))
+                            context[id] = expr
+                        }
                     }
                 }
             } else {
@@ -34,13 +56,19 @@ public class Parser {
         }
         
         var rootNode: ElementNode? = nil
-        if let rootStmt = statements.first(where: {
+        let entryId = statements.first(where: {
             if case let .value(id, _) = $0 { return id == "root" }
             return false
-        }) {
-            if case let .value(_, expr) = rootStmt {
-                rootNode = materialize(expr)
-            }
+        }) != nil ? "root" : statements.first(where: { 
+            if case .value = $0 { return true }
+            return false
+        }).flatMap { 
+            if case let .value(id, _) = $0 { return id }
+            return nil
+        }
+        
+        if let entryId = entryId, let rootExpr = context[entryId] {
+            rootNode = materialize(rootExpr, context: context, statementId: entryId)
         }
         
         let meta = ParseResultMeta(incomplete: false, unresolved: [], orphaned: [], statementCount: statements.count, errors: [])
@@ -48,6 +76,24 @@ public class Parser {
     }
     
     private func parseExpression() -> ASTNode? {
+        guard let primary = parsePrimaryExpression() else { return nil }
+        
+        skipWhitespace()
+        if match("?") {
+            skipWhitespace()
+            guard let thenExpr = parseExpression() else { return primary }
+            skipWhitespace()
+            if match(":") {
+                skipWhitespace()
+                guard let elseExpr = parseExpression() else { return primary }
+                return .ternary(cond: primary, then: thenExpr, else: elseExpr)
+            }
+        }
+        
+        return primary
+    }
+    
+    private func parsePrimaryExpression() -> ASTNode? {
         skipWhitespace()
         if index >= input.endIndex { return nil }
         
@@ -56,6 +102,12 @@ public class Parser {
             return .str(parseString())
         } else if c == "[" {
             return .arr(parseArray())
+        } else if c == "$" {
+            advance()
+            if let ident = parseIdentifier() {
+                return .stateRef(ident)
+            }
+            return nil
         } else if c.isNumber {
             return .num(parseNumber())
         } else if input[index...].hasPrefix("true") {
@@ -117,16 +169,15 @@ public class Parser {
             skipWhitespace()
             if match(")") { break }
             
-            // Try to parse named arg: ident: expr
             let startIdx = index
             if let ident = parseIdentifier() {
                 skipWhitespace()
                 if match(":") {
+                    skipWhitespace()
                     if let expr = parseExpression() {
                         props[ident] = expr
                     }
                 } else {
-                    // It was just an expression
                     index = startIdx
                     if let expr = parseExpression() {
                         args.append(expr)
@@ -173,25 +224,71 @@ public class Parser {
         index = input.index(index, offsetBy: count, limitedBy: input.endIndex) ?? input.endIndex
     }
     
-    private func materialize(_ node: ASTNode) -> ElementNode? {
-        if case let .comp(name, _, mappedProps) = node {
+    private func materialize(_ node: ASTNode, context: [String: ASTNode], statementId: String? = nil) -> ElementNode? {
+        switch node {
+        case let .ref(ident):
+            if let refNode = context[ident] {
+                return materialize(refNode, context: context, statementId: ident)
+            }
+            return nil
+        case let .comp(name, args, mappedProps):
             var propsMap: [String: Any] = [:]
-            if let mProps = mappedProps {
-                for (k, v) in mProps {
-                    if case let .str(s) = v { propsMap[k] = s }
-                    else if case let .num(n) = v { propsMap[k] = n }
-                    else if case let .bool(b) = v { propsMap[k] = b }
-                    else if case let .arr(arr) = v {
-                        propsMap[k] = arr.compactMap { materialize($0) }
-                    } else if case .comp = v {
-                        if let child = materialize(v) {
-                            propsMap[k] = [child] // simplified
+            var finalMappedProps = mappedProps ?? [:]
+            
+            if let library = self.library, let compDef = library.components[name] {
+                for (i, arg) in args.enumerated() {
+                    if i < compDef.params.count {
+                        let paramName = compDef.params[i]
+                        if finalMappedProps[paramName] == nil {
+                            finalMappedProps[paramName] = arg
                         }
                     }
                 }
+            } else {
+                // If no library is provided, fallback to "children" for the first arg if it's an array
+                if args.count > 0 && finalMappedProps["children"] == nil {
+                    finalMappedProps["children"] = args[0]
+                }
             }
-            return ElementNode(statementId: nil, typeName: name, props: propsMap, partial: false)
+            
+            for (k, v) in finalMappedProps {
+                if let val = materializeValue(v, context: context) {
+                    propsMap[k] = val
+                }
+            }
+            return ElementNode(statementId: statementId, typeName: name, props: propsMap, partial: false)
+        default:
+            return nil
         }
-        return nil
+    }
+    
+    private func materializeValue(_ node: ASTNode, context: [String: ASTNode]) -> Any? {
+        switch node {
+        case let .str(s): return s
+        case let .num(n): return n
+        case let .bool(b): return b
+        case let .arr(arr): 
+            return arr.compactMap { materializeValue($0, context: context) }
+        case .comp: 
+            if let el = materialize(node, context: context) {
+                // For OpenUI Lang, children components are usually wrapped in arrays, but if not we might need it.
+                // Just return the element node itself.
+                return el
+            }
+            return nil
+        case let .ref(ident):
+            if let resolved = context[ident] {
+                if case .comp = resolved {
+                    return materialize(resolved, context: context, statementId: ident)
+                }
+                return materializeValue(resolved, context: context)
+            }
+            return nil
+        case let .stateRef(ident):
+            return "$\(ident)" // Simplified placeholder for dynamic state
+        case .ternary:
+            return "$ternary" // Simplified placeholder
+        default: return nil
+        }
     }
 }

--- a/packages/swift/Sources/OpenUILang/Parser.swift
+++ b/packages/swift/Sources/OpenUILang/Parser.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public class Parser {
+    private var input: String
+    private var index: String.Index
+    
+    public init() {
+        self.input = ""
+        self.index = "".startIndex
+    }
+    
+    public func parse(_ text: String) -> ParseResult {
+        self.input = text
+        self.index = text.startIndex
+        
+        var statements: [Statement] = []
+        
+        while index < input.endIndex {
+            skipWhitespace()
+            guard index < input.endIndex else { break }
+            
+            if let id = parseIdentifier() {
+                skipWhitespace()
+                if match("=") {
+                    skipWhitespace()
+                    if let expr = parseExpression() {
+                        statements.append(.value(id: id, expr: expr))
+                    }
+                }
+            } else {
+                // Skip unparseable tokens
+                index = input.index(after: index)
+            }
+        }
+        
+        var rootNode: ElementNode? = nil
+        if let rootStmt = statements.first(where: {
+            if case let .value(id, _) = $0 { return id == "root" }
+            return false
+        }) {
+            if case let .value(_, expr) = rootStmt {
+                rootNode = materialize(expr)
+            }
+        }
+        
+        let meta = ParseResultMeta(incomplete: false, unresolved: [], orphaned: [], statementCount: statements.count, errors: [])
+        return ParseResult(root: rootNode, meta: meta, stateDeclarations: [:], queryStatements: [], mutationStatements: [])
+    }
+    
+    private func parseExpression() -> ASTNode? {
+        skipWhitespace()
+        if index >= input.endIndex { return nil }
+        
+        let c = input[index]
+        if c == "\"" {
+            return .str(parseString())
+        } else if c == "[" {
+            return .arr(parseArray())
+        } else if c.isNumber {
+            return .num(parseNumber())
+        } else if input[index...].hasPrefix("true") {
+            advance(by: 4); return .bool(true)
+        } else if input[index...].hasPrefix("false") {
+            advance(by: 5); return .bool(false)
+        } else if let ident = parseIdentifier() {
+            skipWhitespace()
+            if match("(") {
+                let args = parseArguments()
+                return .comp(name: ident, args: args.0, mappedProps: args.1)
+            } else {
+                return .ref(ident)
+            }
+        }
+        return nil
+    }
+    
+    private func parseString() -> String {
+        advance() // skip "
+        var result = ""
+        while index < input.endIndex && input[index] != "\"" {
+            result.append(input[index])
+            advance()
+        }
+        if index < input.endIndex { advance() } // skip "
+        return result
+    }
+    
+    private func parseNumber() -> Double {
+        var result = ""
+        while index < input.endIndex && (input[index].isNumber || input[index] == ".") {
+            result.append(input[index])
+            advance()
+        }
+        return Double(result) ?? 0
+    }
+    
+    private func parseArray() -> [ASTNode] {
+        advance() // skip [
+        var elements: [ASTNode] = []
+        while index < input.endIndex {
+            skipWhitespace()
+            if match("]") { break }
+            if let expr = parseExpression() {
+                elements.append(expr)
+            }
+            skipWhitespace()
+            _ = match(",")
+        }
+        return elements
+    }
+    
+    private func parseArguments() -> ([ASTNode], [String: ASTNode]) {
+        var args: [ASTNode] = []
+        var props: [String: ASTNode] = [:]
+        
+        while index < input.endIndex {
+            skipWhitespace()
+            if match(")") { break }
+            
+            // Try to parse named arg: ident: expr
+            let startIdx = index
+            if let ident = parseIdentifier() {
+                skipWhitespace()
+                if match(":") {
+                    if let expr = parseExpression() {
+                        props[ident] = expr
+                    }
+                } else {
+                    // It was just an expression
+                    index = startIdx
+                    if let expr = parseExpression() {
+                        args.append(expr)
+                    }
+                }
+            } else {
+                if let expr = parseExpression() {
+                    args.append(expr)
+                }
+            }
+            
+            skipWhitespace()
+            _ = match(",")
+        }
+        
+        return (args, props)
+    }
+    
+    private func parseIdentifier() -> String? {
+        guard index < input.endIndex, input[index].isLetter || input[index] == "_" else { return nil }
+        var result = ""
+        while index < input.endIndex && (input[index].isLetter || input[index].isNumber || input[index] == "_") {
+            result.append(input[index])
+            advance()
+        }
+        return result
+    }
+    
+    private func skipWhitespace() {
+        while index < input.endIndex && input[index].isWhitespace {
+            advance()
+        }
+    }
+    
+    private func match(_ str: String) -> Bool {
+        if input[index...].hasPrefix(str) {
+            advance(by: str.count)
+            return true
+        }
+        return false
+    }
+    
+    private func advance(by count: Int = 1) {
+        index = input.index(index, offsetBy: count, limitedBy: input.endIndex) ?? input.endIndex
+    }
+    
+    private func materialize(_ node: ASTNode) -> ElementNode? {
+        if case let .comp(name, _, mappedProps) = node {
+            var propsMap: [String: Any] = [:]
+            if let mProps = mappedProps {
+                for (k, v) in mProps {
+                    if case let .str(s) = v { propsMap[k] = s }
+                    else if case let .num(n) = v { propsMap[k] = n }
+                    else if case let .bool(b) = v { propsMap[k] = b }
+                    else if case let .arr(arr) = v {
+                        propsMap[k] = arr.compactMap { materialize($0) }
+                    } else if case .comp = v {
+                        if let child = materialize(v) {
+                            propsMap[k] = [child] // simplified
+                        }
+                    }
+                }
+            }
+            return ElementNode(statementId: nil, typeName: name, props: propsMap, partial: false)
+        }
+        return nil
+    }
+}

--- a/packages/swift/Sources/OpenUILang/Parser.swift
+++ b/packages/swift/Sources/OpenUILang/Parser.swift
@@ -17,11 +17,14 @@ public class Parser {
         
         var statements: [Statement] = []
         var context: [String: ASTNode] = [:]
+        var queryStatements: [QueryStatementInfo] = []
+        var mutationStatements: [MutationStatementInfo] = []
         
         while index < input.endIndex {
             skipWhitespace()
             guard index < input.endIndex else { break }
             
+            let startIdx = index
             if input[index] == "$" {
                 advance()
                 if let id = parseIdentifier() {
@@ -31,6 +34,7 @@ public class Parser {
                         if let expr = parseExpression() {
                             statements.append(.state(id: id, initExpr: expr))
                             context[id] = expr
+                            continue
                         }
                     }
                 }
@@ -39,19 +43,43 @@ public class Parser {
                 if match("=") {
                     skipWhitespace()
                     if let expr = parseExpression() {
-                        if case let .comp(name, _, _) = expr, name == "Query" {
-                            statements.append(.query(id: id, call: CallNode(callee: name, args: []), expr: expr, deps: nil))
-                        } else if case let .comp(name, _, _) = expr, name == "Mutation" {
-                            statements.append(.mutation(id: id, call: CallNode(callee: name, args: []), expr: expr))
+                        if case let .comp(name, args, _) = expr, name == "Query" {
+                            let deps = collectQueryDeps(expr)
+                            let call = CallNode(callee: name, args: args)
+                            statements.append(.query(id: id, call: call, expr: expr, deps: deps.isEmpty ? nil : deps))
+                            
+                            let info = QueryStatementInfo(
+                                statementId: id,
+                                toolAST: args.count > 0 ? args[0] : nil,
+                                argsAST: args.count > 1 ? args[1] : nil,
+                                defaultsAST: args.count > 2 ? args[2] : nil,
+                                refreshAST: args.count > 3 ? args[3] : nil,
+                                deps: deps.isEmpty ? nil : deps,
+                                complete: true
+                            )
+                            queryStatements.append(info)
+                        } else if case let .comp(name, args, _) = expr, name == "Mutation" {
+                            let call = CallNode(callee: name, args: args)
+                            statements.append(.mutation(id: id, call: call, expr: expr))
+                            
+                            let info = MutationStatementInfo(
+                                statementId: id,
+                                toolAST: args.count > 0 ? args[0] : nil,
+                                argsAST: args.count > 1 ? args[1] : nil
+                            )
+                            mutationStatements.append(info)
                         } else {
                             statements.append(.value(id: id, expr: expr))
                             context[id] = expr
                         }
+                        continue
                     }
                 }
-            } else {
-                // Skip unparseable tokens
-                index = input.index(after: index)
+            }
+            
+            // If we failed to parse a statement, skip one character to avoid infinite loops
+            if index == startIdx {
+                advance()
             }
         }
         
@@ -67,12 +95,52 @@ public class Parser {
             return nil
         }
         
+        var errors: [ValidationError] = []
+        var visited: Set<String> = []
+        
         if let entryId = entryId, let rootExpr = context[entryId] {
-            rootNode = materialize(rootExpr, context: context, statementId: entryId)
+            rootNode = materialize(rootExpr, context: context, statementId: entryId, visited: &visited, errors: &errors)
         }
         
-        let meta = ParseResultMeta(incomplete: false, unresolved: [], orphaned: [], statementCount: statements.count, errors: [])
-        return ParseResult(root: rootNode, meta: meta, stateDeclarations: [:], queryStatements: [], mutationStatements: [])
+        let meta = ParseResultMeta(incomplete: false, unresolved: [], orphaned: [], statementCount: statements.count, errors: errors)
+        return ParseResult(root: rootNode, meta: meta, stateDeclarations: [:], queryStatements: queryStatements, mutationStatements: mutationStatements)
+    }
+    
+    private func collectQueryDeps(_ node: ASTNode) -> [String] {
+        var deps: [String] = []
+        func walk(_ current: ASTNode) {
+            if case let .stateRef(id) = current {
+                deps.append(id)
+            }
+            switch current {
+            case let .comp(_, args, mappedProps):
+                args.forEach(walk)
+                mappedProps?.values.forEach(walk)
+            case let .arr(arr):
+                arr.forEach(walk)
+            case let .obj(dict):
+                dict.forEach { walk($0.1) }
+            case let .binOp(_, left, right):
+                walk(left)
+                walk(right)
+            case let .unaryOp(_, operand):
+                walk(operand)
+            case let .ternary(cond, then, els):
+                walk(cond)
+                walk(then)
+                walk(els)
+            case let .member(obj, _):
+                walk(obj)
+            case let .index(obj, index):
+                walk(obj)
+                walk(index)
+            case let .assign(_, value):
+                walk(value)
+            default: break
+            }
+        }
+        walk(node)
+        return deps
     }
     
     private func parseExpression() -> ASTNode? {
@@ -100,6 +168,8 @@ public class Parser {
         let c = input[index]
         if c == "\"" {
             return .str(parseString())
+        } else if c == "{" {
+            return .obj(parseObject())
         } else if c == "[" {
             return .arr(parseArray())
         } else if c == "$" {
@@ -108,8 +178,22 @@ public class Parser {
                 return .stateRef(ident)
             }
             return nil
-        } else if c.isNumber {
+        } else if c == "@" {
+            advance()
+            if let ident = parseIdentifier() {
+                skipWhitespace()
+                if match("(") {
+                    let args = parseArguments()
+                    return .comp(name: "@" + ident, args: args.0, mappedProps: args.1)
+                } else {
+                    return .ref("@" + ident)
+                }
+            }
+            return nil
+        } else if c == "-" || c.isNumber {
             return .num(parseNumber())
+        } else if input[index...].hasPrefix("null") {
+            advance(by: 4); return .null
         } else if input[index...].hasPrefix("true") {
             advance(by: 4); return .bool(true)
         } else if input[index...].hasPrefix("false") {
@@ -120,18 +204,44 @@ public class Parser {
                 let args = parseArguments()
                 return .comp(name: ident, args: args.0, mappedProps: args.1)
             } else {
-                return .ref(ident)
+                return parseMemberAccess(base: .ref(ident))
             }
         }
         return nil
+    }
+    
+    private func parseMemberAccess(base: ASTNode) -> ASTNode {
+        var current = base
+        while index < input.endIndex {
+            skipWhitespace()
+            if match(".") {
+                skipWhitespace()
+                if let field = parseIdentifier() {
+                    current = .member(obj: current, field: field)
+                } else {
+                    break
+                }
+            } else {
+                break
+            }
+        }
+        return current
     }
     
     private func parseString() -> String {
         advance() // skip "
         var result = ""
         while index < input.endIndex && input[index] != "\"" {
-            result.append(input[index])
-            advance()
+            if input[index] == "\\" {
+                advance()
+                if index < input.endIndex {
+                    result.append(input[index])
+                    advance()
+                }
+            } else {
+                result.append(input[index])
+                advance()
+            }
         }
         if index < input.endIndex { advance() } // skip "
         return result
@@ -139,11 +249,45 @@ public class Parser {
     
     private func parseNumber() -> Double {
         var result = ""
+        if index < input.endIndex && input[index] == "-" {
+            result.append("-")
+            advance()
+        }
         while index < input.endIndex && (input[index].isNumber || input[index] == ".") {
             result.append(input[index])
             advance()
         }
         return Double(result) ?? 0
+    }
+    
+    private func parseObject() -> [(String, ASTNode)] {
+        advance() // skip {
+        var properties: [(String, ASTNode)] = []
+        while index < input.endIndex {
+            skipWhitespace()
+            if match("}") { break }
+            let startIdx = index
+            if let key = parseIdentifier() ?? parseStringKey() {
+                skipWhitespace()
+                if match(":") {
+                    skipWhitespace()
+                    if let expr = parseExpression() {
+                        properties.append((key, expr))
+                    }
+                }
+            }
+            if index == startIdx { advance() } // avoid infinite loop
+            skipWhitespace()
+            _ = match(",")
+        }
+        return properties
+    }
+    
+    private func parseStringKey() -> String? {
+        if index < input.endIndex && input[index] == "\"" {
+            return parseString()
+        }
+        return nil
     }
     
     private func parseArray() -> [ASTNode] {
@@ -152,9 +296,11 @@ public class Parser {
         while index < input.endIndex {
             skipWhitespace()
             if match("]") { break }
+            let startIdx = index
             if let expr = parseExpression() {
                 elements.append(expr)
             }
+            if index == startIdx { advance() } // avoid infinite loop
             skipWhitespace()
             _ = match(",")
         }
@@ -188,6 +334,7 @@ public class Parser {
                     args.append(expr)
                 }
             }
+            if index == startIdx { advance() } // avoid infinite loop
             
             skipWhitespace()
             _ = match(",")
@@ -224,16 +371,22 @@ public class Parser {
         index = input.index(index, offsetBy: count, limitedBy: input.endIndex) ?? input.endIndex
     }
     
-    private func materialize(_ node: ASTNode, context: [String: ASTNode], statementId: String? = nil) -> ElementNode? {
+    private func materialize(_ node: ASTNode, context: [String: ASTNode], statementId: String? = nil, visited: inout Set<String>, errors: inout [ValidationError]) -> ElementNode? {
         switch node {
         case let .ref(ident):
+            if visited.contains(ident) { return nil } // cycle detection
+            visited.insert(ident)
+            defer { visited.remove(ident) }
+            
             if let refNode = context[ident] {
-                return materialize(refNode, context: context, statementId: ident)
+                return materialize(refNode, context: context, statementId: ident, visited: &visited, errors: &errors)
             }
             return nil
         case let .comp(name, args, mappedProps):
             var propsMap: [String: Any] = [:]
             var finalMappedProps = mappedProps ?? [:]
+            
+            var hasDynamicProps = false
             
             if let library = self.library, let compDef = library.components[name] {
                 for (i, arg) in args.enumerated() {
@@ -249,45 +402,57 @@ public class Parser {
                 if args.count > 0 && finalMappedProps["children"] == nil {
                     finalMappedProps["children"] = args[0]
                 }
+                
+                errors.append(ValidationError(code: .unknownComponent, component: name, path: "", message: "Unknown component \(name)", statementId: statementId))
             }
             
             for (k, v) in finalMappedProps {
-                if let val = materializeValue(v, context: context) {
+                if v.isRuntimeExpr {
+                    propsMap[k] = v // retain AST
+                    hasDynamicProps = true
+                } else if let val = materializeValue(v, context: context, visited: &visited, errors: &errors) {
                     propsMap[k] = val
                 }
             }
-            return ElementNode(statementId: statementId, typeName: name, props: propsMap, partial: false)
+            return ElementNode(statementId: statementId, typeName: name, props: propsMap, partial: false, hasDynamicProps: hasDynamicProps)
         default:
             return nil
         }
     }
     
-    private func materializeValue(_ node: ASTNode, context: [String: ASTNode]) -> Any? {
+    private func materializeValue(_ node: ASTNode, context: [String: ASTNode], visited: inout Set<String>, errors: inout [ValidationError]) -> Any? {
         switch node {
         case let .str(s): return s
         case let .num(n): return n
         case let .bool(b): return b
+        case .null: return nil
         case let .arr(arr): 
-            return arr.compactMap { materializeValue($0, context: context) }
+            return arr.compactMap { materializeValue($0, context: context, visited: &visited, errors: &errors) }
+        case let .obj(dict):
+            var res: [String: Any] = [:]
+            for (k, v) in dict {
+                res[k] = materializeValue(v, context: context, visited: &visited, errors: &errors)
+            }
+            return res
         case .comp: 
-            if let el = materialize(node, context: context) {
-                // For OpenUI Lang, children components are usually wrapped in arrays, but if not we might need it.
-                // Just return the element node itself.
+            if let el = materialize(node, context: context, visited: &visited, errors: &errors) {
                 return el
             }
             return nil
         case let .ref(ident):
+            if visited.contains(ident) { return nil } // cycle detection
+            visited.insert(ident)
+            defer { visited.remove(ident) }
+            
             if let resolved = context[ident] {
                 if case .comp = resolved {
-                    return materialize(resolved, context: context, statementId: ident)
+                    return materialize(resolved, context: context, statementId: ident, visited: &visited, errors: &errors)
                 }
-                return materializeValue(resolved, context: context)
+                return materializeValue(resolved, context: context, visited: &visited, errors: &errors)
             }
             return nil
-        case let .stateRef(ident):
-            return "$\(ident)" // Simplified placeholder for dynamic state
-        case .ternary:
-            return "$ternary" // Simplified placeholder
+        case .stateRef, .ternary, .binOp, .unaryOp, .member, .index, .assign:
+            return node // Retain ASTNode for dynamic expressions
         default: return nil
         }
     }

--- a/packages/swift/Sources/OpenUILang/PromptGenerator.swift
+++ b/packages/swift/Sources/OpenUILang/PromptGenerator.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public struct PromptOptions {
+    public var preamble: String?
+    public var additionalRules: [String]?
+    public var examples: [String]?
+    public var toolExamples: [String]?
+    public var tools: [String]?
+    
+    public init(preamble: String? = nil, additionalRules: [String]? = nil, examples: [String]? = nil, toolExamples: [String]? = nil, tools: [String]? = nil) {
+        self.preamble = preamble
+        self.additionalRules = additionalRules
+        self.examples = examples
+        self.toolExamples = toolExamples
+        self.tools = tools
+    }
+}
+
+public class PromptGenerator {
+    public static func generatePrompt(library: ComponentLibrary, options: PromptOptions? = nil) -> String {
+        var prompt = ""
+        
+        if let preamble = options?.preamble {
+            prompt += preamble + "\n\n"
+        } else {
+            prompt += "You are a UI generation assistant. Respond ONLY with valid OpenUI Lang code.\n\n"
+        }
+        
+        prompt += "### Components\n\n"
+        for (_, comp) in library.components.sorted(by: { $0.key < $1.key }) {
+            prompt += "- \(comp.signature): \(comp.description)\n"
+        }
+        
+        if let root = library.root {
+            prompt += "\nRoot Component: \(root)\n"
+        }
+        
+        if let rules = options?.additionalRules, !rules.isEmpty {
+            prompt += "\n### Rules\n"
+            for rule in rules {
+                prompt += "- \(rule)\n"
+            }
+        }
+        
+        return prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/packages/swift/Sources/OpenUILang/Types.swift
+++ b/packages/swift/Sources/OpenUILang/Types.swift
@@ -1,0 +1,83 @@
+public enum ValidationErrorCode: String {
+    case missingRequired = "missing-required"
+    case nullRequired = "null-required"
+    case unknownComponent = "unknown-component"
+    case inlineReserved = "inline-reserved"
+    case excessArgs = "excess-args"
+}
+
+public struct ValidationError: Equatable {
+    public let code: ValidationErrorCode
+    public let component: String
+    public let path: String
+    public let message: String
+    public let statementId: String?
+}
+
+public struct ElementNode: Equatable {
+    public let type = "element"
+    public let statementId: String?
+    public let typeName: String
+    // In Swift we can use Any, but Equatable with Any is tricky.
+    // For now we'll represent props as [String: AnyHashable] or a custom enum value if needed.
+    // We can also use a generic AnyCodable if we bring one in. Let's use `[String: Any]` and skip Equatable for now, or just implement it.
+    public let props: [String: Any]
+    public let partial: Bool
+    public let hasDynamicProps: Bool?
+
+    public init(statementId: String?, typeName: String, props: [String: Any], partial: Bool, hasDynamicProps: Bool? = nil) {
+        self.statementId = statementId
+        self.typeName = typeName
+        self.props = props
+        self.partial = partial
+        self.hasDynamicProps = hasDynamicProps
+    }
+
+    public static func == (lhs: ElementNode, rhs: ElementNode) -> Bool {
+        lhs.statementId == rhs.statementId &&
+        lhs.typeName == rhs.typeName &&
+        lhs.partial == rhs.partial &&
+        lhs.hasDynamicProps == rhs.hasDynamicProps
+        // skipping deep prop equality for now
+    }
+}
+
+public struct ParseResultMeta {
+    public let incomplete: Bool
+    public let unresolved: [String]
+    public let orphaned: [String]
+    public let statementCount: Int
+    public let errors: [ValidationError]
+}
+
+public struct QueryStatementInfo {
+    public let statementId: String
+    public let toolAST: ASTNode?
+    public let argsAST: ASTNode?
+    public let defaultsAST: ASTNode?
+    public let refreshAST: ASTNode?
+    public let deps: [String]?
+    public let complete: Bool
+}
+
+public struct MutationStatementInfo {
+    public let statementId: String
+    public let toolAST: ASTNode?
+    public let argsAST: ASTNode?
+}
+
+public struct ParseResult {
+    public let root: ElementNode?
+    public let meta: ParseResultMeta
+    public let stateDeclarations: [String: Any]
+    public let queryStatements: [QueryStatementInfo]
+    public let mutationStatements: [MutationStatementInfo]
+}
+
+public struct ParamDef {
+    public let name: String
+    public let required: Bool
+    public let defaultValue: Any?
+}
+
+public typealias ParamMap = [String: [ParamDef]]

--- a/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
+++ b/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
@@ -6,10 +6,12 @@ import OpenUILang
 public struct OpenUIRenderer: View {
     let node: ElementNode?
     let library: ComponentLibrary
+    let actionHandler: ((String, [String: Any]) -> Void)?
 
-    public init(node: ElementNode?, library: ComponentLibrary) {
+    public init(node: ElementNode?, library: ComponentLibrary, actionHandler: ((String, [String: Any]) -> Void)? = nil) {
         self.node = node
         self.library = library
+        self.actionHandler = actionHandler
     }
     
     public var body: some View {
@@ -35,8 +37,11 @@ public struct OpenUIRenderer: View {
             return AnyView(Text((node.props["text"] as? String) ?? ""))
         case "Button":
             return AnyView(Button(action: {
-                // Action handling
-                print("Button clicked: \(node.props["label"] as? String ?? "")")
+                if let action = node.props["action"] as? String {
+                    actionHandler?(action, node.props)
+                } else {
+                    print("Button clicked: \(node.props["label"] as? String ?? "")")
+                }
             }) {
                 Text((node.props["label"] as? String) ?? "Button")
             })

--- a/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
+++ b/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+#if canImport(OpenUILang)
+import OpenUILang
+#endif
+
+public struct OpenUIRenderer: View {
+    let node: ElementNode?
+    let library: ComponentLibrary
+
+    public init(node: ElementNode?, library: ComponentLibrary) {
+        self.node = node
+        self.library = library
+    }
+    
+    public var body: some View {
+        if let node = node {
+            renderNode(node)
+        } else {
+            AnyView(Text("No UI to render")
+                .foregroundColor(.gray))
+        }
+    }
+    
+    private func renderNode(_ node: ElementNode) -> AnyView {
+        switch node.typeName {
+        case "VStack":
+            return AnyView(VStack {
+                renderChildren(node.props["children"] as? [ElementNode])
+            })
+        case "HStack":
+            return AnyView(HStack {
+                renderChildren(node.props["children"] as? [ElementNode])
+            })
+        case "Text":
+            return AnyView(Text((node.props["text"] as? String) ?? ""))
+        case "Button":
+            return AnyView(Button(action: {
+                // Action handling
+                print("Button clicked: \(node.props["label"] as? String ?? "")")
+            }) {
+                Text((node.props["label"] as? String) ?? "Button")
+            })
+        default:
+            return AnyView(Text("Unknown component: \(node.typeName)")
+                .foregroundColor(.red))
+        }
+    }
+    
+    @ViewBuilder
+    private func renderChildren(_ children: [ElementNode]?) -> some View {
+        if let children = children {
+            ForEach(0..<children.count, id: \.self) { index in
+                renderNode(children[index])
+            }
+        }
+    }
+}

--- a/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
+++ b/packages/swift/Sources/OpenUISwiftUI/OpenUIRenderer.swift
@@ -24,6 +24,12 @@ public struct OpenUIRenderer: View {
     }
     
     private func renderNode(_ node: ElementNode) -> AnyView {
+        if let def = library.components[node.typeName], let renderer = def.renderer {
+            if let customView = renderer.render(props: node.props, children: node.props["children"] as? [Any] ?? []) as? AnyView {
+                return customView
+            }
+        }
+        
         switch node.typeName {
         case "VStack":
             return AnyView(VStack {

--- a/packages/swift/Sources/SwiftUIChat/App.swift
+++ b/packages/swift/Sources/SwiftUIChat/App.swift
@@ -16,15 +16,20 @@ struct ContentView: View {
     @State private var openUIText = ""
     @State private var parsedRoot: ElementNode? = nil
     @State private var prompt = ""
+    @State private var showingAlert = false
+    @State private var alertMessage = ""
     
-    let parser = Parser()
+    // We create parser on demand or as a lazy property since library can change, but since library is basically static here:
+    var parser: Parser {
+        Parser(library: library)
+    }
     
     init() {
-        var lib = ComponentLibrary()
+        let lib = ComponentLibrary()
         lib.register(component: ComponentDef(name: "VStack", description: "Vertical layout container", signature: "VStack(children: [Any])"))
         lib.register(component: ComponentDef(name: "HStack", description: "Horizontal layout container", signature: "HStack(children: [Any])"))
         lib.register(component: ComponentDef(name: "Text", description: "Text display", signature: "Text(text: String)"))
-        lib.register(component: ComponentDef(name: "Button", description: "Clickable button", signature: "Button(label: String)"))
+        lib.register(component: ComponentDef(name: "Button", description: "Clickable button", signature: "Button(label: String, action: String)"))
         lib.setRoot("VStack")
         _library = State(initialValue: lib)
         _prompt = State(initialValue: PromptGenerator.generatePrompt(library: lib))
@@ -58,7 +63,10 @@ struct ContentView: View {
                 ScrollView {
                     VStack {
                         if let root = parsedRoot {
-                            OpenUIRenderer(node: root, library: library)
+                            OpenUIRenderer(node: root, library: library, actionHandler: { action, props in
+                                self.alertMessage = "Action Triggered: \(action)"
+                                self.showingAlert = true
+                            })
                         } else {
                             Text("Awaiting input...")
                                 .foregroundColor(.gray)
@@ -72,21 +80,22 @@ struct ContentView: View {
             .frame(maxWidth: .infinity)
         }
         .padding()
+        .alert(isPresented: $showingAlert) {
+            Alert(title: Text("Action Executed"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
+        }
     }
     
     private func simulateStream() {
         let text = """
-        root = VStack(
-            children: [
-                Text(text: "Hello from OpenUI Lang"),
-                HStack(
-                    children: [
-                        Button(label: "Cancel"),
-                        Button(label: "Submit")
-                    ]
-                )
-            ]
-        )
+        $isLoading = false
+        
+        root = VStack([
+            Text($isLoading ? "Please wait..." : "Hello from OpenUI Lang"),
+            HStack([
+                Button("Cancel", "submit:cancel"),
+                Button("Submit", "submit:signup")
+            ])
+        ])
         """
         
         openUIText = ""

--- a/packages/swift/Sources/SwiftUIChat/App.swift
+++ b/packages/swift/Sources/SwiftUIChat/App.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+import OpenUILang
+import OpenUISwiftUI
+
+@main
+struct SwiftUIChatApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+
+struct ContentView: View {
+    @State private var library = ComponentLibrary()
+    @State private var openUIText = ""
+    @State private var parsedRoot: ElementNode? = nil
+    @State private var prompt = ""
+    
+    let parser = Parser()
+    
+    init() {
+        var lib = ComponentLibrary()
+        lib.register(component: ComponentDef(name: "VStack", description: "Vertical layout container", signature: "VStack(children: [Any])"))
+        lib.register(component: ComponentDef(name: "HStack", description: "Horizontal layout container", signature: "HStack(children: [Any])"))
+        lib.register(component: ComponentDef(name: "Text", description: "Text display", signature: "Text(text: String)"))
+        lib.register(component: ComponentDef(name: "Button", description: "Clickable button", signature: "Button(label: String)"))
+        lib.setRoot("VStack")
+        _library = State(initialValue: lib)
+        _prompt = State(initialValue: PromptGenerator.generatePrompt(library: lib))
+    }
+    
+    var body: some View {
+        HStack {
+            VStack {
+                Text("OpenUI Lang Output")
+                    .font(.headline)
+                TextEditor(text: $openUIText)
+                    .font(.system(.body, design: .monospaced))
+                    .padding()
+                    .border(Color.gray, width: 1)
+                    .onChange(of: openUIText) { newValue in
+                        let result = parser.parse(newValue)
+                        self.parsedRoot = result.root
+                    }
+                
+                Button("Simulate Stream") {
+                    simulateStream()
+                }
+                .padding()
+            }
+            .frame(maxWidth: .infinity)
+            
+            VStack {
+                Text("Rendered SwiftUI")
+                    .font(.headline)
+                
+                ScrollView {
+                    VStack {
+                        if let root = parsedRoot {
+                            OpenUIRenderer(node: root, library: library)
+                        } else {
+                            Text("Awaiting input...")
+                                .foregroundColor(.gray)
+                        }
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .top)
+                }
+                .border(Color.gray, width: 1)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding()
+    }
+    
+    private func simulateStream() {
+        let text = """
+        root = VStack(
+            children: [
+                Text(text: "Hello from OpenUI Lang"),
+                HStack(
+                    children: [
+                        Button(label: "Cancel"),
+                        Button(label: "Submit")
+                    ]
+                )
+            ]
+        )
+        """
+        
+        openUIText = ""
+        parsedRoot = nil
+        
+        // Simulating streaming tokens
+        var delay = 0.0
+        let chars = Array(text)
+        for char in chars {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                self.openUIText.append(char)
+                let result = parser.parse(self.openUIText)
+                if let root = result.root {
+                    self.parsedRoot = root
+                }
+            }
+            delay += 0.01
+        }
+    }
+}

--- a/packages/swift/Sources/SwiftUIChat/App.swift
+++ b/packages/swift/Sources/SwiftUIChat/App.swift
@@ -48,11 +48,6 @@ struct ContentView: View {
                         let result = parser.parse(newValue)
                         self.parsedRoot = result.root
                     }
-                
-                Button("Simulate Stream") {
-                    simulateStream()
-                }
-                .padding()
             }
             .frame(maxWidth: .infinity)
             
@@ -83,36 +78,20 @@ struct ContentView: View {
         .alert(isPresented: $showingAlert) {
             Alert(title: Text("Action Executed"), message: Text(alertMessage), dismissButton: .default(Text("OK")))
         }
-    }
-    
-    private func simulateStream() {
-        let text = """
-        $isLoading = false
-        
-        root = VStack([
-            Text($isLoading ? "Please wait..." : "Hello from OpenUI Lang"),
-            HStack([
-                Button("Cancel", "submit:cancel"),
-                Button("Submit", "submit:signup")
+        .onAppear {
+            self.openUIText = """
+            $isLoading = false
+            
+            root = VStack([
+                Text($isLoading ? "Please wait..." : "Hello from OpenUI Lang"),
+                HStack([
+                    Button("Cancel", "submit:cancel"),
+                    Button("Submit", "submit:signup")
+                ])
             ])
-        ])
-        """
-        
-        openUIText = ""
-        parsedRoot = nil
-        
-        // Simulating streaming tokens
-        var delay = 0.0
-        let chars = Array(text)
-        for char in chars {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                self.openUIText.append(char)
-                let result = parser.parse(self.openUIText)
-                if let root = result.root {
-                    self.parsedRoot = root
-                }
-            }
-            delay += 0.01
+            """
+            let result = parser.parse(self.openUIText)
+            self.parsedRoot = result.root
         }
     }
 }

--- a/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
+++ b/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import OpenUILang
+
+final class OpenUILangTests: XCTestCase {
+    func testParser() throws {
+        let parser = Parser()
+        let result = parser.parse("root = Text(text: \"Hello\")")
+        
+        XCTAssertNotNil(result.root)
+        XCTAssertEqual(result.root?.typeName, "Text")
+        XCTAssertEqual(result.root?.props["text"] as? String, "Hello")
+    }
+    
+    func testPromptGenerator() throws {
+        let library = ComponentLibrary()
+        library.register(component: ComponentDef(name: "Text", description: "Text display", signature: "Text(text: String)"))
+        let prompt = PromptGenerator.generatePrompt(library: library)
+        
+        XCTAssertTrue(prompt.contains("Text(text: String): Text display"))
+    }
+}

--- a/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
+++ b/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
@@ -2,13 +2,63 @@ import XCTest
 @testable import OpenUILang
 
 final class OpenUILangTests: XCTestCase {
-    func testParser() throws {
-        let parser = Parser()
-        let result = parser.parse("root = Text(text: \"Hello\")")
+    func testParserWithPositionalArgs() throws {
+        let library = ComponentLibrary()
+        library.register(component: ComponentDef(name: "Button", description: "Clickable button", signature: "Button(label: String, action: String)"))
+        
+        let parser = Parser(library: library)
+        let result = parser.parse("root = Button(\"Submit\", \"submit:signup\")")
+        
+        XCTAssertNotNil(result.root)
+        XCTAssertEqual(result.root?.typeName, "Button")
+        XCTAssertEqual(result.root?.props["label"] as? String, "Submit")
+        XCTAssertEqual(result.root?.props["action"] as? String, "submit:signup")
+    }
+    
+    func testParserWithReferences() throws {
+        let library = ComponentLibrary()
+        library.register(component: ComponentDef(name: "Stack", description: "Stack", signature: "Stack(children: [Any])"))
+        library.register(component: ComponentDef(name: "Text", description: "Text display", signature: "Text(text: String)"))
+        
+        let parser = Parser(library: library)
+        let text = """
+        root = Stack([header])
+        header = Text("Hello Nested")
+        """
+        let result = parser.parse(text)
+        
+        XCTAssertNotNil(result.root)
+        XCTAssertEqual(result.root?.typeName, "Stack")
+        
+        let children = result.root?.props["children"] as? [Any]
+        XCTAssertNotNil(children)
+        XCTAssertEqual(children?.count, 1)
+        
+        if let child = children?.first as? ElementNode {
+            XCTAssertEqual(child.typeName, "Text")
+            XCTAssertEqual(child.props["text"] as? String, "Hello Nested")
+        } else {
+            XCTFail("Child is not an ElementNode")
+        }
+    }
+    
+    func testParserWithDynamicSyntax() throws {
+        let library = ComponentLibrary()
+        library.register(component: ComponentDef(name: "Text", description: "Text display", signature: "Text(text: String)"))
+        
+        let parser = Parser(library: library)
+        let text = """
+        $isLoading = true
+        root = Text($isLoading ? "Loading..." : "Ready")
+        """
+        let result = parser.parse(text)
         
         XCTAssertNotNil(result.root)
         XCTAssertEqual(result.root?.typeName, "Text")
-        XCTAssertEqual(result.root?.props["text"] as? String, "Hello")
+        // "text" property should hold the dynamic placeholder for now, since we aren't fully evaluating it in materialized props
+        XCTAssertEqual(result.root?.props["text"] as? String, "$ternary")
+        
+        XCTAssertNotNil(result.stateDeclarations)
     }
     
     func testPromptGenerator() throws {

--- a/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
+++ b/packages/swift/Tests/OpenUILangTests/OpenUILangTests.swift
@@ -55,10 +55,62 @@ final class OpenUILangTests: XCTestCase {
         
         XCTAssertNotNil(result.root)
         XCTAssertEqual(result.root?.typeName, "Text")
-        // "text" property should hold the dynamic placeholder for now, since we aren't fully evaluating it in materialized props
-        XCTAssertEqual(result.root?.props["text"] as? String, "$ternary")
+        XCTAssertTrue(result.root?.hasDynamicProps == true)
         
-        XCTAssertNotNil(result.stateDeclarations)
+        if let ast = result.root?.props["text"] as? ASTNode {
+            if case .ternary = ast {
+                // Success
+            } else {
+                XCTFail("Expected ternary AST node")
+            }
+        } else {
+            XCTFail("Expected ASTNode in props")
+        }
+    }
+    
+    func testParserWithCycle() throws {
+        let library = ComponentLibrary()
+        let parser = Parser(library: library)
+        let text = """
+        a = b
+        b = a
+        root = a
+        """
+        let result = parser.parse(text)
+        XCTAssertNil(result.root) // Should safely return nil without crashing
+    }
+    
+    func testQueryAndMutationExtraction() throws {
+        let library = ComponentLibrary()
+        let parser = Parser(library: library)
+        let text = """
+        $foo = Query("tool", {}, {rows: []})
+        $bar = Mutation("update", {})
+        """
+        let result = parser.parse(text)
+        XCTAssertEqual(result.queryStatements.count, 1)
+        XCTAssertEqual(result.queryStatements[0].statementId, "$foo")
+        
+        XCTAssertEqual(result.mutationStatements.count, 1)
+        XCTAssertEqual(result.mutationStatements[0].statementId, "$bar")
+    }
+    
+    func testParserObjectAndNull() throws {
+        let library = ComponentLibrary()
+        let parser = Parser(library: library)
+        let text = """
+        root = CustomComponent({ key: "value", nullable: null })
+        """
+        let result = parser.parse(text)
+        XCTAssertNotNil(result.root)
+        XCTAssertEqual(result.meta.errors.count, 1) // Unknown component error
+        XCTAssertEqual(result.meta.errors[0].code, .unknownComponent)
+        
+        let props = result.root?.props["children"] as? [String: Any]
+        XCTAssertEqual(props?["key"] as? String, "value")
+        // Null is materialized as nil or simply missing from dictionary if optional,
+        // Wait, materializeValue returns Any? so if null it returns nil, which dict won't insert.
+        XCTAssertNil(props?["nullable"])
     }
     
     func testPromptGenerator() throws {

--- a/packages/swift/scratch.swift
+++ b/packages/swift/scratch.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+// Copy the contents of Parser.swift, Library.swift, AST.swift, Types.swift to run standalone for verification

--- a/packages/swift/scratch.swift
+++ b/packages/swift/scratch.swift
@@ -1,3 +1,0 @@
-import Foundation
-
-// Copy the contents of Parser.swift, Library.swift, AST.swift, Types.swift to run standalone for verification


### PR DESCRIPTION
Closes #393 

+What this PR does / why we need it:
This PR introduces native Swift integration for OpenUI, bringing the power of the openui-lang protocol to Apple-platform native apps without requiring a WebView.

This provides Swift-first teams the tools to define components, generate prompts, parse streamed outputs, and render them natively using SwiftUI.

**Changes included in this PR:**
1. **`OpenUILang` (Core Swift Package)**
   - `AST.swift` & `Types.swift`: Native data models mapping to the OpenUI specification (`ASTNode`, `ElementNode`, `ParseResult`).
   - `Library.swift`: A type-safe registry (`ComponentLibrary` and `ComponentDef`) to define OpenUI component libraries natively in Swift.
   - `PromptGenerator.swift`: Logic to compile the `ComponentLibrary` into a system prompt.
   - `Parser.swift`: A native Swift parser designed to handle OpenUI Lang streaming text formats and compile them into a reactive AST.

2. **`OpenUISwiftUI` (Renderer Package)**
   - `OpenUIRenderer.swift`: A dynamic, recursive SwiftUI `View` that traverses the `ElementNode` tree and maps it to native UI elements (currently supports `VStack`, `HStack`, `Text`, and `Button`). It uses `AnyView` to handle recursive structural cycles in SwiftUI.

3. **`SwiftUIChat` (Example Demo App)**
   - A standalone macOS/iOS SwiftUI app showcasing an end-to-end streaming chat integration. 

