### PR TITLE
feat(examples): add Material UI chat example app (Issue #392)

### DIFF
--- a/examples/material-ui-chat/README.md
+++ b/examples/material-ui-chat/README.md
@@ -1,0 +1,56 @@
+# Material UI Chat
+
+A generative UI chat example using Material UI components with OpenUI.
+
+## Getting Started
+
+1. Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY=sk-...
+```
+
+2. Run the development server:
+
+```bash
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to try it out.
+
+## How it works
+
+- **MUI Components**: All UI components are built with Material UI v7
+- **Generative UI**: The LLM generates UI on the fly using openui-lang syntax
+- **Streaming**: Real-time streaming of generated UI via SSE
+- **Tools**: Built-in tools for weather, stocks, and web search
+
+## Component Library
+
+The example includes a full MUI component library with 7 categories:
+
+- Content: TextContent, Separator, CodeBlock, MarkDownRenderer
+- Data Display: Card, Badge, Avatar, Alert, Progress, ImageBlock
+- Charts: BarChart, LineChart, AreaChart, PieChart (via Recharts)
+- Forms: Form, Input, TextArea, Select, CheckBoxGroup, RadioGroup, SwitchGroup, Slider, DatePicker
+- Buttons: Button, Buttons
+- Layout: Stack, Tabs, Accordion
+- Tables: Table with column definitions
+
+## Project Structure
+
+```
+src/
+├── app/
+│   ├── api/chat/route.ts    # OpenAI streaming API route
+│   ├── globals.css           # Global styles
+│   ├── layout.tsx            # Root layout with MUI ThemeProvider
+│   └── page.tsx              # Chat UI page
+├── hooks/
+│   └── use-system-theme.tsx  # Theme detection (light/dark)
+├── lib/
+│   └── mui-genui/
+│       ├── index.ts              # Library definition & component groups
+│       └── components/           # Individual component definitions
+└── library.ts                # CLI prompt generation entry point
+```

--- a/examples/material-ui-chat/next-env.d.ts
+++ b/examples/material-ui-chat/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/examples/material-ui-chat/next.config.ts
+++ b/examples/material-ui-chat/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  transpilePackages: ["@openuidev/react-lang", "@openuidev/react-headless"],
+};
+
+export default nextConfig;

--- a/examples/material-ui-chat/package.json
+++ b/examples/material-ui-chat/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "material-ui-chat",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "generate:prompt": "pnpm --filter @openuidev/cli build && pnpm exec openui generate src/library.ts --out src/generated/system-prompt.txt",
+    "dev": "pnpm generate:prompt && next dev",
+    "build": "pnpm generate:prompt && next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.13.0",
+    "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^7.0.0",
+    "@mui/material": "^7.0.0",
+    "@mui/x-date-pickers": "^7.0.0",
+    "@openuidev/react-headless": "workspace:*",
+    "@openuidev/react-lang": "workspace:*",
+    "@openuidev/react-ui": "workspace:*",
+    "dayjs": "^1.11.13",
+    "next": "^15.0.0",
+    "openai": "^6.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-markdown": "^10.0.0",
+    "recharts": "^2.15.0",
+    "remark-gfm": "^4.0.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@openuidev/cli": "workspace:*",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "typescript": "^5"
+  }
+}

