### PR TITLE
chore: centralize @types/node version with pnpm catalog

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
     "@types/mdx": "^2.0.13",
-    "@types/node": "^25.2.3",
+    "@types/node": "catalog:",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint-config-next": "16.2.6",

--- a/examples/form-generator/package.json
+++ b/examples/form-generator/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@openuidev/cli": "workspace:*",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/hands-on-table-chat/package.json
+++ b/examples/hands-on-table-chat/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/mastra-chat/package.json
+++ b/examples/mastra-chat/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@openuidev/cli": "workspace:*",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/material-ui-chat/package.json
+++ b/examples/material-ui-chat/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@openuidev/cli": "workspace:*",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/multi-agent-chat/package.json
+++ b/examples/multi-agent-chat/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/openui-artifact-demo/package.json
+++ b/examples/openui-artifact-demo/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@openuidev/cli": "workspace:*",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-syntax-highlighter": "^15.5.13",

--- a/examples/openui-chat/package.json
+++ b/examples/openui-chat/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@openuidev/cli": "workspace:*",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/openui-dashboard/package.json
+++ b/examples/openui-dashboard/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/openui-react-native/backend/package.json
+++ b/examples/openui-react-native/backend/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@openuidev/react-lang": "^0.1.3",
-    "@types/node": "^22",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^5",

--- a/examples/react-email/package.json
+++ b/examples/react-email/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/shadcn-chat/package.json
+++ b/examples/shadcn-chat/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/supabase-chat/package.json
+++ b/examples/supabase-chat/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/examples/vercel-ai-chat/package.json
+++ b/examples/vercel-ai-chat/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "catalog:",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -22,7 +22,7 @@
     "ci": "pnpm run lint:check && pnpm run format:check"
   },
   "devDependencies": {
-    "@types/node": "^22.15.32",
+    "@types/node": "catalog:",
     "rimraf": "^5.0.7"
   },
   "keywords": [

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -135,7 +135,7 @@
     "@storybook/test": "^8.5.3",
     "@storybook/theming": "^8.5.3",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^22.12.0",
+    "@types/node": "catalog:",
     "@types/node-fetch": "2.6.13",
     "@types/react": "catalog:",
     "@types/react-dom": ">=19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@types/node':
+      specifier: ^22.15.32
+      version: 22.19.19
     '@types/react':
       specifier: '>=19.0.0'
       version: 19.2.14
@@ -140,7 +143,7 @@ importers:
         version: 16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6)
       fumadocs-mdx:
         specifier: 14.3.2
-        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react@19.2.4)(vite@7.3.3(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react@19.2.4)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       fumadocs-ui:
         specifier: 16.9.1
         version: 16.9.1(@emotion/is-prop-valid@1.4.0)(@tailwindcss/oxide@4.2.2)(@takumi-rs/image-response@0.68.17)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.1)
@@ -191,8 +194,8 @@ importers:
         specifier: ^2.0.13
         version: 2.0.13
       '@types/node':
-        specifier: ^25.2.3
-        version: 25.3.2
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -280,8 +283,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -350,8 +353,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -414,8 +417,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -481,8 +484,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/openui-cli
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -542,8 +545,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -603,8 +606,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -664,8 +667,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -728,8 +731,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -770,8 +773,8 @@ importers:
         specifier: ^0.1.3
         version: 0.1.3(react@19.2.4)
       '@types/node':
-        specifier: ^22
-        version: 22.15.32
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -868,8 +871,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1028,8 +1031,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1083,8 +1086,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1190,8 +1193,8 @@ importers:
         specifier: ^4
         version: 4.2.1
       '@types/node':
-        specifier: ^20
-        version: 20.19.35
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/react':
         specifier: ^19
         version: 19.2.14
@@ -1296,10 +1299,10 @@ importers:
     dependencies:
       '@inquirer/core':
         specifier: ^11.1.5
-        version: 11.1.5(@types/node@22.15.32)
+        version: 11.1.5(@types/node@22.19.19)
       '@inquirer/prompts':
         specifier: ^8.3.0
