### PR TITLE
Add AI Native Dashboard project

### DIFF
--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -77,6 +77,18 @@ const projects: ProjectItem[] = [
     ],
   },
   {
+    name: "AI Native Dashboard",
+    description:
+      "An OpenUI-powered infinite canvas for generating movable, resizable dashboard widgets from natural language.",
+    type: "App",
+    status: "Community",
+    accent: "green",
+    icon: Sparkles,
+    links: [
+      { label: "GitHub", href: "https://github.com/jaibhasin/AI-Native-Dashboard", external: true },
+    ],
+  },
+  {
     name: "Field Theory UI",
     description:
       "A local-first web interface for exploring X/Twitter bookmarks with OpenUI-powered interactive dashboards.",

--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -77,18 +77,6 @@ const projects: ProjectItem[] = [
     ],
   },
   {
-    name: "AI Native Dashboard",
-    description:
-      "An OpenUI-powered infinite canvas for generating movable, resizable dashboard widgets from natural language.",
-    type: "App",
-    status: "Community",
-    accent: "green",
-    icon: Sparkles,
-    links: [
-      { label: "GitHub", href: "https://github.com/jaibhasin/AI-Native-Dashboard", external: true },
-    ],
-  },
-  {
     name: "Field Theory UI",
     description:
       "A local-first web interface for exploring X/Twitter bookmarks with OpenUI-powered interactive dashboards.",
@@ -269,6 +257,18 @@ const projects: ProjectItem[] = [
         href: "https://azukiazusa.dev/blog/openui-framework-for-generative-ui/",
         external: true,
       },
+    ],
+  },
+  {
+    name: "AI Native Dashboard",
+    description:
+      "An OpenUI-powered infinite canvas for generating movable, resizable dashboard widgets from natural language.",
+    type: "App",
+    status: "Community",
+    accent: "green",
+    icon: Sparkles,
+    links: [
+      { label: "GitHub", href: "https://github.com/jaibhasin/AI-Native-Dashboard", external: true },
     ],
   },
 ];


### PR DESCRIPTION
Closes #616.

## What changed
Added AI Native Dashboard to the OpenUI Projects directory as a community app, placed with the other app entries rather than appended to the end.

## Why
The issue requested listing AI Native Dashboard as an OpenUI-powered infinite canvas for generating dashboard widgets from natural language.

## Notes
Used only the GitHub project link because the live demo is not working.

## Validation
- `pnpm --filter @openuidev/docs exec prettier --check app/(home)/projects/page.tsx`
- `pnpm --filter @openuidev/docs exec eslint app/(home)/projects/page.tsx`
- `git diff --check -- 'docs/app/(home)/projects/page.tsx'`