### PR TITLE
fix(parser): preserve markdown fences and comments inside strings

### DIFF
--- a/packages/lang-core/src/parser/__tests__/parser.test.ts
+++ b/packages/lang-core/src/parser/__tests__/parser.test.ts
@@ -235,3 +235,43 @@ describe("orphaned statements", () => {
     expect(result.meta.orphaned).toHaveLength(0);
   });
 });
+
+describe("markdown fences and multiline comments in strings", () => {
+  it("preserves js markdown fences inside strings", () => {
+    const code = 'root = Title("```js\\nconsole.log(\\"Hello World\\");\\n```")';
+    const result = parse(code, schema);
+    expect(result.meta.errors).toHaveLength(0);
+    expect(result.root).not.toBeNull();
+    expect(result.root?.props.text).toBe('```js\nconsole.log("Hello World");\n```');
+  });
+
+  it("preserves python fenced code blocks inside strings", () => {
+    const code = 'root = Title("```python\\nprint(\'hi\')\\n```")';
+    const result = parse(code, schema);
+    expect(result.meta.errors).toHaveLength(0);
+    expect(result.root).not.toBeNull();
+    expect(result.root?.props.text).toBe("```python\nprint('hi')\n```");
+  });
+
+  it("preserves // inside multiline strings", () => {
+    const code = `root = Title("
+Hello // World
+https://example.com/
+")`;
+    const result = parse(code, schema);
+    expect(result.meta.errors).toHaveLength(0);
+    expect(result.root).not.toBeNull();
+    expect(result.root?.props.text).toBe('\nHello // World\nhttps://example.com/\n');
+  });
+
+  it("preserves # inside multiline strings", () => {
+    const code = `root = Title("
+Hello # World
+https://example.com/
+")`;
+    const result = parse(code, schema);
+    expect(result.meta.errors).toHaveLength(0);
+    expect(result.root).not.toBeNull();
+    expect(result.root?.props.text).toBe('\nHello # World\nhttps://example.com/\n');
+  });
+});

--- a/packages/lang-core/src/parser/__tests__/parser.test.ts
+++ b/packages/lang-core/src/parser/__tests__/parser.test.ts
@@ -246,7 +246,7 @@ describe("markdown fences and multiline comments in strings", () => {
   });
 
   it("preserves python fenced code blocks inside strings", () => {
-    const code = 'root = Title("```python\\nprint(\'hi\')\\n```")';
+    const code = "root = Title(\"```python\\nprint('hi')\\n```\")";
     const result = parse(code, schema);
     expect(result.meta.errors).toHaveLength(0);
     expect(result.root).not.toBeNull();
@@ -261,7 +261,7 @@ https://example.com/
     const result = parse(code, schema);
     expect(result.meta.errors).toHaveLength(0);
     expect(result.root).not.toBeNull();
-    expect(result.root?.props.text).toBe('\nHello // World\nhttps://example.com/\n');
+    expect(result.root?.props.text).toBe("\nHello // World\nhttps://example.com/\n");
   });
 
   it("preserves # inside multiline strings", () => {
@@ -272,6 +272,6 @@ https://example.com/
     const result = parse(code, schema);
     expect(result.meta.errors).toHaveLength(0);
     expect(result.root).not.toBeNull();
-    expect(result.root?.props.text).toBe('\nHello # World\nhttps://example.com/\n');
+    expect(result.root?.props.text).toBe("\nHello # World\nhttps://example.com/\n");
   });
 });

--- a/packages/lang-core/src/parser/__tests__/parser.test.ts
+++ b/packages/lang-core/src/parser/__tests__/parser.test.ts
@@ -274,4 +274,16 @@ https://example.com/
     expect(result.root).not.toBeNull();
     expect(result.root?.props.text).toBe("\nHello # World\nhttps://example.com/\n");
   });
+
+  it("does not treat apostrophes as string delimiters when stripping fences", () => {
+    const code = `Here's the code:
+
+\`\`\`js
+root = Title("hello")
+\`\`\``;
+    const result = parse(code, schema);
+    expect(result.meta.errors).toHaveLength(0);
+    expect(result.root).not.toBeNull();
+    expect(result.root?.props.text).toBe("hello");
+  });
 });