-        version: 8.3.0(@types/node@22.15.32)
+        version: 8.3.0(@types/node@22.19.19)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -1308,8 +1311,8 @@ importers:
         version: 0.25.12
     devDependencies:
       '@types/node':
-        specifier: ^22.15.32
-        version: 22.15.32
+        specifier: 'catalog:'
+        version: 22.19.19
       rimraf:
         specifier: ^5.0.7
         version: 5.0.10
@@ -1520,7 +1523,7 @@ importers:
         version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^8.5.3
-        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       '@storybook/test':
         specifier: ^8.5.3
         version: 8.6.18(storybook@8.6.18(prettier@3.5.3))
@@ -1531,8 +1534,8 @@ importers:
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: ^22.12.0
-        version: 22.15.32
+        specifier: 'catalog:'
+        version: 22.19.19
       '@types/node-fetch':
         specifier: 2.6.13
         version: 2.6.13
@@ -1607,10 +1610,10 @@ importers:
         version: 4.20.3
       vite:
         specifier: ^6.4.2
-        version: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+        version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.15.32)(jsdom@29.1.1)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@29.1.1)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       webpack:
         specifier: ^5.104.1
         version: 5.107.2(esbuild@0.25.12)(lightningcss@1.32.0)(postcss@8.5.15)
@@ -7104,6 +7107,7 @@ packages:
   '@rolldown/binding-darwin-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
@@ -8402,12 +8406,6 @@ packages:
 
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
-  '@types/node@20.19.35':
-    resolution: {integrity: sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==}
-
-  '@types/node@22.15.32':
-    resolution: {integrity: sha512-3jigKqgSjsH6gYZv2nEsqdXfZqIFGAV36XYYjf9KGZ3PSG+IhLecqPnI310RvjutyMwifE2hhhNEklOUrvx/wA==}
 
   '@types/node@22.19.19':
     resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
@@ -18815,122 +18813,122 @@ snapshots:
 
   '@inquirer/ansi@2.0.3': {}
 
-  '@inquirer/checkbox@5.1.0(@types/node@22.15.32)':
+  '@inquirer/checkbox@5.1.0(@types/node@22.19.19)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/confirm@6.0.8(@types/node@22.15.32)':
+  '@inquirer/confirm@6.0.8(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/core@11.1.5(@types/node@22.15.32)':
+  '@inquirer/core@11.1.5(@types/node@22.19.19)':
     dependencies:
       '@inquirer/ansi': 2.0.3
       '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.0
       mute-stream: 3.0.0
       signal-exit: 4.1.0
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/editor@5.0.8(@types/node@22.15.32)':
+  '@inquirer/editor@5.0.8(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/external-editor': 2.0.3(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/expand@5.0.8(@types/node@22.15.32)':
+  '@inquirer/expand@5.0.8(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/external-editor@2.0.3(@types/node@22.15.32)':
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.19)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
   '@inquirer/figures@2.0.3': {}
 
-  '@inquirer/input@5.0.8(@types/node@22.15.32)':
+  '@inquirer/input@5.0.8(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/number@4.0.8(@types/node@22.15.32)':
+  '@inquirer/number@4.0.8(@types/node@22.19.19)':
     dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/password@5.0.8(@types/node@22.15.32)':
-    dependencies:
-      '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
-    optionalDependencies:
-      '@types/node': 22.15.32
-
-  '@inquirer/prompts@8.3.0(@types/node@22.15.32)':
-    dependencies:
-      '@inquirer/checkbox': 5.1.0(@types/node@22.15.32)
-      '@inquirer/confirm': 6.0.8(@types/node@22.15.32)
-      '@inquirer/editor': 5.0.8(@types/node@22.15.32)
-      '@inquirer/expand': 5.0.8(@types/node@22.15.32)
-      '@inquirer/input': 5.0.8(@types/node@22.15.32)
-      '@inquirer/number': 4.0.8(@types/node@22.15.32)
-      '@inquirer/password': 5.0.8(@types/node@22.15.32)
-      '@inquirer/rawlist': 5.2.4(@types/node@22.15.32)
-      '@inquirer/search': 4.1.4(@types/node@22.15.32)
-      '@inquirer/select': 5.1.0(@types/node@22.15.32)
-    optionalDependencies:
-      '@types/node': 22.15.32
-
-  '@inquirer/rawlist@5.2.4(@types/node@22.15.32)':
-    dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
-    optionalDependencies:
-      '@types/node': 22.15.32
-
-  '@inquirer/search@4.1.4(@types/node@22.15.32)':
-    dependencies:
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
-    optionalDependencies:
-      '@types/node': 22.15.32
-
-  '@inquirer/select@5.1.0(@types/node@22.15.32)':
+  '@inquirer/password@5.0.8(@types/node@22.19.19)':
     dependencies:
       '@inquirer/ansi': 2.0.3
