### PR TITLE
test(openui-cli): add unit tests for CLI helper functions

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -14,6 +14,7 @@
     "build:templates": "node scripts/build-templates.js",
     "build": "pnpm run build:cli && pnpm run build:templates",
     "build:exec": "node dist/index.js",
+    "test": "vitest run",
     "lint:check": "eslint ./src --ignore-pattern 'src/templates/**'",
     "lint:fix": "eslint ./src --fix --ignore-pattern 'src/templates/**'",
     "format:fix": "prettier --write './src/**' '!./src/templates/**'",
@@ -22,7 +23,8 @@
     "ci": "pnpm run lint:check && pnpm run format:check"
   },
   "devDependencies": {
-    "@types/node": "^22.15.32"
+    "@types/node": "^22.15.32",
+    "vitest": "^4.0.18"
   },
   "keywords": [
     "openui",

--- a/packages/openui-cli/src/lib/__tests__/detect-package-manager.test.ts
+++ b/packages/openui-cli/src/lib/__tests__/detect-package-manager.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectPackageManager } from "../detect-package-manager";
+
+describe("detectPackageManager", () => {
+  const originalUserAgent = process.env["npm_config_user_agent"];
+
+  beforeEach(() => {
+    delete process.env["npm_config_user_agent"];
+  });
+
+  afterEach(() => {
+    if (originalUserAgent === undefined) {
+      delete process.env["npm_config_user_agent"];
+    } else {
+      process.env["npm_config_user_agent"] = originalUserAgent;
+    }
+  });
+
+  it("returns 'pnpm dlx' for a pnpm user agent", () => {
+    process.env["npm_config_user_agent"] = "pnpm/9.1.0 npm/? node/v20.0.0 linux x64";
+    expect(detectPackageManager()).toBe("pnpm dlx");
+  });
+
+  it("returns 'yarn dlx' for a yarn user agent", () => {
+    process.env["npm_config_user_agent"] = "yarn/4.1.0 npm/? node/v20.0.0 linux x64";
+    expect(detectPackageManager()).toBe("yarn dlx");
+  });
+
+  it("returns 'bunx' for a bun user agent", () => {
+    process.env["npm_config_user_agent"] = "bun/1.1.0 npm/? node/v20.0.0 linux x64";
+    expect(detectPackageManager()).toBe("bunx");
+  });
+
+  it("returns 'npx' for an npm user agent", () => {
+    process.env["npm_config_user_agent"] = "npm/10.5.0 node/v20.0.0 linux x64";
+    expect(detectPackageManager()).toBe("npx");
+  });
+
+  it("returns 'npx' when the user agent is unset", () => {
+    expect(detectPackageManager()).toBe("npx");
+  });
+
+  it("returns 'npx' for an unrecognized user agent", () => {
+    process.env["npm_config_user_agent"] = "deno/1.40.0";
+    expect(detectPackageManager()).toBe("npx");
+  });
+
+  it("does not match package managers that merely contain the name", () => {
+    // The check is prefix-based, so a stray substring must not trigger a match.
+    process.env["npm_config_user_agent"] = "custom-pnpm/1.0.0";
+    expect(detectPackageManager()).toBe("npx");
+  });
+});

