### PR TITLE
fix(cli): make template build cross-platform

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build:cli": "tsc -p .",
-    "build:templates": "rm -rf dist/templates/openui-chat && mkdir -p dist/templates && cp -R src/templates/openui-chat dist/templates/openui-chat",
+    "build:templates": "node scripts/copy-template.mjs",
     "build": "pnpm run build:cli && pnpm run build:templates",
     "build:exec": "node dist/index.js",
     "lint:check": "eslint ./src --ignore-pattern 'src/templates/**'",

--- a/packages/openui-cli/scripts/copy-template.mjs
+++ b/packages/openui-cli/scripts/copy-template.mjs
@@ -1,0 +1,13 @@
+import { cpSync, mkdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..");
+const source = resolve(packageRoot, "src/templates/openui-chat");
+const templatesDir = resolve(packageRoot, "dist/templates");
+const destination = resolve(templatesDir, "openui-chat");
+
+rmSync(destination, { recursive: true, force: true });
+mkdirSync(templatesDir, { recursive: true });
+cpSync(source, destination, { recursive: true });


### PR DESCRIPTION
## Summary
- replace the Unix-only template build command with a Node script
- copy the bundled openui-chat template using fs.rmSync/mkdirSync/cpSync so prepare works on Windows too

## Verification
- node packages/openui-cli/scripts/copy-template.mjs

Fixes #597