### PR TITLE
chore: centralize react/react-dom/@types/react in pnpm catalog

### DIFF
--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -43,8 +43,8 @@
   },
   "peerDependencies": {
     "@openuidev/react-lang": "workspace:*",
-    "react": "^18.3.1 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "zod": "catalog:"
   },
   "repository": {
@@ -53,7 +53,7 @@
     "directory": "packages/react-email"
   },
   "devDependencies": {
-    "@types/react": "^19",
+    "@types/react": "catalog:",
     "typescript": "^5"
   }
 }

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -39,11 +39,11 @@
     "ci": "pnpm run lint:check && pnpm run format:check"
   },
   "peerDependencies": {
-    "react": "^18.3.1 || ^19.0.0",
+    "react": "catalog:",
     "zustand": "catalog:"
   },
   "devDependencies": {
-    "@types/react": ">=19.0.0",
+    "@types/react": "catalog:",
     "openai": "^6.22.0",
     "vitest": "^4.1.0"
   },

--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.0.0",
-    "react": "^18.3.1 || ^19.0.0",
+    "react": "catalog:",
     "zod": "catalog:"
   },
   "peerDependenciesMeta": {
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "@types/react": "^19.0.0",
+    "@types/react": "catalog:",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -85,8 +85,8 @@
   "peerDependencies": {
     "@openuidev/react-headless": "workspace:^",
     "@openuidev/react-lang": "workspace:^",
-    "react": "^18.3.1 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react": "catalog:",
+    "react-dom": "catalog:",
     "zustand": "catalog:",
     "zod": "catalog:"
   },
@@ -137,7 +137,7 @@
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^22.12.0",
     "@types/node-fetch": "2.6.13",
-    "@types/react": ">=19.0.0",
+    "@types/react": "catalog:",
     "@types/react-dom": ">=19.0.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@typescript-eslint/eslint-plugin": "^8.56.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,18 @@ settings:
 
 catalogs:
   default:
+    '@types/react':
+      specifier: '>=19.0.0'
+      version: 19.2.14
     jsdom:
       specifier: ^26.1.0
       version: 26.1.0
+    react:
+      specifier: ^18.3.1 || ^19.0.0
+      version: 19.2.4
+    react-dom:
+      specifier: ^18.0.0 || ^19.0.0
+      version: 19.2.4
     zod:
       specifier: ^3.25.0 || ^4.0.0
       version: 4.3.6
@@ -1284,17 +1293,17 @@ importers:
         specifier: ^0.0.41
         version: 0.0.41(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^18.3.1 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^18.0.0 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
     devDependencies:
       '@types/react':
-        specifier: ^19
+        specifier: 'catalog:'
         version: 19.2.14
       typescript:
         specifier: ^5
@@ -1306,14 +1315,14 @@ importers:
         specifier: ^0.0.45
         version: 0.0.45
       react:
-        specifier: ^18.3.1 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       zustand:
         specifier: 'catalog:'
         version: 4.5.7(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
       '@types/react':
-        specifier: '>=19.0.0'
+        specifier: 'catalog:'
         version: 19.2.14
       openai:
         specifier: ^6.22.0
@@ -1328,7 +1337,7 @@ importers:
         specifier: workspace:^
         version: link:../lang-core
       react:
-        specifier: ^18.3.1 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       zod:
         specifier: 'catalog:'
@@ -1338,7 +1347,7 @@ importers:
         specifier: ^1.27.1
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       vitest:
         specifier: ^4.0.18
@@ -1410,13 +1419,13 @@ importers:
         specifier: ^0.562.0
         version: 0.562.0(react@19.2.4)
       react:
-        specifier: ^18.3.1 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-day-picker:
         specifier: ^9.5.1
         version: 9.7.0(react@19.2.4)
       react-dom:
-        specifier: ^18.0.0 || ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       react-markdown:
         specifier: ^10.1.0
@@ -1498,7 +1507,7 @@ importers:
         specifier: 2.6.13
         version: 2.6.13
       '@types/react':
-        specifier: '>=19.0.0'
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
         specifier: '>=19.0.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,9 @@ packages:
 # Centralized dependency versions shared across packages.
 # Reference these from a package.json with the "catalog:" protocol.
 catalog:
+  "@types/react": ">=19.0.0"
   jsdom: "^26.1.0"
+  react: "^18.3.1 || ^19.0.0"
+  react-dom: "^18.0.0 || ^19.0.0"
   zod: "^3.25.0 || ^4.0.0"
   zustand: "^4.5.5"


### PR DESCRIPTION
## Summary

Follow-up to the pnpm catalog work (#612). Centralizes the React-related dependencies through the `catalog:` protocol so their versions live in one place.

The `react` / `react-dom` peer ranges were already aligned across the library packages but declared inline in each `package.json`, and `@types/react` was split across three equivalent-but-different ranges.

## Changes

Added to the `catalog` in `pnpm-workspace.yaml`:

| dep | catalog version |
| --- | --- |
| `react` | `^18.3.1 \|\| ^19.0.0` |
| `react-dom` | `^18.0.0 \|\| ^19.0.0` |
| `@types/react` | `>=19.0.0` |

Replaced the inline versions with `catalog:` in:

- `react-lang` — `react` (peer), `@types/react` (`^19.0.0` → catalog)
- `react-ui` — `react`, `react-dom` (peer), `@types/react` (`>=19.0.0` → catalog)
- `react-headless` — `react` (peer), `@types/react` (`>=19.0.0` → catalog)
- `react-email` — `react`, `react-dom` (peer), `@types/react` (`^19` → catalog)

`@types/react` is unified to `>=19.0.0` (matching `react-ui` / `react-headless`).

### Intentionally left as-is

- **`browser-bundle`** `react` / `react-dom` are runtime `dependencies` pinned to `^19.0.0` (the bundled version), not the wider peer range — they shouldn't share the peer catalog entry.
- **`@types/react-dom`** is used in a single package, so there's no version to centralize.
- **`openui-cli` chat template** is outside the workspace (`!**/src/templates/**`), so `catalog:` would not resolve there.

## Verification

- `pnpm install` resolves cleanly (remaining peer warnings are pre-existing and unrelated)
- `@openuidev/react-headless` tests: 70 passed / 70
- `react-lang` / `react-ui` have no test files (`--passWithNoTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)