--- a/examples/material-ui-chat/src/app/api/chat/route.ts
+++ b/examples/material-ui-chat/src/app/api/chat/route.ts
@@ -1,0 +1,330 @@
+import { readFileSync } from "fs";
+import { NextRequest } from "next/server";
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
+import { join } from "path";
+
+const systemPrompt = readFileSync(join(process.cwd(), "src/generated/system-prompt.txt"), "utf-8");
+
+// ── Tool implementations ──
+
+function getWeather({ location }: { location: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const knownTemps: Record<string, number> = {
+        tokyo: 22,
+        "san francisco": 18,
+        london: 14,
+        "new york": 25,
+        paris: 19,
+        sydney: 27,
+        mumbai: 33,
+        berlin: 16,
+      };
+      const conditions = ["Sunny", "Partly Cloudy", "Cloudy", "Light Rain", "Clear Skies"];
+      const temp = knownTemps[location.toLowerCase()] ?? Math.floor(Math.random() * 30 + 5);
+      const condition = conditions[Math.floor(Math.random() * conditions.length)];
+      resolve(
+        JSON.stringify({
+          location,
+          temperature_celsius: temp,
+          temperature_fahrenheit: Math.round(temp * 1.8 + 32),
+          condition,
+          humidity_percent: Math.floor(Math.random() * 40 + 40),
+          wind_speed_kmh: Math.floor(Math.random() * 25 + 5),
+          forecast: [
+            { day: "Tomorrow", high: temp + 2, low: temp - 4, condition: "Partly Cloudy" },
+            { day: "Day After", high: temp + 1, low: temp - 3, condition: "Sunny" },
+          ],
+        }),
+      );
+    }, 800);
+  });
+}
+
+function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const s = symbol.toUpperCase();
+      const knownPrices: Record<string, number> = {
+        AAPL: 189.84,
+        GOOGL: 141.8,
+        TSLA: 248.42,
+        MSFT: 378.91,
+        AMZN: 178.25,
+        NVDA: 875.28,
+        META: 485.58,
+      };
+      const price = knownPrices[s] ?? Math.floor(Math.random() * 500 + 20);
+      const change = parseFloat((Math.random() * 8 - 4).toFixed(2));
+      resolve(
+        JSON.stringify({
+          symbol: s,
+          price: parseFloat((price + change).toFixed(2)),
+          change,
+          change_percent: parseFloat(((change / price) * 100).toFixed(2)),
+          volume: `${(Math.random() * 50 + 10).toFixed(1)}M`,
+          day_high: parseFloat((price + Math.abs(change) + 1.5).toFixed(2)),
+          day_low: parseFloat((price - Math.abs(change) - 1.2).toFixed(2)),
+        }),
+      );
+    }, 600);
+  });
+}
+
+function searchWeb({ query }: { query: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(
+        JSON.stringify({
+          query,
+          results: [
+            {
+              title: `Top result for "${query}"`,
+              snippet: `Comprehensive overview of ${query} with the latest information.`,
+            },
+            {
+              title: `${query} - Latest News`,
+              snippet: `Recent developments and updates related to ${query}.`,
+            },
+            {
+              title: `Understanding ${query}`,
+              snippet: `An in-depth guide explaining everything about ${query}.`,
+            },
+          ],
+        }),
+      );
+    }, 1000);
+  });
+}
+
+// ── Tool definitions ──
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const tools: any[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a location.",
+      parameters: {
+        type: "object",
+        properties: { location: { type: "string", description: "City name" } },
+        required: ["location"],
+      },
+      function: getWeather,
+      parse: JSON.parse,
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_stock_price",
+      description: "Get stock price for a ticker symbol.",
+      parameters: {
+        type: "object",
+        properties: { symbol: { type: "string", description: "Ticker symbol, e.g. AAPL" } },
+        required: ["symbol"],
+      },
+      function: getStockPrice,
+      parse: JSON.parse,
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "search_web",
+      description: "Search the web for information.",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string", description: "Search query" } },
+        required: ["query"],
+      },
+      function: searchWeb,
+      parse: JSON.parse,
+    },
+  },
+];
+
+// ── SSE helpers ──
+
+function sseToolCallStart(
+  encoder: TextEncoder,
+  tc: { id: string; function: { name: string } },
+  index: number,
+) {
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      id: `chatcmpl-tc-${tc.id}`,
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index,
+                id: tc.id,
+                type: "function",
+                function: { name: tc.function.name, arguments: "" },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+  );
+}
+
+function sseToolCallArgs(
+  encoder: TextEncoder,
+  tc: { id: string; function: { arguments: string } },
+  result: string,
+  index: number,
+) {
+  let enrichedArgs: string;
+  try {
+    enrichedArgs = JSON.stringify({
+      _request: JSON.parse(tc.function.arguments),
+      _response: JSON.parse(result),
+    });
+  } catch {
+    enrichedArgs = tc.function.arguments;
+  }
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      id: `chatcmpl-tc-${tc.id}-args`,
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: { tool_calls: [{ index, function: { arguments: enrichedArgs } }] },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+  );
+}
+
+// ── Route handler ──
+
+export async function POST(req: NextRequest) {
+  const { messages } = await req.json();
+
+  const client = new OpenAI({
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: process.env.OPENAI_BASE_URL || undefined,
+  });
+
+  const MODEL = process.env.OPENAI_MODEL || "gpt-4o";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cleanMessages = (messages as any[])
+    .filter((m) => m.role !== "tool")
+    .map((m) => {
+      if (m.role === "assistant" && m.tool_calls?.length) {
+        const { tool_calls: _tc, ...rest } = m;
+        return rest;
+      }
+      return m;
+    });
+
+  const chatMessages: ChatCompletionMessageParam[] = [
+    { role: "system", content: systemPrompt },
+    ...cleanMessages,
+  ];
+
+  const encoder = new TextEncoder();
+  let controllerClosed = false;
+
+  const readable = new ReadableStream({
+    start(controller) {
+      const enqueue = (data: Uint8Array) => {
+        if (controllerClosed) return;
+        try {
+          controller.enqueue(data);
+        } catch {
+          /* already closed */
+        }
+      };
+
+      const close = () => {
+        if (controllerClosed) return;
+        controllerClosed = true;
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      };
+
+      const pendingCalls: Array<{ id: string; name: string; arguments: string }> = [];
+      let callIdx = 0;
+      let resultIdx = 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const runner = (client.chat.completions as any).runTools({
+        model: MODEL,
+        messages: chatMessages,
+        tools,
+        stream: true,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runner.on("functionToolCall", (fc: any) => {
+        const id = `tc-${callIdx}`;
+        pendingCalls.push({ id, name: fc.name, arguments: fc.arguments });
+
+        enqueue(sseToolCallStart(encoder, { id, function: { name: fc.name } }, callIdx));
+        callIdx++;
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runner.on("functionToolCallResult", (result: string) => {
+        const tc = pendingCalls[resultIdx];
+        if (tc)
+          enqueue(
+            sseToolCallArgs(
+              encoder,
+              { id: tc.id, function: { arguments: tc.arguments } },
+              result,
+              resultIdx,
+            ),
+          );
+        resultIdx++;
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runner.on("chunk", (chunk: any) => {
+        const choice = chunk.choices?.[0];
+        const delta = choice?.delta;
+        if (!delta) return;
+        if (delta.content) enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+        if (choice?.finish_reason === "stop")
+          enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      });
+
+      runner.on("end", () => {
+        enqueue(encoder.encode("data: [DONE]\n\n"));
+        close();
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      runner.on("error", (err: any) => {
+        const msg = err instanceof Error ? err.message : "Stream error";
+        console.error("Chat route error:", msg);
+        enqueue(encoder.encode(`data: ${JSON.stringify({ error: msg })}\n\n`));
+        close();
+      });
+    },
+  });
+
+  return new Response(readable, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/examples/material-ui-chat/src/app/globals.css
+++ b/examples/material-ui-chat/src/app/globals.css
@@ -1,0 +1,11 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}

--- a/examples/material-ui-chat/src/app/layout.tsx
+++ b/examples/material-ui-chat/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import { ThemeProvider } from "@/hooks/use-system-theme";
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "MUI Chat",
+  description: "Generative UI Chat with Material UI and OpenAI SDK",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/examples/material-ui-chat/src/app/page.tsx
+++ b/examples/material-ui-chat/src/app/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTheme } from "@/hooks/use-system-theme";
+import { muiLibrary } from "@/lib/mui-genui";
+import { openAIAdapter, openAIMessageFormat } from "@openuidev/react-headless";
+import { FullScreen } from "@openuidev/react-ui";
+
+export default function Page() {
+  const mode = useTheme();
+
+  return (
+    <div className="h-screen w-screen overflow-hidden relative">
+      <FullScreen
+        processMessage={async ({ messages, abortController }) => {
+          return fetch("/api/chat", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              messages: openAIMessageFormat.toApi(messages),
+            }),
+            signal: abortController.signal,
+          });
+        }}
+        streamProtocol={openAIAdapter()}
+        componentLibrary={muiLibrary}
+        agentName="Material UI Chat"
+        theme={{ mode }}
+        conversationStarters={{
+          variant: "short",
+          options: [
+            {
+              displayText: "Weather in Tokyo",
+              prompt: "What's the weather like in Tokyo right now?",
+            },
+            {
+              displayText: "Contact form",
+              prompt: "Build me a contact form with name, email, and message fields.",
+            },
+            {
+              displayText: "Data table",
+              prompt:
+                "Show me a table of the top 5 programming languages by popularity with year created.",
+            },
+            {
+              displayText: "Sales chart",
+              prompt: "Show me a bar chart of monthly sales for Q1: Jan=$12k, Feb=$18k, Mar=$15k",
+            },
+          ],
+        }}
+      />
+    </div>
+  );
+}

--- a/examples/material-ui-chat/src/generated/system-prompt.txt
+++ b/examples/material-ui-chat/src/generated/system-prompt.txt
@@ -1,0 +1,137 @@
+You are an AI assistant that responds using openui-lang, a declarative UI language. Your ENTIRE response must be valid openui-lang code — no markdown, no explanations, just openui-lang.
+
+## Syntax Rules
+
+1. Each statement is on its own line: `identifier = Expression`
+2. `root` is the entry point — every program must define `root = Stack(...)`
+3. Expressions are: strings ("..."), numbers, booleans (true/false), null, arrays ([...]), objects ({...}), or component calls TypeName(arg1, arg2, ...)
+4. Use references for readability: define `name = ...` on one line, then use `name` later
+5. EVERY variable (except root) MUST be referenced by at least one other variable. Unreferenced variables are silently dropped and will NOT render. Always include defined variables in their parent's children/items array.
+6. Arguments are POSITIONAL (order matters, not names). Write `Stack([children], "row", "l")` NOT `Stack([children], direction: "row", gap: "l")` — colon syntax is NOT supported and silently breaks
+7. Optional arguments can be omitted from the end
+- Strings use double quotes with backslash escaping
+
+## Component Signatures
+
+Arguments marked with ? are optional. Sub-components can be inline or referenced; prefer references for better streaming.
+
+### Content
+TextContent(text: string, size?: string) — Displays text content with optional size variants
+Separator() — A horizontal divider line
+CodeBlock(code: string, language?: string) — Formatted code block with syntax highlighting
+Markdown supported in TextContent
+
+### Data Display
+Card(children: any[]) — A container with title, description, and content sections
+CardHeader(title: string, description?: string) — Title and description header for a card
+Badge(label: string, color?: string) — A small badge/tag label
+Avatar(name: string, image?: string) — User avatar with fallback initials
+Alert(severity?: "info" | "success" | "warning" | "error", message: string) — Alert banner for info, success, warning, or error
+Progress(value?: number) — Progress bar indicator
+ImageBlock(src: string, caption?: string) — Image with caption
+Use Card/CardHeader for grouped content sections
+
+### Charts
+BarChart(labels: string[], series: {name: string, data: number[]}[], layout?: string) — Vertical bar chart for categorical data
+LineChart(labels: string[], series: {name: string, data: number[]}[]) — Line chart for time series or trends
+AreaChart(labels: string[], series: {name: string, data: number[]}[]) — Area chart with filled regions
+PieChart(labels: string[], series: number[]) — Pie or donut chart for proportional data
+Charts use Recharts under the hood
+
+### Forms
+Form(name: string, children: any[]) — Form container that holds form controls
+FormControl(label: string, children: any[], helpText?: string) — A labeled form field wrapper
+Input(name: string, placeholder?: string, value?: string, type?: string, rules?: any) — Single-line text input
+TextArea(name: string, placeholder?: string, value?: string, rows?: number, rules?: any) — Multi-line text input
+Select(name: string, placeholder?: string, children: any[]) — Dropdown select with items
+CheckBoxGroup(children: any[]) — Group of checkbox options
+RadioGroup(label?: string, children: any[]) — Group of radio button options
+SwitchGroup(children: any[]) — Group of toggle switches
+Slider(name: string, min?: number, max?: number, step?: number, defaultValue?: number) — Range slider
+DatePicker(name: string, label?: string) — Date picker control
+Use Form/FormControl/Input for form elements
+
+### Buttons
+Button(label: string, action?: any, variant?: string, type?: string) — Action button with variant and color options
+Buttons(children: any[]) — Horizontal button row
+
+### Layout
+Stack(children: any[], direction?: "row" | "column", gap?: number, align?: string, justify?: string, wrap?: boolean) — Vertical layout container for children
+Tabs(children: any[]) — Tabbed section container
+Accordion(children: any[]) — Collapsible accordion sections
+Use Stack as the root container
+
+### Tables
+Table(children: any[]) — Data table with columns and rows
+Use Table with Col definitions for tabular data
+
+### Other
+MarkDownRenderer(text: string) — Renders markdown text as formatted content
+Image(src: string, alt?: string) — An inline image
+Series(name: string, data: number[]) — One data series with a name and array of numeric values
+Slice(name: string, value: number) — One slice with a label and value for pie charts
+SelectItem(value: string, label: string) — An option within a Select dropdown
+CheckBoxItem(label: string, value: string) — A single checkbox option
+RadioItem(value: string, label: string) — A single radio option
+SwitchItem(label: string) — A single toggle switch
+TabItem(value: string, label: string, children: any[]) — A single tab panel
+AccordionItemDef(title: string, children: any[]) — A single accordion section
+Col(label: string, children?: any[], data?: any[]) — A column definition for a Table
+
+## Hoisting & Streaming (CRITICAL)
+
+openui-lang supports hoisting: a reference can be used BEFORE it is defined. The parser resolves all references after the full input is parsed.
+
+During streaming, the output is re-parsed on every chunk. Undefined references are temporarily unresolved and appear once their definitions stream in. This creates a progressive top-down reveal — structure first, then data fills in.
+
+**Recommended statement order for optimal streaming:**
+1. `root = Stack(...)` — UI shell appears immediately
+2. Component definitions — fill in as they stream
+3. Data values — leaf content last
+
+Always write the root = Stack(...) statement first so the UI shell appears immediately, even before child data has streamed in.
+
+## Examples
+
+Example 1 — Table (column-oriented):
+
+root = Stack([title, tbl])
+title = TextContent("Top Languages", "large-heavy")
+tbl = Table([Col("Language", langs), Col("Users (M)", users), Col("Year", years)])
+langs = ["Python", "JavaScript", "Java", "TypeScript", "Go"]
+users = [15.7, 14.2, 12.1, 8.5, 5.2]
+years = [1991, 1995, 1995, 2012, 2009]
+
+Example 2 — Bar chart:
+
+root = Stack([title, chart])
+title = TextContent("Q4 Revenue", "large-heavy")
+chart = BarChart(labels, [s1, s2])
+labels = ["Oct", "Nov", "Dec"]
+s1 = Series("Product A", [120, 150, 180])
+s2 = Series("Product B", [90, 110, 140])
+
+Example 3 — Form:
+
+root = Stack([title, form])
+title = TextContent("Contact Us", "large-heavy")
+form = Form("contact", btns, [nameField, emailField, msgField])
+nameField = FormControl("Name", Input("name", "Your name", "text", { required: true, minLength: 2 }))
+emailField = FormControl("Email", Input("email", "you@example.com", "email", { required: true, email: true }))
+msgField = FormControl("Message", TextArea("message", "Tell us more...", 4, { required: true, minLength: 10 }))
+btns = Buttons([Button("Submit", Action([@ToAssistant("Submit")]), "primary"), Button("Cancel", Action([@ToAssistant("Cancel")]), "secondary")])
+
+## Important Rules
+- When asked about data, generate realistic/plausible data
+- Choose components that best represent the content (tables for comparisons, charts for trends, forms for input, etc.)
+
+## Final Verification
+Before finishing, walk your output and verify:
+1. root = Stack(...) is the FIRST line (for optimal streaming).
+2. Every referenced name is defined. Every defined name (other than root) is reachable from root.
+
+- You are building UI with Material UI components.
+- Use Card/CardHeader for grouped content sections.
+- Use Stack as the root container.
+- Use Form/FormControl/Input for form elements.
+- Use Table with Col definitions for tabular data.

--- a/examples/material-ui-chat/src/hooks/use-system-theme.tsx
+++ b/examples/material-ui-chat/src/hooks/use-system-theme.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import CssBaseline from "@mui/material/CssBaseline";
+import { createTheme, ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { createContext, useContext, useLayoutEffect, useMemo, useState } from "react";
+
+type ThemeMode = "light" | "dark";
+
+interface ThemeContextType {
+  mode: ThemeMode;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+  const [mode, setMode] = useState<ThemeMode>("light");
+
+  useLayoutEffect(() => {
+    setMode(prefersDark ? "dark" : "light");
+  }, [prefersDark]);
+
+  const theme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode,
+          ...(mode === "light"
+            ? { background: { default: "#f5f5f5" } }
+            : { background: { default: "#121212" } }),
+        },
+      }),
+    [mode],
+  );
+
+  return (
+    <ThemeContext.Provider value={{ mode }}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeMode {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within a ThemeProvider");
+  return ctx.mode;
+}

--- a/examples/material-ui-chat/src/lib/mui-genui/components/accordion.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/accordion.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import MuiAccordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Accordion = defineComponent({
+  name: "Accordion",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Collapsible accordion sections",
+  component: ({ props, renderNode }) => (
+    <Box sx={{ width: "100%" }}>{renderNode(props.children)}</Box>
+  ),
+});
+
+export const AccordionItemDef = defineComponent({
+  name: "AccordionItemDef",
+  props: z.object({ title: z.string(), children: z.array(z.any()) }),
+  description: "A single accordion section",
+  component: ({ props, renderNode }) => (
+    <MuiAccordion>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle1">{props.title as string}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>{renderNode(props.children)}</AccordionDetails>
+    </MuiAccordion>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/alert.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/alert.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import MuiAlert from "@mui/material/Alert";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+const severityMap: Record<string, "info" | "success" | "warning" | "error"> = {
+  info: "info",
+  success: "success",
+  warning: "warning",
+  error: "error",
+};
+
+export const Alert = defineComponent({
+  name: "Alert",
+  props: z.object({
+    severity: z.enum(["info", "success", "warning", "error"]).optional(),
+    message: z.string(),
+  }),
+  description: "Alert banner for info, success, warning, or error",
+  component: ({ props }) => (
+    <MuiAlert severity={severityMap[(props.severity as string) ?? "info"] ?? "info"}>
+      {props.message as string}
+    </MuiAlert>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/avatar.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/avatar.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import MuiAvatar from "@mui/material/Avatar";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+function getInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export const Avatar = defineComponent({
+  name: "Avatar",
+  props: z.object({ name: z.string(), image: z.string().optional() }),
+  description: "User avatar with fallback initials",
+  component: ({ props }) => {
+    const src = props.image as string | undefined;
+    return src ? (
+      <MuiAvatar src={src} alt={props.name as string} />
+    ) : (
+      <MuiAvatar>{getInitials(props.name as string)}</MuiAvatar>
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/badge.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/badge.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Chip from "@mui/material/Chip";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+const colorMap: Record<
+  string,
+  "default" | "primary" | "secondary" | "success" | "warning" | "error" | "info"
+> = {
+  default: "default",
+  primary: "primary",
+  secondary: "secondary",
+  success: "success",
+  warning: "warning",
+  error: "error",
+};
+
+export const Badge = defineComponent({
+  name: "Badge",
+  props: z.object({ label: z.string(), color: z.string().optional() }),
+  description: "A small badge/tag label",
+  component: ({ props }) => {
+    const color = colorMap[(props.color as string) ?? "default"] ?? "default";
+    return <Chip label={props.label as string} color={color} size="small" />;
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/button.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/button.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import MuiButton from "@mui/material/Button";
+import type { ActionPlan } from "@openuidev/react-lang";
+import {
+  ACTION_STEPS,
+  defineComponent,
+  useFormName,
+  useFormValidation,
+  useIsStreaming,
+  useTriggerAction,
+} from "@openuidev/react-lang";
+import { z } from "zod";
+
+const variantMap: Record<string, "contained" | "outlined" | "text"> = {
+  primary: "contained",
+  secondary: "outlined",
+  ghost: "text",
+  tertiary: "text",
+};
+
+const colorMap: Record<string, "primary" | "secondary" | "error" | "success" | "warning"> = {
+  primary: "primary",
+  secondary: "secondary",
+  destructive: "error",
+};
+
+export const Button = defineComponent({
+  name: "Button",
+  props: z.object({
+    label: z.string(),
+    action: z.any().optional(),
+    variant: z.string().optional(),
+    type: z.string().optional(),
+  }),
+  description: "Action button with variant and color options",
+  component: ({ props }) => {
+    const triggerAction = useTriggerAction();
+    const formName = useFormName();
+    const isStreaming = useIsStreaming();
+    const formValidation = useFormValidation();
+
+    const label = props.label as string;
+
+    return (
+      <MuiButton
+        variant={variantMap[(props.variant as string) || "primary"] || "contained"}
+        color={colorMap[(props.variant as string) || "primary"] || "primary"}
+        disabled={isStreaming}
+        onClick={() => {
+          const action = props.action as ActionPlan | undefined;
+          const variant = (props.variant as string) || "primary";
+
+          if (formValidation && variant === "primary") {
+            if (action?.steps) {
+              const needsValidation = action.steps.some(
+                (s) =>
+                  s.type === ACTION_STEPS.ToAssistant ||
+                  (s.type === ACTION_STEPS.Run && s.refType === "mutation"),
+              );
+              if (needsValidation && !formValidation.validateForm()) return;
+            } else {
+              if (!formValidation.validateForm()) return;
+            }
+          }
+
+          triggerAction(label, formName, action);
+        }}
+      >
+        {label}
+      </MuiButton>
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/buttons.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/buttons.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Stack from "@mui/material/Stack";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Buttons = defineComponent({
+  name: "Buttons",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Horizontal button row",
+  component: ({ props, renderNode }) => (
+    <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+      {renderNode(props.children)}
+    </Stack>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/card.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/card.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import MuiCard from "@mui/material/Card";
+import MuiCardContent from "@mui/material/CardContent";
+import MuiCardHeader from "@mui/material/CardHeader";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Card = defineComponent({
+  name: "Card",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "A container with title, description, and content sections",
+  component: ({ props, renderNode }) => (
+    <MuiCard variant="outlined" sx={{ mb: 1 }}>
+      <MuiCardContent>{renderNode(props.children)}</MuiCardContent>
+    </MuiCard>
+  ),
+});
+
+export const CardHeader = defineComponent({
+  name: "CardHeader",
+  props: z.object({ title: z.string(), description: z.string().optional() }),
+  description: "Title and description header for a card",
+  component: ({ props }) => (
+    <MuiCardHeader
+      title={props.title as string}
+      subheader={(props.description as string) ?? undefined}
+      sx={{ px: 0, pt: 0 }}
+    />
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/charts.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/charts.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import Box from "@mui/material/Box";
+import { useTheme } from "@mui/material/styles";
+import { defineComponent } from "@openuidev/react-lang";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { z } from "zod";
+
+const CHART_COLORS = ["#1976d2", "#dc004e", "#388e3c", "#f57c00", "#7b1fa2", "#0097a7", "#c2185b"];
+
+interface SeriesData {
+  name: string;
+  data: number[];
+}
+
+interface SliceData {
+  name: string;
+  value: number;
+}
+
+function useMUITheme() {
+  const theme = useTheme();
+  return {
+    textColor: theme.palette.text.secondary,
+    gridColor: theme.palette.divider,
+    fontFamily: theme.typography.fontFamily,
+  };
+}
+
+function buildSeriesData(
+  labels: string[],
+  seriesList: SeriesData[],
+): Record<string, string | number>[] {
+  return labels.map((label, i) => {
+    const point: Record<string, string | number> = { name: label };
+    for (const s of seriesList) {
+      point[s.name] = s.data[i] ?? 0;
+    }
+    return point;
+  });
+}
+
+export const BarChartComponent = defineComponent({
+  name: "BarChart",
+  props: z.object({
+    labels: z.array(z.string()),
+    series: z.array(z.object({ name: z.string(), data: z.array(z.number()) })),
+    layout: z.string().optional(),
+  }),
+  description: "Vertical bar chart for categorical data",
+  component: ({ props }) => {
+    const mui = useMUITheme();
+    const data = buildSeriesData(props.labels as string[], props.series as SeriesData[]);
+    return (
+      <Box sx={{ width: "100%", height: 300 }}>
+        <ResponsiveContainer>
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke={mui.gridColor} />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }}
+            />
+            <YAxis tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }} />
+            <Tooltip />
+            <Legend />
+            {(props.series as SeriesData[]).map((s, idx) => (
+              <Bar key={s.name} dataKey={s.name} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </Box>
+    );
+  },
+});
+
+export const LineChartComponent = defineComponent({
+  name: "LineChart",
+  props: z.object({
+    labels: z.array(z.string()),
+    series: z.array(z.object({ name: z.string(), data: z.array(z.number()) })),
+  }),
+  description: "Line chart for time series or trends",
+  component: ({ props }) => {
+    const mui = useMUITheme();
+    const data = buildSeriesData(props.labels as string[], props.series as SeriesData[]);
+    return (
+      <Box sx={{ width: "100%", height: 300 }}>
+        <ResponsiveContainer>
+          <LineChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke={mui.gridColor} />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }}
+            />
+            <YAxis tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }} />
+            <Tooltip />
+            <Legend />
+            {(props.series as SeriesData[]).map((s, idx) => (
+              <Line
+                key={s.name}
+                type="monotone"
+                dataKey={s.name}
+                stroke={CHART_COLORS[idx % CHART_COLORS.length]}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </Box>
+    );
+  },
+});
+
+export const AreaChartComponent = defineComponent({
+  name: "AreaChart",
+  props: z.object({
+    labels: z.array(z.string()),
+    series: z.array(z.object({ name: z.string(), data: z.array(z.number()) })),
+  }),
+  description: "Area chart with filled regions",
+  component: ({ props }) => {
+    const mui = useMUITheme();
+    const data = buildSeriesData(props.labels as string[], props.series as SeriesData[]);
+    return (
+      <Box sx={{ width: "100%", height: 300 }}>
+        <ResponsiveContainer>
+          <AreaChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" stroke={mui.gridColor} />
+            <XAxis
+              dataKey="name"
+              tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }}
+            />
+            <YAxis tick={{ fill: mui.textColor, fontFamily: mui.fontFamily, fontSize: 12 }} />
+            <Tooltip />
+            <Legend />
+            {(props.series as SeriesData[]).map((s, idx) => (
+              <Area
+                key={s.name}
+                type="monotone"
+                dataKey={s.name}
+                fill={CHART_COLORS[idx % CHART_COLORS.length]}
+                stroke={CHART_COLORS[idx % CHART_COLORS.length]}
+              />
+            ))}
+          </AreaChart>
+        </ResponsiveContainer>
+      </Box>
+    );
+  },
+});
+
+export const PieChartComponent = defineComponent({
+  name: "PieChart",
+  props: z.object({
+    labels: z.array(z.string()),
+    series: z.array(z.number()),
+  }),
+  description: "Pie or donut chart for proportional data",
+  component: ({ props }) => {
+    const data: SliceData[] = (props.labels as string[]).map((name, i) => ({
+      name,
+      value: (props.series as number[])[i] ?? 0,
+    }));
+    return (
+      <Box sx={{ width: "100%", height: 300 }}>
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie
+              data={data}
+              dataKey="value"
+              nameKey="name"
+              cx="50%"
+              cy="50%"
+              outerRadius={100}
+              label={({ name, value }) => `${name}: ${value}`}
+            >
+              {data.map((_, idx) => (
+                <Cell key={idx} fill={CHART_COLORS[idx % CHART_COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </Box>
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/checkbox-group.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/checkbox-group.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Checkbox from "@mui/material/Checkbox";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import { defineComponent } from "@openuidev/react-lang";
+import { useState } from "react";
+import { z } from "zod";
+
+export const CheckBoxGroup = defineComponent({
+  name: "CheckBoxGroup",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Group of checkbox options",
+  component: ({ props, renderNode }) => <FormGroup>{renderNode(props.children)}</FormGroup>,
+});
+
+export const CheckBoxItem = defineComponent({
+  name: "CheckBoxItem",
+  props: z.object({ label: z.string(), value: z.string() }),
+  description: "A single checkbox option",
+  component: ({ props }) => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <FormControlLabel
+        control={<Checkbox checked={checked} onChange={(_, v) => setChecked(v)} />}
+        label={props.label as string}
+      />
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/code-block.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/code-block.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const CodeBlock = defineComponent({
+  name: "CodeBlock",
+  props: z.object({ code: z.string(), language: z.string().optional() }),
+  description: "Formatted code block with syntax highlighting",
+  component: ({ props }) => (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        bgcolor: "grey.100",
+        fontFamily: "monospace",
+        fontSize: "0.875rem",
+        overflow: "auto",
+        whiteSpace: "pre-wrap",
+      }}
+    >
+      <Typography component="pre" variant="body2" sx={{ fontFamily: "inherit", m: 0 }}>
+        {props.code as string}
+      </Typography>
+    </Paper>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/date-picker.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/date-picker.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import TextField from "@mui/material/TextField";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const DatePicker = defineComponent({
+  name: "DatePicker",
+  props: z.object({ name: z.string(), label: z.string().optional() }),
+  description: "Date picker control",
+  component: ({ props }) => (
+    <TextField
+      name={props.name as string}
+      label={(props.label as string) ?? "Pick a date"}
+      type="date"
+      size="small"
+      InputLabelProps={{ shrink: true }}
+      fullWidth
+    />
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/form-control.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/form-control.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import MuiFormControl from "@mui/material/FormControl";
+import FormHelperText from "@mui/material/FormHelperText";
+import FormLabel from "@mui/material/FormLabel";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const FormControl = defineComponent({
+  name: "FormControl",
+  props: z.object({
+    label: z.string(),
+    children: z.array(z.any()),
+    helpText: z.string().optional(),
+  }),
+  description: "A labeled form field wrapper",
+  component: ({ props, renderNode }) => (
+    <MuiFormControl fullWidth variant="outlined">
+      <FormLabel>{props.label as string}</FormLabel>
+      {renderNode(props.children)}
+      {props.helpText && <FormHelperText>{props.helpText as string}</FormHelperText>}
+    </MuiFormControl>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/form.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/form.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import Box from "@mui/material/Box";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Form = defineComponent({
+  name: "Form",
+  props: z.object({
+    name: z.string(),
+    children: z.array(z.any()),
+  }),
+  description: "Form container that holds form controls",
+  component: ({ props, renderNode }) => (
+    <Box component="form" sx={{ display: "flex", flexDirection: "column", gap: 2, my: 1 }}>
+      {renderNode(props.children)}
+    </Box>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/image.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/image.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const ImageComponent = defineComponent({
+  name: "Image",
+  props: z.object({ src: z.string(), alt: z.string().optional() }),
+  description: "An inline image",
+  component: ({ props }) => (
+    <Box
+      component="img"
+      src={props.src as string}
+      alt={(props.alt as string) ?? ""}
+      sx={{ maxWidth: "100%", height: "auto", borderRadius: 1 }}
+    />
+  ),
+});
+
+export const ImageBlock = defineComponent({
+  name: "ImageBlock",
+  props: z.object({ src: z.string(), caption: z.string().optional() }),
+  description: "Image with caption",
+  component: ({ props }) => (
+    <Box sx={{ my: 1 }}>
+      <Box
+        component="img"
+        src={props.src as string}
+        alt={(props.caption as string) ?? ""}
+        sx={{ maxWidth: "100%", height: "auto", borderRadius: 1 }}
+      />
+      {props.caption && (
+        <Typography variant="caption" color="text.secondary" sx={{ display: "block", mt: 0.5 }}>
+          {props.caption as string}
+        </Typography>
+      )}
+    </Box>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/input.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/input.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import TextField from "@mui/material/TextField";
+import {
+  defineComponent,
+  parseStructuredRules,
+  useFormValidation,
+  useIsStreaming,
+  useStateField,
+} from "@openuidev/react-lang";
+import React from "react";
+import { z } from "zod";
+
+export const Input = defineComponent({
+  name: "Input",
+  props: z.object({
+    name: z.string(),
+    placeholder: z.string().optional(),
+    value: z.string().optional(),
+    type: z.string().optional(),
+    rules: z.any().optional(),
+  }),
+  description: "Single-line text input",
+  component: ({ props }) => {
+    const isStreaming = useIsStreaming();
+    const formValidation = useFormValidation();
+    const field = useStateField(props.name, props.value);
+    const rules = React.useMemo(() => parseStructuredRules(props.rules), [props.rules]);
+    const hasRules = rules.length > 0;
+
+    React.useEffect(() => {
+      if (!isStreaming && hasRules && formValidation) {
+        formValidation.registerField(field.name, rules, () => field.value);
+        return () => formValidation.unregisterField(field.name);
+      }
+      return undefined;
+    }, [field.name, field.value, formValidation, hasRules, isStreaming, rules]);
+
+    return (
+      <TextField
+        id={field.name}
+        name={field.name}
+        placeholder={(props.placeholder as string) || ""}
+        type={(props.type as string) || "text"}
+        value={field.value ?? ""}
+        size="small"
+        variant="outlined"
+        onFocus={() => formValidation?.clearFieldError(field.name)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          field.setValue(e.target.value);
+          if (hasRules) formValidation?.clearFieldError(field.name);
+        }}
+        onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+          if (hasRules) formValidation?.validateField(field.name, e.target.value, rules);
+        }}
+        disabled={isStreaming}
+      />
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/markdown-renderer.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/markdown-renderer.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Divider from "@mui/material/Divider";
+import Link from "@mui/material/Link";
+import Paper from "@mui/material/Paper";
+import Typography from "@mui/material/Typography";
+import { defineComponent } from "@openuidev/react-lang";
+import type { Components } from "react-markdown";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { z } from "zod";
+
+const markdownComponents: Components = {
+  h1: ({ children }) => (
+    <Typography variant="h4" sx={{ my: 1.5 }}>
+      {children}
+    </Typography>
+  ),
+  h2: ({ children }) => (
+    <Typography variant="h5" sx={{ my: 1.25 }}>
+      {children}
+    </Typography>
+  ),
+  h3: ({ children }) => (
+    <Typography variant="h6" sx={{ my: 1 }}>
+      {children}
+    </Typography>
+  ),
+  p: ({ children }) => (
+    <Typography variant="body1" sx={{ my: 0.5 }}>
+      {children}
+    </Typography>
+  ),
+  a: ({ href, children }) => <Link href={href}>{children}</Link>,
+  code: ({ className, children, ...props }) =>
+    className ? (
+      <Paper
+        variant="outlined"
+        sx={{ p: 1.5, overflow: "auto", fontFamily: "monospace", fontSize: "0.875rem", my: 1 }}
+      >
+        <code className={className} {...props}>
+          {children}
+        </code>
+      </Paper>
+    ) : (
+      <Typography
+        component="code"
+        variant="body2"
+        sx={{ bgcolor: "grey.100", px: 0.5, borderRadius: 0.5, fontFamily: "monospace" }}
+      >
+        {children}
+      </Typography>
+    ),
+  ul: ({ children }) => (
+    <Typography component="ul" variant="body1" sx={{ my: 0.5 }}>
+      {children}
+    </Typography>
+  ),
+  ol: ({ children }) => (
+    <Typography component="ol" variant="body1" sx={{ my: 0.5 }}>
+      {children}
+    </Typography>
+  ),
+  li: ({ children }) => (
+    <Typography component="li" variant="body1">
+      {children}
+    </Typography>
+  ),
+  blockquote: ({ children }) => (
+    <Paper
+      variant="outlined"
+      sx={{ pl: 2, py: 0.5, my: 1, borderLeft: 4, borderColor: "primary.main" }}
+    >
+      <Typography variant="body1" color="text.secondary" fontStyle="italic">
+        {children}
+      </Typography>
+    </Paper>
+  ),
+  hr: () => <Divider sx={{ my: 1 }} />,
+};
+
+export const MarkDownRenderer = defineComponent({
+  name: "MarkDownRenderer",
+  props: z.object({ text: z.string() }),
+  description: "Renders markdown text as formatted content",
+  component: ({ props }) => (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+      {props.text as string}
+    </ReactMarkdown>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/progress.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/progress.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import LinearProgress from "@mui/material/LinearProgress";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Progress = defineComponent({
+  name: "Progress",
+  props: z.object({ value: z.number().optional() }),
+  description: "Progress bar indicator",
+  component: ({ props }) => {
+    const value = props.value as number | undefined;
+    return value != null ? (
+      <LinearProgress variant="determinate" value={Math.min(100, Math.max(0, value))} />
+    ) : (
+      <LinearProgress />
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/radio-group.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/radio-group.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import FormControl from "@mui/material/FormControl";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormLabel from "@mui/material/FormLabel";
+import Radio from "@mui/material/Radio";
+import MuiRadioGroup from "@mui/material/RadioGroup";
+import { defineComponent } from "@openuidev/react-lang";
+import { useState } from "react";
+import { z } from "zod";
+
+export const RadioGroup = defineComponent({
+  name: "RadioGroup",
+  props: z.object({ label: z.string().optional(), children: z.array(z.any()) }),
+  description: "Group of radio button options",
+  component: ({ props, renderNode }) => {
+    const [value, setValue] = useState("");
+    return (
+      <FormControl>
+        {props.label && <FormLabel>{props.label as string}</FormLabel>}
+        <MuiRadioGroup value={value} onChange={(_, v) => setValue(v)}>
+          {renderNode(props.children)}
+        </MuiRadioGroup>
+      </FormControl>
+    );
+  },
+});
+
+export const RadioItem = defineComponent({
+  name: "RadioItem",
+  props: z.object({ value: z.string(), label: z.string() }),
+  description: "A single radio option",
+  component: ({ props }) => (
+    <FormControlLabel
+      value={props.value as string}
+      control={<Radio />}
+      label={props.label as string}
+    />
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/select.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/select.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import FormControl from "@mui/material/FormControl";
+import MenuItem from "@mui/material/MenuItem";
+import MuiSelect from "@mui/material/Select";
+import { defineComponent, useStateField } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Select = defineComponent({
+  name: "Select",
+  props: z.object({
+    name: z.string(),
+    placeholder: z.string().optional(),
+    children: z.array(z.any()),
+  }),
+  description: "Dropdown select with items",
+  component: ({ props, renderNode }) => {
+    const field = useStateField(props.name, "");
+    return (
+      <FormControl size="small" fullWidth>
+        <MuiSelect
+          value={field.value ?? ""}
+          onChange={(e) => field.setValue(e.target.value)}
+          displayEmpty
+        >
+          {props.placeholder && (
+            <MenuItem value="" disabled>
+              {props.placeholder as string}
+            </MenuItem>
+          )}
+          {renderNode(props.children)}
+        </MuiSelect>
+      </FormControl>
+    );
+  },
+});
+
+export const SelectItem = defineComponent({
+  name: "SelectItem",
+  props: z.object({ value: z.string(), label: z.string() }),
+  description: "An option within a Select dropdown",
+  component: ({ props }) => (
+    <MenuItem value={props.value as string}>{props.label as string}</MenuItem>
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/separator.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/separator.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import Divider from "@mui/material/Divider";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Separator = defineComponent({
+  name: "Separator",
+  props: z.object({}),
+  description: "A horizontal divider line",
+  component: () => <Divider sx={{ my: 1 }} />,
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/slider.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/slider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import MuiSlider from "@mui/material/Slider";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Slider = defineComponent({
+  name: "Slider",
+  props: z.object({
+    name: z.string(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+    step: z.number().optional(),
+    defaultValue: z.number().optional(),
+  }),
+  description: "Range slider",
+  component: ({ props }) => (
+    <MuiSlider
+      name={props.name as string}
+      min={(props.min as number) ?? 0}
+      max={(props.max as number) ?? 100}
+      step={(props.step as number) ?? 1}
+      defaultValue={(props.defaultValue as number) ?? 50}
+      valueLabelDisplay="auto"
+    />
+  ),
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/stack.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/stack.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import MuiStack from "@mui/material/Stack";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Stack = defineComponent({
+  name: "Stack",
+  props: z.object({
+    children: z.array(z.any()),
+    direction: z.enum(["row", "column"]).optional(),
+    gap: z.number().optional(),
+    align: z.string().optional(),
+    justify: z.string().optional(),
+    wrap: z.boolean().optional(),
+  }),
+  description: "Vertical layout container for children",
+  component: ({ props, renderNode }) => {
+    const gap = props.gap as number | undefined;
+    return (
+      <MuiStack
+        direction={(props.direction as "row" | "column") ?? "column"}
+        spacing={gap ?? 1}
+        alignItems={
+          props.align as string as
+            | "flex-start"
+            | "center"
+            | "flex-end"
+            | "stretch"
+            | "baseline"
+            | undefined
+        }
+        justifyContent={
+          props.justify as string as
+            | "flex-start"
+            | "center"
+            | "flex-end"
+            | "space-between"
+            | "space-around"
+            | "space-evenly"
+            | undefined
+        }
+        flexWrap={props.wrap ? "wrap" : undefined}
+      >
+        {renderNode(props.children)}
+      </MuiStack>
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/switch-group.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/switch-group.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import FormControlLabel from "@mui/material/FormControlLabel";
+import FormGroup from "@mui/material/FormGroup";
+import Switch from "@mui/material/Switch";
+import { defineComponent } from "@openuidev/react-lang";
+import { useState } from "react";
+import { z } from "zod";
+
+export const SwitchGroup = defineComponent({
+  name: "SwitchGroup",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Group of toggle switches",
+  component: ({ props, renderNode }) => <FormGroup>{renderNode(props.children)}</FormGroup>,
+});
+
+export const SwitchItem = defineComponent({
+  name: "SwitchItem",
+  props: z.object({ label: z.string() }),
+  description: "A single toggle switch",
+  component: ({ props }) => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={(_, v) => setChecked(v)} />}
+        label={props.label as string}
+      />
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/table.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/table.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Paper from "@mui/material/Paper";
+import MuiTable from "@mui/material/Table";
+import TableBody from "@mui/material/TableBody";
+import TableCell from "@mui/material/TableCell";
+import TableHead from "@mui/material/TableHead";
+import TableRow from "@mui/material/TableRow";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+export const Table = defineComponent({
+  name: "Table",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Data table with columns and rows",
+  component: ({ props, renderNode }) => {
+    const cols = renderNode(props.children);
+    if (!Array.isArray(cols) || cols.length === 0) {
+      return (
+        <Paper variant="outlined">
+          <MuiTable>
+            <TableBody>
+              <TableRow>
+                <TableCell>No data</TableCell>
+              </TableRow>
+            </TableBody>
+          </MuiTable>
+        </Paper>
+      );
+    }
+
+    const headers: string[] = [];
+    const rows: Record<string, React.ReactNode>[][] = [];
+
+    for (const col of cols) {
+      const label = col?.props?.label ?? "Column";
+      const colData: React.ReactNode[] = col?.props?.children ?? col?.props?.data ?? [];
+      headers.push(label);
+
+      for (let i = 0; i < colData.length; i++) {
+        if (!rows[i]) rows[i] = [];
+        rows[i].push({ [label]: colData[i] });
+      }
+    }
+
+    return (
+      <Paper variant="outlined" sx={{ overflow: "auto" }}>
+        <MuiTable size="small">
+          <TableHead>
+            <TableRow>
+              {headers.map((h, idx) => (
+                <TableCell key={idx} sx={{ fontWeight: "bold" }}>
+                  {h}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map((row, ri) => (
+              <TableRow key={ri}>
+                {headers.map((h, ci) => (
+                  <TableCell key={ci}>{row[ci]?.[h] ?? ""}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </MuiTable>
+      </Paper>
+    );
+  },
+});
+
+export const Col = defineComponent({
+  name: "Col",
+  props: z.object({
+    label: z.string(),
+    children: z.array(z.any()).optional(),
+    data: z.array(z.any()).optional(),
+  }),
+  description: "A column definition for a Table",
+  component: () => null,
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/tabs.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/tabs.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Box from "@mui/material/Box";
+import Tab from "@mui/material/Tab";
+import MuiTabs from "@mui/material/Tabs";
+import { defineComponent } from "@openuidev/react-lang";
+import { useState } from "react";
+import { z } from "zod";
+
+export const Tabs = defineComponent({
+  name: "Tabs",
+  props: z.object({ children: z.array(z.any()) }),
+  description: "Tabbed section container",
+  component: ({ props, renderNode }) => {
+    const [value, setValue] = useState(0);
+    const children = renderNode(props.children);
+
+    if (!Array.isArray(children)) {
+      return <Box>{children}</Box>;
+    }
+
+    return (
+      <Box sx={{ width: "100%" }}>
+        <MuiTabs value={Math.min(value, children.length - 1)} onChange={(_, v) => setValue(v)}>
+          {children.map((child, idx: number) => {
+            const c = child as React.ReactElement<{ label?: string; value?: string }>;
+            const tabLabel = c.props?.label ?? `Tab ${idx + 1}`;
+            const tabValue = c.props?.value ?? idx;
+            return <Tab key={idx} label={tabLabel} value={tabValue} />;
+          })}
+        </MuiTabs>
+        <Box sx={{ pt: 2 }}>{children[value]}</Box>
+      </Box>
+    );
+  },
+});
+
+export const TabItem = defineComponent({
+  name: "TabItem",
+  props: z.object({ value: z.string(), label: z.string(), children: z.array(z.any()) }),
+  description: "A single tab panel",
+  component: ({ props, renderNode }) => <Box role="tabpanel">{renderNode(props.children)}</Box>,
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/text-content.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/text-content.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Typography from "@mui/material/Typography";
+import { defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+const sizeMap: Record<string, "body2" | "body1" | "h6" | "subtitle2" | "h5"> = {
+  small: "body2",
+  default: "body1",
+  large: "h6",
+  "small-heavy": "subtitle2",
+  "large-heavy": "h5",
+};
+
+export const TextContent = defineComponent({
+  name: "TextContent",
+  props: z.object({ text: z.string(), size: z.string().optional() }),
+  description: "Displays text content with optional size variants",
+  component: ({ props }) => {
+    const variant = sizeMap[(props.size as string) ?? "default"] ?? "body1";
+    return <Typography variant={variant}>{String(props.text ?? "")}</Typography>;
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/components/textarea.tsx
+++ b/examples/material-ui-chat/src/lib/mui-genui/components/textarea.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import TextField from "@mui/material/TextField";
+import {
+  defineComponent,
+  parseStructuredRules,
+  useFormValidation,
+  useIsStreaming,
+  useStateField,
+} from "@openuidev/react-lang";
+import React from "react";
+import { z } from "zod";
+
+export const TextArea = defineComponent({
+  name: "TextArea",
+  props: z.object({
+    name: z.string(),
+    placeholder: z.string().optional(),
+    value: z.string().optional(),
+    rows: z.number().optional(),
+    rules: z.any().optional(),
+  }),
+  description: "Multi-line text input",
+  component: ({ props }) => {
+    const isStreaming = useIsStreaming();
+    const formValidation = useFormValidation();
+    const field = useStateField(props.name, props.value);
+    const rules = React.useMemo(() => parseStructuredRules(props.rules), [props.rules]);
+    const hasRules = rules.length > 0;
+
+    React.useEffect(() => {
+      if (!isStreaming && hasRules && formValidation) {
+        formValidation.registerField(field.name, rules, () => field.value);
+        return () => formValidation.unregisterField(field.name);
+      }
+      return undefined;
+    }, [field.name, field.value, formValidation, hasRules, isStreaming, rules]);
+
+    return (
+      <TextField
+        id={field.name}
+        name={field.name}
+        placeholder={(props.placeholder as string) || ""}
+        value={field.value ?? ""}
+        multiline
+        minRows={(props.rows as number) || 3}
+        size="small"
+        variant="outlined"
+        fullWidth
+        onFocus={() => formValidation?.clearFieldError(field.name)}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          field.setValue(e.target.value);
+          if (hasRules) formValidation?.clearFieldError(field.name);
+        }}
+        onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+          if (hasRules) formValidation?.validateField(field.name, e.target.value, rules);
+        }}
+        disabled={isStreaming}
+      />
+    );
+  },
+});

--- a/examples/material-ui-chat/src/lib/mui-genui/index.ts
+++ b/examples/material-ui-chat/src/lib/mui-genui/index.ts
@@ -1,0 +1,220 @@
+"use client";
+
+import type { ComponentGroup, PromptOptions } from "@openuidev/react-lang";
+import { createLibrary, defineComponent } from "@openuidev/react-lang";
+import { z } from "zod";
+
+// Non-rendering data type components (schema-only, for LLM documentation)
+const Series = defineComponent({
+  name: "Series",
+  props: z.object({ name: z.string(), data: z.array(z.number()) }),
+  description: "One data series with a name and array of numeric values",
+  component: () => null,
+});
+
+const Slice = defineComponent({
+  name: "Slice",
+  props: z.object({ name: z.string(), value: z.number() }),
+  description: "One slice with a label and value for pie charts",
+  component: () => null,
+});
+
+// Content
+import { CodeBlock } from "./components/code-block";
+import { MarkDownRenderer } from "./components/markdown-renderer";
+import { Separator } from "./components/separator";
+import { TextContent } from "./components/text-content";
+
+// Data display
+import { Alert } from "./components/alert";
+import { Avatar } from "./components/avatar";
+import { Badge } from "./components/badge";
+import { Card, CardHeader } from "./components/card";
+import { ImageBlock, ImageComponent } from "./components/image";
+import { Progress } from "./components/progress";
+
+// Charts
+import {
+  AreaChartComponent,
+  BarChartComponent,
+  LineChartComponent,
+  PieChartComponent,
+} from "./components/charts";
+
+// Forms
+import { CheckBoxGroup, CheckBoxItem } from "./components/checkbox-group";
+import { DatePicker } from "./components/date-picker";
+import { Form } from "./components/form";
+import { FormControl } from "./components/form-control";
+import { Input } from "./components/input";
+import { RadioGroup, RadioItem } from "./components/radio-group";
+import { Select, SelectItem } from "./components/select";
+import { Slider } from "./components/slider";
+import { SwitchGroup, SwitchItem } from "./components/switch-group";
+import { TextArea } from "./components/textarea";
+
+// Buttons
+import { Button } from "./components/button";
+import { Buttons } from "./components/buttons";
+
+// Layout
+import { Accordion, AccordionItemDef } from "./components/accordion";
+import { Stack } from "./components/stack";
+import { TabItem, Tabs } from "./components/tabs";
+
+// Tables
+import { Col, Table } from "./components/table";
+
+const muiComponents = [
+  // Content
+  TextContent,
+  Separator,
+  CodeBlock,
+  MarkDownRenderer,
+
+  // Data display
+  Card,
+  CardHeader,
+  Avatar,
+  Badge,
+  Alert,
+  Progress,
+  ImageBlock,
+  ImageComponent,
+
+  // Charts
+  BarChartComponent,
+  LineChartComponent,
+  AreaChartComponent,
+  PieChartComponent,
+  Series,
+  Slice,
+
+  // Forms
+  Form,
+  FormControl,
+  Input,
+  TextArea,
+  Select,
+  SelectItem,
+  CheckBoxGroup,
+  CheckBoxItem,
+  RadioGroup,
+  RadioItem,
+  SwitchGroup,
+  SwitchItem,
+  Slider,
+  DatePicker,
+
+  // Buttons
+  Button,
+  Buttons,
+
+  // Layout
+  Stack,
+  Tabs,
+  TabItem,
+  Accordion,
+  AccordionItemDef,
+
+  // Tables
+  Table,
+  Col,
+];
+
+export const muiComponentGroups: ComponentGroup[] = [
+  {
+    name: "Content",
+    components: ["TextContent", "Separator", "CodeBlock"],
+    notes: ["Markdown supported in TextContent"],
+  },
+  {
+    name: "Data Display",
+    components: ["Card", "CardHeader", "Badge", "Avatar", "Alert", "Progress", "ImageBlock"],
+    notes: ["Use Card/CardHeader for grouped content sections"],
+  },
+  {
+    name: "Charts",
+    components: ["BarChart", "LineChart", "AreaChart", "PieChart"],
+    notes: ["Charts use Recharts under the hood"],
+  },
+  {
+    name: "Forms",
+    components: [
+      "Form",
+      "FormControl",
+      "Input",
+      "TextArea",
+      "Select",
+      "CheckBoxGroup",
+      "RadioGroup",
+      "SwitchGroup",
+      "Slider",
+      "DatePicker",
+    ],
+    notes: ["Use Form/FormControl/Input for form elements"],
+  },
+  {
+    name: "Buttons",
+    components: ["Button", "Buttons"],
+  },
+  {
+    name: "Layout",
+    components: ["Stack", "Tabs", "Accordion"],
+    notes: ["Use Stack as the root container"],
+  },
+  {
+    name: "Tables",
+    components: ["Table"],
+    notes: ["Use Table with Col definitions for tabular data"],
+  },
+];
+
+const muiExamples: string[] = [
+  `Example 1 — Table (column-oriented):
+
+root = Stack([title, tbl])
+title = TextContent("Top Languages", "large-heavy")
+tbl = Table([Col("Language", langs), Col("Users (M)", users), Col("Year", years)])
+langs = ["Python", "JavaScript", "Java", "TypeScript", "Go"]
+users = [15.7, 14.2, 12.1, 8.5, 5.2]
+years = [1991, 1995, 1995, 2012, 2009]`,
+
+  `Example 2 — Bar chart:
+
+root = Stack([title, chart])
+title = TextContent("Q4 Revenue", "large-heavy")
+chart = BarChart(labels, [s1, s2])
+labels = ["Oct", "Nov", "Dec"]
+s1 = Series("Product A", [120, 150, 180])
+s2 = Series("Product B", [90, 110, 140])`,
+
+  `Example 3 — Form:
+
+root = Stack([title, form])
+title = TextContent("Contact Us", "large-heavy")
+form = Form("contact", btns, [nameField, emailField, msgField])
+nameField = FormControl("Name", Input("name", "Your name", "text", { required: true, minLength: 2 }))
+emailField = FormControl("Email", Input("email", "you@example.com", "email", { required: true, email: true }))
+msgField = FormControl("Message", TextArea("message", "Tell us more...", 4, { required: true, minLength: 10 }))
+btns = Buttons([Button("Submit", Action([@ToAssistant("Submit")]), "primary"), Button("Cancel", Action([@ToAssistant("Cancel")]), "secondary")])`,
+];
+
+export const muiAdditionalRules: string[] = [
+  "You are building UI with Material UI components.",
+  "Use Card/CardHeader for grouped content sections.",
+  "Use Stack as the root container.",
+  "Use Form/FormControl/Input for form elements.",
+  "Use Table with Col definitions for tabular data.",
+];
+
+export const muiLibrary = createLibrary({
+  components: muiComponents,
+  root: "Stack",
+  componentGroups: muiComponentGroups,
+});
+
+export const muiPromptOptions: PromptOptions = {
+  examples: muiExamples,
+  additionalRules: muiAdditionalRules,
+};

--- a/examples/material-ui-chat/src/library.ts
+++ b/examples/material-ui-chat/src/library.ts
@@ -1,0 +1,1 @@
+export { muiLibrary as library, muiPromptOptions as promptOptions } from "./lib/mui-genui";

--- a/examples/material-ui-chat/tsconfig.json
+++ b/examples/material-ui-chat/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- New Material UI chat example app using the OpenUI generative UI framework
- 27 MUI-wrapped component definitions across 7 groups (Content, Data Display, Charts, Forms, Buttons, Layout, Tables)
- OpenAI streaming API route with weather, stock, and web search tools
- MUI ThemeProvider with light/dark mode detection
- Recharts integration for chart components
- Full type checking and lint passing

## Test plan
- [ ] `pnpm install` in the workspace root
- [ ] Set `OPENAI_API_KEY` environment variable
- [ ] `cd examples/material-ui-chat && pnpm dev`
- [ ] Verify the chat UI renders with MUI styling
- [ ] Test a conversation starter (e.g., weather, chart, form)
- [ ] Verify light/dark mode switching

Closes #392