--- a/packages/lang-core/src/parser/parser.ts
+++ b/packages/lang-core/src/parser/parser.ts
@@ -253,8 +253,43 @@ export function stripFences(input: string): string {
   let i = 0;
 
   while (i < input.length) {
-    // Look for opening ```
-    const fenceStart = input.indexOf("```", i);
+    // Scan for opening ``` while tracking string context
+    let inStr: false | '"' | "'" = false;
+    let fenceStart = -1;
+    while (i < input.length) {
+      const c = input[i];
+      if (inStr) {
+        if (c === "\\" && i + 1 < input.length) {
+          i += 2; // skip escaped character
+          continue;
+        }
+        if (c === inStr) {
+          inStr = false;
+        }
+        i++;
+        continue;
+      }
+
+      // Not in string
+      if (c === '"' || c === "'") {
+        inStr = c;
+        i++;
+        continue;
+      }
+
+      if (
+        c === "`" &&
+        i + 1 < input.length &&
+        input[i + 1] === "`" &&
+        i + 2 < input.length &&
+        input[i + 2] === "`"
+      ) {
+        fenceStart = i;
+        break;
+      }
+      i++;
+    }
+
     if (fenceStart === -1) break;
 
     // Skip language tag until newline
@@ -269,23 +304,23 @@ export function stripFences(input: string): string {
     j++; // skip the newline
 
     // Scan for closing ``` while tracking string context
-    let inStr = false;
+    let closeInStr: false | '"' | "'" = false;
     let closePos = -1;
     let k = j;
     while (k < input.length) {
       const c = input[k];
-      if (inStr) {
+      if (closeInStr) {
         if (c === "\\" && k + 1 < input.length) {
           k += 2; // skip escaped character
           continue;
         }
-        if (c === '"') inStr = false;
+        if (c === closeInStr) closeInStr = false;
         k++;
         continue;
       }
       // Not in string
-      if (c === '"') {
-        inStr = true;
+      if (c === '"' || c === "'") {
+        closeInStr = c;
         k++;
         continue;
       }
@@ -333,10 +368,10 @@ export function stripFences(input: string): string {
 
 /** Strip // and # line comments outside of strings (handles both " and ' delimiters). */
 function stripComments(input: string): string {
+  let inStr: false | '"' | "'" = false;
   return input
     .split("\n")
     .map((line) => {
-      let inStr: false | '"' | "'" = false;
       for (let i = 0; i < line.length; i++) {
         const c = line[i];
         if (inStr) {

--- a/packages/lang-core/src/parser/parser.ts
+++ b/packages/lang-core/src/parser/parser.ts
@@ -246,6 +246,22 @@ function buildResult(
 // Public API
 // ─────────────────────────────────────────────────────────────────────────────
 
+function skipString(input: string, start: number): number {
+  if (input[start] !== '"') return start;
+  let i = start + 1;
+  while (i < input.length) {
+    const c = input[i];
+    if (c === "\\") {
+      i += 2; // skip escape character and the escaped character
+    } else if (c === '"') {
+      return i + 1; // return index after the closing quote
+    } else {
+      i++;
+    }
+  }
+  return i; // return length if string was unclosed
+}
+
 /** Extract code from markdown fences, or return as-is if no fences found.
  *  String-context-aware: skips ``` inside double-quoted strings. */
 export function stripFences(input: string): string {
@@ -254,29 +270,15 @@ export function stripFences(input: string): string {
 
   while (i < input.length) {
     // Scan for opening ``` while tracking string context
-    let inStr: false | '"' | "'" = false;
     let fenceStart = -1;
     while (i < input.length) {
+      const nextI = skipString(input, i);
+      if (nextI > i) {
+        i = nextI;
+        continue;
+      }
+
       const c = input[i];
-      if (inStr) {
-        if (c === "\\" && i + 1 < input.length) {
-          i += 2; // skip escaped character
-          continue;
-        }
-        if (c === inStr) {
-          inStr = false;
-        }
-        i++;
-        continue;
-      }
-
-      // Not in string
-      if (c === '"' || c === "'") {
-        inStr = c;
-        i++;
-        continue;
-      }
-
       if (
         c === "`" &&
         i + 1 < input.length &&
@@ -304,26 +306,15 @@ export function stripFences(input: string): string {
     j++; // skip the newline
 
     // Scan for closing ``` while tracking string context
-    let closeInStr: false | '"' | "'" = false;
     let closePos = -1;
     let k = j;
     while (k < input.length) {
+      const nextK = skipString(input, k);
+      if (nextK > k) {
+        k = nextK;
+        continue;
+      }
       const c = input[k];
-      if (closeInStr) {
-        if (c === "\\" && k + 1 < input.length) {
-          k += 2; // skip escaped character
-          continue;
-        }
-        if (c === closeInStr) closeInStr = false;
-        k++;
-        continue;
-      }
-      // Not in string
-      if (c === '"' || c === "'") {
-        closeInStr = c;
-        k++;
-        continue;
-      }
       if (
         c === "`" &&
         k + 1 < input.length &&


### PR DESCRIPTION
## What

This PR fixes two parser preprocessing issues where markdown content inside string literals could be incorrectly modified before parsing.

## Changes

* Made `stripFences` string-aware so fenced code blocks inside string literals are preserved.
* Preserved string context across line boundaries in `stripComments`.
* Added regression tests covering both issues.

## Test Plan

* [ ] Not applicable (explain why)
* [x] Verified locally

```bash
pnpm --filter @openuidev/lang-core test
```

## Checklist

* [x] I linked a related issue, if applicable
* [ ] I updated docs/README when needed
* [x] I considered backwards compatibility

Closes #581

Closes #596
