### PR TITLE
fix(build): fix tsdown external dependency regex on Windows (#626)

### DIFF
--- a/packages/lang-core/tsdown.config.ts
+++ b/packages/lang-core/tsdown.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   deps: {
-    neverBundle: [/^[^./]/],
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/],
   },
 });

--- a/packages/react-email/tsdown.config.ts
+++ b/packages/react-email/tsdown.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   deps: {
-    neverBundle: [/^[^./]/],
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/],
   },
 });

--- a/packages/react-headless/tsdown.config.ts
+++ b/packages/react-headless/tsdown.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   deps: {
-    neverBundle: [/^[^./]/],
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/],
   },
 });

--- a/packages/react-lang/tsdown.config.ts
+++ b/packages/react-lang/tsdown.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   deps: {
-    neverBundle: [/^[^./]/],
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/],
   },
 });

--- a/packages/react-ui/tsdown.config.ts
+++ b/packages/react-ui/tsdown.config.ts
@@ -35,7 +35,7 @@ const shared = {
   outDir: "dist",
   clean: false,
   deps: {
-    neverBundle: [/^[^./]/, /\.scss$/, /\.css$/],
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/, /\.scss$/, /\.css$/],
   },
 } satisfies Parameters<typeof defineConfig>[0];
 


### PR DESCRIPTION
## What

Fixes #626.

The existing `neverBundle` regex (`/^[^./]/`) treats Windows drive-letter paths as external dependencies. During Windows builds this leaves local TypeScript imports unresolved in generated output, which later causes `@openuidev/browser-bundle` to fail with errors such as:

```txt
Could not resolve "./library.ts"
Could not resolve "./Renderer.tsx"
```

This change updates the regex so Windows absolute paths are handled correctly while preserving the existing behavior for package imports.

## Changes

Updated the `neverBundle` configuration in the affected `tsdown` configs to avoid matching Windows absolute paths.

## Test Plan

Tested on Windows 11.

`pnpm install` now completes successfully and `@openuidev/browser-bundle` builds without the unresolved import errors. I also verified that `pnpm --filter @openuidev/docs dev` starts successfully after the change.
