### PR TITLE
chore: centralize typescript version with pnpm catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier-plugin-organize-imports": "^3.2.4",
     "publint": "^0.3.18",
     "tsdown": "^0.21.7",
-    "typescript": "^5.9.3"
+    "typescript": "catalog:"
   },
   "keywords": [
     "openui",

--- a/packages/react-email/package.json
+++ b/packages/react-email/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@types/react": "catalog:",
-    "typescript": "^5"
+    "typescript": "catalog:"
   }
 }

--- a/packages/svelte-lang/package.json
+++ b/packages/svelte-lang/package.json
@@ -71,7 +71,7 @@
 		"jsdom": "catalog:",
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
-		"typescript": "^5.0.0",
+		"typescript": "catalog:",
 		"vite": "^6.0.0",
 		"vitest": "^4.1.0"
 	}

--- a/packages/svelte-lang/src/__tests__/library.test.ts
+++ b/packages/svelte-lang/src/__tests__/library.test.ts
@@ -66,8 +66,8 @@ describe("createLibrary", () => {
   it("creates a library with a components record", () => {
     const lib = createLibrary({ components: [TextContent, Container] });
 
-    expect(lib.components.TextContent).toBe(TextContent);
-    expect(lib.components.Container).toBe(Container);
+    expect(lib.components["TextContent"]).toBe(TextContent);
+    expect(lib.components["Container"]).toBe(Container);
     expect(Object.keys(lib.components)).toHaveLength(2);
   });
 

--- a/packages/vue-lang/package.json
+++ b/packages/vue-lang/package.json
@@ -65,7 +65,7 @@
 		"@vitejs/plugin-vue": "^6.0.7",
 		"@vue/test-utils": "^2.4.0",
 		"jsdom": "catalog:",
-		"typescript": "^5.0.0",
+		"typescript": "catalog:",
 		"vite": "^6.0.0",
 		"vitest": "^4.1.0",
 		"vue": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     react-dom:
       specifier: ^18.0.0 || ^19.0.0
       version: 19.2.4
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
     zod:
       specifier: ^3.25.0 || ^4.0.0
       version: 4.3.6
@@ -106,7 +109,7 @@ importers:
         specifier: ^0.21.7
         version: 0.21.10(@arethetypeswrong/core@0.18.2)(publint@0.3.18)(synckit@0.11.12)(typescript@5.9.3)
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   docs:
@@ -1333,7 +1336,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.14
       typescript:
-        specifier: ^5
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/react-headless:
@@ -1640,7 +1643,7 @@ importers:
         specifier: ^4.0.0
         version: 4.4.5(picomatch@4.0.4)(svelte@5.55.9(@typescript-eslint/types@8.59.4))(typescript@5.9.3)
       typescript:
-        specifier: ^5.0.0
+        specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: ^6.0.0
@@ -1668,7 +1671,7 @@ importers:
         specifier: 'catalog:'
         version: 26.1.0
       typescript:
-        specifier: ^5.0.0
+        specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,5 +19,6 @@ catalog:
   jsdom: "^26.1.0"
   react: "^18.3.1 || ^19.0.0"
   react-dom: "^18.0.0 || ^19.0.0"
+  typescript: "^5.9.3"
   zod: "^3.25.0 || ^4.0.0"
   zustand: "^4.5.5"


### PR DESCRIPTION
## What

`typescript` was declared as a devDependency with divergent specs across the library packages and the monorepo root. Move the version into the pnpm catalog and reference it via the `catalog:` protocol so the toolchain version lives in one place — mirroring #612 / #624 / #634.

Cataloged spec: **`^5.9.3`** (the root's existing spec).

| manifest | before | after |
|---|---|---|
| `package.json` (root) | `^5.9.3` | `catalog:` |
| `packages/react-email` | `^5` | `catalog:` |
| `packages/svelte-lang` | `^5.0.0` | `catalog:` |
| `packages/vue-lang` | `^5.0.0` | `catalog:` |

## No resolved-version change

Every importer already resolved to `typescript@5.9.3`, so this only tightens the declared specs onto the single catalog entry — the lockfile diff is just the four specifiers flipping to `catalog:` plus the new catalog entry. `examples/` and `docs/` keep their inline `^5` / `~5.9.2` specs, matching #612's library-only scope.

## Drive-by fix

`fix(svelte-lang)`: the test `src/__tests__/library.test.ts` used dot access on `lib.components` (a string-index-signature type), which `noPropertyAccessFromIndexSignature` (set in the root tsconfig) rejects. Switched to bracket access, matching the parallel `vue-lang` test. This was already failing `svelte-check` on `main`; surfaced while verifying this change.

## Verification

- `react-email`, `svelte-lang`, `vue-lang`: **build + typecheck/check pass** with `typescript@5.9.3` resolved from the catalog.
- `svelte-lang` `vitest`: 30/30 pass.
- `pnpm install --frozen-lockfile`: clean (lockfile consistent with manifests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)