### PR TITLE
Remove calculate function and related documentation from chat API tools. Update README files to reflect the removal of the calculate tool from mock implementations across examples.

### DIFF
--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -105,23 +105,6 @@ function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
   });
 }
 
-function calculate({ expression }: { expression: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      try {
-        const sanitized = expression.replace(
-          /[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-          "",
-        );
-        const result = new Function(`return (${sanitized})`)();
-        resolve(JSON.stringify({ expression, result: Number(result) }));
-      } catch {
-        resolve(JSON.stringify({ expression, error: "Invalid expression" }));
-      }
-    }, 300);
-  });
-}
-
 function searchWeb({ query }: { query: string }): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -177,20 +160,6 @@ const tools: any[] = [
         required: ["symbol"],
       },
       function: getStockPrice,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "calculate",
-      description: "Evaluate a math expression.",
-      parameters: {
-        type: "object",
-        properties: { expression: { type: "string", description: "Math expression to evaluate" } },
-        required: ["expression"],
-      },
-      function: calculate,
       parse: JSON.parse,
     },
   },

--- a/docs/content/docs/openui-lang/examples/shadcn-chat.mdx
+++ b/docs/content/docs/openui-lang/examples/shadcn-chat.mdx
@@ -72,7 +72,7 @@ The client sends a conversation to `/api/chat`. The API route loads a generated 
 
 The key decoupling: the server streams OpenUI Lang — an abstract description of UI structure. The client's `shadcnChatLibrary` decides how each node renders. That's where shadcn/ui enters, and that's also where you'd plug in any other design system.
 
-The API route also supports **server-side tool execution**. When the model invokes a tool (weather, stock price, calculator, or web search), the route runs it and feeds the result back into the completion loop before streaming the final UI response.
+The API route also supports **server-side tool execution**. When the model invokes a tool (weather, stock price, or web search), the route runs it and feeds the result back into the completion loop before streaming the final UI response.
 
 ## Project layout
 