-      '@inquirer/core': 11.1.5(@types/node@22.15.32)
-      '@inquirer/figures': 2.0.3
-      '@inquirer/type': 4.0.3(@types/node@22.15.32)
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
 
-  '@inquirer/type@4.0.3(@types/node@22.15.32)':
+  '@inquirer/prompts@8.3.0(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.0(@types/node@22.19.19)
+      '@inquirer/confirm': 6.0.8(@types/node@22.19.19)
+      '@inquirer/editor': 5.0.8(@types/node@22.19.19)
+      '@inquirer/expand': 5.0.8(@types/node@22.19.19)
+      '@inquirer/input': 5.0.8(@types/node@22.19.19)
+      '@inquirer/number': 4.0.8(@types/node@22.19.19)
+      '@inquirer/password': 5.0.8(@types/node@22.19.19)
+      '@inquirer/rawlist': 5.2.4(@types/node@22.19.19)
+      '@inquirer/search': 4.1.4(@types/node@22.19.19)
+      '@inquirer/select': 5.1.0(@types/node@22.19.19)
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
+
+  '@inquirer/rawlist@5.2.4(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
+  '@inquirer/search@4.1.4(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
+  '@inquirer/select@5.1.0(@types/node@22.19.19)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@22.19.19)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.19)
+    optionalDependencies:
+      '@types/node': 22.19.19
+
+  '@inquirer/type@4.0.3(@types/node@22.19.19)':
+    optionalDependencies:
+      '@types/node': 22.19.19
 
   '@internationalized/date@3.12.0':
     dependencies:
@@ -18988,14 +18986,14 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       jest-mock: 29.7.0
 
   '@jest/fake-timers@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -19029,16 +19027,16 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       glob: 10.5.0
       magic-string: 0.27.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -24376,13 +24374,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@storybook/builder-vite@8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       '@storybook/csf-plugin': 8.6.18(storybook@8.6.18(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.18(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@storybook/components@8.6.18(storybook@8.6.18(prettier@3.5.3))':
     dependencies:
@@ -24449,11 +24447,11 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 8.6.18(prettier@3.5.3)
 
-  '@storybook/react-vite@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@storybook/react-vite@8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       '@rollup/pluginutils': 5.2.0(rollup@4.60.4)
-      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+      '@storybook/builder-vite': 8.6.18(storybook@8.6.18(prettier@3.5.3))(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       '@storybook/react': 8.6.18(@storybook/test@8.6.18(storybook@8.6.18(prettier@3.5.3)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.6.18(prettier@3.5.3))(typescript@5.9.3)
       find-up: 5.0.0
       magic-string: 0.30.21
@@ -24463,7 +24461,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 8.6.18(prettier@3.5.3)
       tsconfig-paths: 4.2.0
-      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
     optionalDependencies:
       '@storybook/test': 8.6.18(storybook@8.6.18(prettier@3.5.3))
     transitivePeerDependencies:
@@ -24875,7 +24873,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/chai@5.2.3':
     dependencies:
@@ -24884,13 +24882,13 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/cookie@0.6.0': {}
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/d3-array@3.2.1': {}
 
@@ -25033,7 +25031,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -25049,7 +25047,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/hast@2.3.10':
     dependencies:
@@ -25097,25 +25095,17 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       form-data: 4.0.5
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       form-data: 4.0.5
 
   '@types/node@18.19.130':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/node@20.19.35':
-    dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@22.15.32':
-    dependencies:
-      undici-types: 6.21.0
 
   '@types/node@22.19.19':
     dependencies:
@@ -25162,16 +25152,16 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
@@ -25457,13 +25447,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
@@ -26644,7 +26634,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -26655,7 +26645,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -27789,7 +27779,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.29.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.29.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.7.0)))(eslint@9.29.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -27811,7 +27801,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.29.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.29.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.29.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.29.0(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.29.0(jiti@2.7.0)))(eslint@9.29.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -28562,7 +28552,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react@19.2.4)(vite@7.3.3(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)):
+  fumadocs-mdx@14.3.2(@types/mdast@4.0.4)(@types/mdx@2.0.13)(@types/react@19.2.14)(fumadocs-core@16.9.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.570.0(react@19.2.4))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.3.6))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2))(react@19.2.4)(vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -28588,7 +28578,7 @@ snapshots:
       '@types/react': 19.2.14
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.89.2)
       react: 19.2.4