--- a/packages/openui-cli/src/lib/__tests__/resolve-args.test.ts
+++ b/packages/openui-cli/src/lib/__tests__/resolve-args.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveArgs } from "../resolve-args";
+
+const inputMock = vi.fn();
+const selectMock = vi.fn();
+
+// The prompt libraries are imported dynamically inside resolveArgs, so we stub
+// them here to keep the tests deterministic and free of real interactive input.
+vi.mock("@inquirer/prompts", () => ({
+  input: (...args: unknown[]) => inputMock(...args),
+  select: (...args: unknown[]) => selectMock(...args),
+}));
+
+class FakeExitPromptError extends Error {}
+
+vi.mock("@inquirer/core", () => ({
+  ExitPromptError: FakeExitPromptError,
+}));
+
+// process.exit never returns in production; replicate that by throwing so the
+// remaining logic does not run, then assert on the captured exit code.
+class ProcessExit extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+describe("resolveArgs", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    inputMock.mockReset();
+    selectMock.mockReset();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new ProcessExit((code as number) ?? 0);
+    });
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("returns provided values without prompting (interactive)", async () => {
+    const result = await resolveArgs(
+      {
+        name: { value: "my-app" },
+        count: { value: 3 },
+      },
+      true,
+    );
+
+    expect(result).toEqual({ name: "my-app", count: 3 });
+    expect(inputMock).not.toHaveBeenCalled();
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it("returns provided values without prompting (non-interactive)", async () => {
+    const result = await resolveArgs({ name: { value: "my-app" } }, false);
+
+    expect(result).toEqual({ name: "my-app" });
+    expect(inputMock).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it("exits with code 1 on a missing required arg when non-interactive", async () => {
+    await expect(
+      resolveArgs(
+        {
+          entry: {
+            prompt: { type: "input", message: "Entry file path?" },
+            required: true,
+          },
+        },
+        false,
+      ),
+    ).rejects.toBeInstanceOf(ProcessExit);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Missing required argument --entry"),
+    );
+    expect(inputMock).not.toHaveBeenCalled();
+  });
+
+  it("prompts for missing required args when interactive (input)", async () => {
+    inputMock.mockResolvedValue("from-input");
+
+    const result = await resolveArgs(
+      {
+        entry: {
+          prompt: { type: "input", message: "Entry file path?", default: "index.ts" },
+          required: true,
+        },
+      },
+      true,
+    );
+
+    expect(result).toEqual({ entry: "from-input" });
+    expect(inputMock).toHaveBeenCalledWith({
+      message: "Entry file path?",
+      default: "index.ts",
+    });
+  });
+
+  it("prompts using select for select-type configs", async () => {
+    selectMock.mockResolvedValue("react");
+
+    const result = await resolveArgs(
+      {
+        framework: {
+          prompt: {
+            type: "select",
+            message: "Pick a framework",
+            choices: [{ value: "react" }, { value: "vue" }],
+          },
+          required: true,
+        },
+      },
+      true,
+    );
+
+    expect(result).toEqual({ framework: "react" });
+    expect(selectMock).toHaveBeenCalledWith({
+      message: "Pick a framework",
+      choices: [{ value: "react" }, { value: "vue" }],
+    });
+  });
+
+  it("mixes provided values with prompted ones, preserving keys", async () => {
+    inputMock.mockResolvedValue("prompted");
+
+    const result = await resolveArgs(
+      {
+        name: { value: "given" },
+        entry: {
+          prompt: { type: "input", message: "Entry?" },
+          required: true,
+        },
+      },
+      true,
+    );
+
+    expect(result).toEqual({ name: "given", entry: "prompted" });
+    expect(inputMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("exits cleanly (code 0) when the user cancels a prompt", async () => {
+    inputMock.mockRejectedValue(new FakeExitPromptError("cancelled"));
+
+    await expect(
+      resolveArgs(
+        {
+          entry: {
+            prompt: { type: "input", message: "Entry?" },
+            required: true,
+          },
+        },
+        true,
+      ),
+    ).rejects.toBeInstanceOf(ProcessExit);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+  });
+
+  it("rethrows non-cancellation errors from a prompt", async () => {
+    const boom = new Error("unexpected");
+    inputMock.mockRejectedValue(boom);
+
+    await expect(
+      resolveArgs(
+        {
+          entry: {
+            prompt: { type: "input", message: "Entry?" },
+            required: true,
+          },
+        },
+        true,
+      ),
+    ).rejects.toBe(boom);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openui-cli/tsconfig.json
+++ b/packages/openui-cli/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["src/playground", "src/templates"],
+  "exclude": ["src/playground", "src/templates", "**/__tests__/**", "**/*.test.ts"],
   "compilerOptions": {
     "target": "es2022",
     "lib": ["es2022"],

--- a/packages/openui-cli/tsconfig.test.json
+++ b/packages/openui-cli/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1249,6 +1249,9 @@ importers:
       '@types/node':
         specifier: ^22.15.32
         version: 22.15.32
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.15.32)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.43.0)(tsx@4.20.3)(yaml@2.8.3)
 
   packages/react-email:
     dependencies:
@@ -7169,6 +7172,7 @@ packages:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.12':
@@ -8621,6 +8625,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unhead/vue@2.1.13':
     resolution: {integrity: sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==}
@@ -14435,6 +14440,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -27869,7 +27875,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.6.1))
@@ -27889,7 +27895,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.3
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.29.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.29.0(jiti@2.6.1))
@@ -27916,7 +27922,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -27931,14 +27937,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -27953,7 +27959,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@9.29.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1)))(eslint@9.29.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Closes #554.

Adds a Vitest test suite for `packages/openui-cli`, which previously had no test coverage, covering the two isolated helper functions called out in the issue.

### Tests added
- **`src/lib/__tests__/detect-package-manager.test.ts`** (7 tests) — `detectPackageManager()` returns `pnpm dlx` / `yarn dlx` / `bunx` / `npx` based on `npm_config_user_agent`, plus edge cases (unset agent, unrecognized agent, and that matching is prefix-based rather than substring). The env var is saved/restored around each test.
- **`src/lib/__tests__/resolve-args.test.ts`** (8 tests) — `resolveArgs()`:
  - returns provided `{ value }` args without prompting (interactive and non-interactive)
  - exits with code `1` + logs an error on a missing required arg when non-interactive
  - prompts via `input` and `select` when interactive (`@inquirer/prompts` mocked — no real input)
  - mixes provided values with prompted ones, preserving keys
  - exits cleanly (code `0`) on user cancel (`ExitPromptError`)
  - rethrows unexpected prompt errors

### Supporting changes
- `package.json`: added a `test` script (`vitest run`) and `vitest` devDependency (matching the version used by `lang-core`).
- `tsconfig.test.json`: added to match the convention used by the other packages so the repo's typed ESLint config can lint the test files.
- `tsconfig.json`: excluded `**/__tests__/**` and `**/*.test.ts` from the `tsc` build so test files don't leak into the published `dist/`.

## Acceptance criteria
- [x] The CLI package has a working test script — **15 tests pass**
- [x] Helper tests are deterministic and do not require real interactive input (inquirer + `process.exit` mocked)
- [x] Existing build/lint scripts continue to work (`build`, `lint:check`, `format:check`/`ci` all pass; `dist/` stays free of test artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)