--- a/docs/content/docs/openui-lang/examples/vercel-ai-chat.mdx
+++ b/docs/content/docs/openui-lang/examples/vercel-ai-chat.mdx
@@ -80,7 +80,7 @@ Browser (useChat) -- POST /api/chat --> Next.js route --> LLM
                   <-- streaming text --                   (OpenUI Lang markup)
 ```
 
-The API route calls the LLM with `streamText`, the system prompt, and tool definitions. When the LLM invokes a tool (weather, stock price, calculator, or web search), the AI SDK executes it server-side and feeds the result back — up to 5 steps. The response streams back as OpenUI Lang markup.
+The API route calls the LLM with `streamText`, the system prompt, and tool definitions. When the LLM invokes a tool (weather, stock price, or web search), the AI SDK executes it server-side and feeds the result back — up to 5 steps. The response streams back as OpenUI Lang markup.
 
 On the client, `<Renderer />` and `openuiChatLibrary` progressively render each token into interactive UI components as the response arrives.
 

--- a/examples/multi-agent-chat/README.md
+++ b/examples/multi-agent-chat/README.md
@@ -50,7 +50,6 @@ The Vercel AI SDK handles the streaming transport on both ends:
 │                              │       │  │    ├──────────────────────────────┤  │    │
 │                              │       │  │    │ get_weather (mock)           │  │    │
 │                              │       │  │    │ get_stock_price (mock)       │  │    │
-│                              │       │  │    │ calculate (mock)             │  │    │
 │                              │       │  │    │ search_web (mock)            │  │    │
 │                              │       │  │    └──────────────────────────────┘  │    │
 │                              │       │  └──────────────────────────────────────┘    │
@@ -94,7 +93,7 @@ multi-agent-chat/
 │   │   ├── use-system-theme.tsx       # Detects system light/dark preference
 │   │   └── use-threads.ts            # Thread CRUD + localStorage persistence
 │   ├── lib/
-│   │   ├── tools.ts                   # Tool definitions: analytics sub-agent + 4 mock tools
+│   │   ├── tools.ts                   # Tool definitions: analytics sub-agent + 3 mock tools
 │   │   └── thread-store.ts           # Read/write threads to localStorage
 │   ├── library.ts                     # OpenUI library export for prompt generation
 │   └── generated/
@@ -206,14 +205,13 @@ Conversations are organized into threads stored in localStorage. Each thread has
 
 ### Helper Tools (`src/lib/tools.ts`)
 
-Four mock tools with simulated network delays that return realistic data:
+Three mock tools with simulated network delays that return realistic data:
 
 
 | Tool              | Input                  | Delay  | Description                                             |
 | ----------------- | ---------------------- | ------ | ------------------------------------------------------- |
 | `get_weather`     | `location` (city name) | 800ms  | Temperature, conditions, humidity, wind, 2-day forecast |
 | `get_stock_price` | `symbol` (ticker)      | 600ms  | Price, change, volume, day range                        |
-| `calculate`       | `expression` (math)    | 300ms  | Evaluates math expressions safely                       |
 | `search_web`      | `query` (search term)  | 1000ms | Returns 3 mock search results                           |
 
 

--- a/examples/multi-agent-chat/src/lib/tools.ts
+++ b/examples/multi-agent-chat/src/lib/tools.ts
@@ -157,26 +157,6 @@ Output contract (strict):
     },
   }),
 
-  calculate: tool({
-    description: "Evaluate a math expression.",
-    inputSchema: z.object({
-      expression: z.string().describe("Math expression to evaluate"),
-    }),
-    execute: async ({ expression }) => {
-      await new Promise((r) => setTimeout(r, 300));
-      try {
-        const sanitized = expression.replace(
-          /[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-          "",
-        );
-        const result = new Function(`return (${sanitized})`)();
-        return { expression, result: Number(result) };
-      } catch {
-        return { expression, error: "Invalid expression" };
-      }
-    },
-  }),
-
   search_web: tool({
     description: "Search the web for information.",
     inputSchema: z.object({

--- a/examples/openui-artifact-demo/src/app/api/chat/route.ts
+++ b/examples/openui-artifact-demo/src/app/api/chat/route.ts
@@ -55,21 +55,6 @@ function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
   });
 }
 
-function calculate({ expression }: { expression: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      try {
-        const sanitized = expression.replace(/[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g, "");
-         
-        const result = new Function(`return (${sanitized})`)();
-        resolve(JSON.stringify({ expression, result: Number(result) }));
-      } catch {
-        resolve(JSON.stringify({ expression, error: "Invalid expression" }));
-      }
-    }, 300);
-  });
-}
-
 function searchWeb({ query }: { query: string }): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -114,20 +99,6 @@ const tools: any[] = [
         required: ["symbol"],
       },
       function: getStockPrice,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "calculate",
-      description: "Evaluate a math expression.",
-      parameters: {
-        type: "object",
-        properties: { expression: { type: "string", description: "Math expression to evaluate" } },
-        required: ["expression"],
-      },
-      function: calculate,
       parse: JSON.parse,
     },
   },

--- a/examples/openui-chat/src/app/api/chat/route.ts
+++ b/examples/openui-chat/src/app/api/chat/route.ts
@@ -55,21 +55,6 @@ function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
   });
 }
 
-function calculate({ expression }: { expression: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      try {
-        const sanitized = expression.replace(/[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g, "");
-
-        const result = new Function(`return (${sanitized})`)();
-        resolve(JSON.stringify({ expression, result: Number(result) }));
-      } catch {
-        resolve(JSON.stringify({ expression, error: "Invalid expression" }));
-      }
-    }, 300);
-  });
-}
-
 function searchWeb({ query }: { query: string }): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -114,20 +99,6 @@ const tools: any[] = [
         required: ["symbol"],
       },
       function: getStockPrice,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "calculate",
-      description: "Evaluate a math expression.",
-      parameters: {
-        type: "object",
-        properties: { expression: { type: "string", description: "Math expression to evaluate" } },
-        required: ["expression"],
-      },
-      function: calculate,
       parse: JSON.parse,
     },
   },

--- a/examples/shadcn-chat/README.md
+++ b/examples/shadcn-chat/README.md
@@ -200,7 +200,7 @@ The full library (`shadcnChatLibrary`) is assembled with `createLibrary({ root: 
 
 ### Mock Tools
 
-All four tools are mock implementations with simulated network delays. They return realistic-looking data so the LLM can generate rich UI responses.
+All three tools are mock implementations with simulated network delays. They return realistic-looking data so the LLM can generate rich UI responses.
 
 #### `get_weather`
 
@@ -239,15 +239,6 @@ Returns current price data for a stock ticker.
 | `day_low` | `188.90` |
 
 Hardcoded prices for: AAPL ($189.84), GOOGL ($141.80), TSLA ($248.42), MSFT ($378.91), AMZN ($178.25), NVDA ($875.28), META ($485.58). Other tickers get a random price.
-
-#### `calculate`
-
-Evaluates a math expression safely.
-
-- **Input**: `expression` (string) — e.g. `"2 * (3 + 4)"` or `"Math.sqrt(144)"`
-- **Simulated delay**: 300ms
-- **Supports**: `+`, `-`, `*`, `/`, `()`, `%`, `Math.sqrt`, `pow`, `abs`, `ceil`, `floor`, `round`
-- **Returns**: `{ expression, result }` or `{ expression, error }` on invalid input
 
 #### `search_web`
 

--- a/examples/shadcn-chat/src/app/api/chat/route.ts
+++ b/examples/shadcn-chat/src/app/api/chat/route.ts
@@ -105,24 +105,6 @@ function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
   });
 }
 