-      vite: 7.3.3(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -29496,7 +29486,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -29506,7 +29496,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -29533,7 +29523,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       jest-util: 29.7.0
 
   jest-regex-util@29.6.3: {}
@@ -29541,7 +29531,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -29558,13 +29548,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -32299,7 +32289,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -34334,7 +34324,7 @@ snapshots:
   type-graphql@2.0.0-rc.1(class-validator@0.14.4)(graphql-scalars@1.25.0(graphql@16.14.0))(graphql@16.14.0):
     dependencies:
       '@graphql-yoga/subscription': 5.0.5
-      '@types/node': 22.19.19
+      '@types/node': 25.3.2
       '@types/semver': 7.7.1
       graphql: 16.14.0
       graphql-query-complexity: 0.12.0(graphql@16.14.0)
@@ -34872,7 +34862,7 @@ snapshots:
       vite: 7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
       vue: 3.5.34(typescript@5.9.3)
 
-  vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3):
+  vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -34881,7 +34871,7 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
@@ -34907,6 +34897,25 @@ snapshots:
       terser: 5.48.0
       tsx: 4.20.3
       yaml: 2.8.3
+
+  vite@7.3.3(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      sass: 1.89.2
+      terser: 5.48.0
+      tsx: 4.20.3
+      yaml: 2.8.3
+    optional: true
 
   vite@7.3.3(@types/node@25.3.2)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3):
     dependencies:
@@ -34948,10 +34957,10 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.15.32)(jsdom@29.1.1)(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@22.19.19)(jsdom@29.1.1)(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.7(vite@6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -34968,11 +34977,11 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@22.15.32)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 22.15.32
+      '@types/node': 22.19.19
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 # Centralized dependency versions shared across packages.
 # Reference these from a package.json with the "catalog:" protocol.
 catalog:
+  "@types/node": "^22.15.32"
   "@types/react": ">=19.0.0"
   "@typescript-eslint/eslint-plugin": "^8.56.1"
   eslint: "^9.0.0"


### PR DESCRIPTION
## What

Adds `@types/node` to the pnpm catalog and references it via the `catalog:` protocol across all packages.

## Why

`@types/node` versions had drifted across the workspace:

| version | where |
|---|---|
| `^20` | most examples |
| `^22` | openui-react-native/backend |
| `^22.12.0` | packages/react-ui |
| `^22.15.32` | packages/openui-cli |
| `^25.2.3` | docs |

Unified on **`^22.15.32`** (Node 22 LTS, already used by the core `react-ui` / `openui-cli` packages). `docs` moves from `^25` down to the LTS line.

This follows the same pattern as the already-merged react (#624), eslint (#634) and typescript (#645) catalog work.

## Notes

- 16 `package.json` files updated to `"@types/node": "catalog:"`.
- Lockfile regenerated; catalog resolves to `22.19.19`.
- Pre-existing peer-dependency warnings (openai/zod, vue, nuxt) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)