### PR TITLE
fix(cli): make build:templates cross-platform

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build:cli": "tsc -p .",
-    "build:templates": "rm -rf dist/templates/openui-chat && mkdir -p dist/templates && cp -R src/templates/openui-chat dist/templates/openui-chat",
+    "build:templates": "node scripts/build-templates.js",
     "build": "pnpm run build:cli && pnpm run build:templates",
     "build:exec": "node dist/index.js",
     "lint:check": "eslint ./src --ignore-pattern 'src/templates/**'",

--- a/packages/openui-cli/scripts/build-templates.js
+++ b/packages/openui-cli/scripts/build-templates.js
@@ -1,0 +1,21 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const srcDir = path.resolve(__dirname, "../src/templates/openui-chat");
+const destDir = path.resolve(__dirname, "../dist/templates/openui-chat");
+
+// Equivalent to: rm -rf dist/templates/openui-chat
+fs.rmSync(destDir, {
+  recursive: true,
+  force: true,
+});
+
+// Equivalent to: mkdir -p dist/templates
+fs.mkdirSync(path.dirname(destDir), {
+  recursive: true,
+});
+
+// Equivalent to: cp -R src/templates/openui-chat dist/templates/openui-chat
+fs.cpSync(srcDir, destDir, {
+  recursive: true,
+});

--- a/packages/openui-cli/scripts/build-templates.js
+++ b/packages/openui-cli/scripts/build-templates.js
@@ -4,6 +4,10 @@ const path = require("node:path");
 const srcDir = path.resolve(__dirname, "../src/templates/openui-chat");
 const destDir = path.resolve(__dirname, "../dist/templates/openui-chat");
 
+if (!fs.existsSync(srcDir)) {
+  throw new Error(`Template source directory not found: ${srcDir}`);
+}
+
 // Equivalent to: rm -rf dist/templates/openui-chat
 fs.rmSync(destDir, {
   recursive: true,


### PR DESCRIPTION
## What

Fixes #597 by replacing Unix-specific shell commands in `@openuidev/cli`'s `build:templates` script with a cross-platform Node.js implementation.

## Changes

* [x] Added `scripts/build-templates.js` using native Node.js filesystem APIs
* [x] Updated `build:templates` to use the new script
* [x] Removed dependency on Unix shell commands (`rm`, `mkdir`, `cp`)

## Test Plan

* [ ] Not applicable (explain why)
* [x] Verified locally

Ran:

```bash
pnpm --filter @openuidev/cli build
```

Verified that templates are copied to:

```text
dist/templates/openui-chat
```

While validating the workspace on Windows, I encountered a separate Windows compatibility issue in `@openuidev/react-ui`:

```text
packages/react-ui prepare: > rm -rf dist && pnpm generate:css-utils && pnpm build:scss && pnpm build:tsc && pnpm build:cjs && pnpm run copy-css
packages/react-ui prepare: 'rm' is not recognized as an internal or external command,
packages/react-ui prepare: operable program or batch file.
packages/react-ui prepare: ELIFECYCLE Command failed with exit code 1.
```

This issue appears unrelated to `@openuidev/cli` and is not addressed in this PR.

## Checklist

* [x] I linked a related issue, if applicable
* [ ] I updated docs/README when needed
* [x] I considered backwards compatibility