-function calculate({ expression }: { expression: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      try {
-        const sanitized = expression.replace(
-          /[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-          "",
-        );
-
-        const result = new Function(`return (${sanitized})`)();
-        resolve(JSON.stringify({ expression, result: Number(result) }));
-      } catch {
-        resolve(JSON.stringify({ expression, error: "Invalid expression" }));
-      }
-    }, 300);
-  });
-}
-
 function searchWeb({ query }: { query: string }): Promise<string> {
   return new Promise((resolve) => {
     setTimeout(() => {
@@ -178,20 +160,6 @@ const tools: any[] = [
         required: ["symbol"],
       },
       function: getStockPrice,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "calculate",
-      description: "Evaluate a math expression.",
-      parameters: {
-        type: "object",
-        properties: { expression: { type: "string", description: "Math expression to evaluate" } },
-        required: ["expression"],
-      },
-      function: calculate,
       parse: JSON.parse,
     },
   },

--- a/examples/svelte-chat/src/lib/tools.ts
+++ b/examples/svelte-chat/src/lib/tools.ts
@@ -68,26 +68,6 @@ export const tools = {
 		},
 	}),
 
-	calculate: tool({
-		description: "Evaluate a math expression.",
-		inputSchema: z.object({
-			expression: z.string().describe("Math expression to evaluate"),
-		}),
-		execute: async ({ expression }) => {
-			await new Promise((r) => setTimeout(r, 300));
-			try {
-				const sanitized = expression.replace(
-					/[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-					"",
-				);
-				const result = new Function(`return (${sanitized})`)();
-				return { expression, result: Number(result) };
-			} catch {
-				return { expression, error: "Invalid expression" };
-			}
-		},
-	}),
-
 	search_web: tool({
 		description: "Search the web for information.",
 		inputSchema: z.object({

--- a/examples/vercel-ai-chat/README.md
+++ b/examples/vercel-ai-chat/README.md
@@ -193,7 +193,7 @@ The hook exposes:
 
 ### `src/lib/tools.ts` — Mock Tools
 
-All four tools are mock implementations with simulated network delays. They return realistic-looking data so the LLM can generate rich UI responses.
+All three tools are mock implementations with simulated network delays. They return realistic-looking data so the LLM can generate rich UI responses.
 
 #### `get_weather`
 
@@ -232,15 +232,6 @@ Returns current price data for a stock ticker.
 | `day_low` | `188.90` |
 
 Hardcoded prices for: AAPL ($189.84), GOOGL ($141.80), TSLA ($248.42), MSFT ($378.91), AMZN ($178.25), NVDA ($875.28), META ($485.58). Other tickers get a random price.
-
-#### `calculate`
-
-Evaluates a math expression safely.
-
-- **Input**: `expression` (string) — e.g. `"2 * (3 + 4)"` or `"Math.sqrt(144)"`
-- **Simulated delay**: 300ms
-- **Supports**: `+`, `-`, `*`, `/`, `()`, `%`, `Math.sqrt`, `pow`, `abs`, `ceil`, `floor`, `round`
-- **Returns**: `{ expression, result }` or `{ expression, error }` on invalid input
 
 #### `search_web`
 

--- a/examples/vercel-ai-chat/src/lib/tools.ts
+++ b/examples/vercel-ai-chat/src/lib/tools.ts
@@ -68,26 +68,6 @@ export const tools = {
     },
   }),
 
-  calculate: tool({
-    description: "Evaluate a math expression.",
-    inputSchema: z.object({
-      expression: z.string().describe("Math expression to evaluate"),
-    }),
-    execute: async ({ expression }) => {
-      await new Promise((r) => setTimeout(r, 300));
-      try {
-        const sanitized = expression.replace(
-          /[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-          "",
-        );
-        const result = new Function(`return (${sanitized})`)();
-        return { expression, result: Number(result) };
-      } catch {
-        return { expression, error: "Invalid expression" };
-      }
-    },
-  }),
-
   search_web: tool({
     description: "Search the web for information.",
     inputSchema: z.object({

--- a/examples/vue-chat/lib/tools.ts
+++ b/examples/vue-chat/lib/tools.ts
@@ -68,26 +68,6 @@ export const tools = {
     },
   }),
 
-  calculate: tool({
-    description: "Evaluate a math expression.",
-    inputSchema: z.object({
-      expression: z.string().describe("Math expression to evaluate"),
-    }),
-    execute: async ({ expression }) => {
-      await new Promise((r) => setTimeout(r, 300));
-      try {
-        const sanitized = expression.replace(
-          /[^0-9+\-*/().%\s,Math.sqrtpowabsceilfloorround]/g,
-          "",
-        );
-        const result = new Function(`return (${sanitized})`)();
-        return { expression, result: Number(result) };
-      } catch {
-        return { expression, error: "Invalid expression" };
-      }
-    },
-  }),
-
   search_web: tool({
     description: "Search the web for information.",
     inputSchema: z.object({


### PR DESCRIPTION
Remove the `calculate` mock tool from chat backends

  ## Summary

  Removes the `calculate` mock tool (a math-expression evaluator) from every OpenUI chat
  example backend and the docs chat route, and cleans up all documentation that referenced
  it. **13 files changed, +6 / −227.**

  ## What changed

  **Tool removed from 8 backends** — both the function definition and its registration:

  - OpenAI function-calling style (`function calculate(...)` + `tools[]` entry):
    `openui-chat`, `openui-artefact-demo`, `shadcn-chat`, and the `docs` chat route.
  - Vercel AI SDK style (`calculate: tool({ ... })`):
    `vercel-ai-chat`, `multi-agent-chat`, `svelte-chat`, `vue-chat`.

  **Docs cleaned up (5 files)** — removed the README `#### calculate` sections / tool-table
  rows / architecture-diagram entry, corrected tool counts (4 → 3), and dropped "calculator"
  from two `.mdx` prose lines so nothing advertises a tool that no longer exists.
  
  closes #580 