### PR TITLE
chore: centralize esbuild version with pnpm catalog

### DIFF
--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -56,7 +56,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "esbuild": "^0.25.12",
+    "esbuild": "catalog:",
     "rimraf": "^5.0.7"
   }
 }

--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -53,6 +53,6 @@
     "@inquirer/core": "^11.1.5",
     "@inquirer/prompts": "^8.3.0",
     "commander": "^14.0.3",
-    "esbuild": "^0.25.10"
+    "esbuild": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@typescript-eslint/eslint-plugin':
       specifier: ^8.56.1
       version: 8.59.4
+    esbuild:
+      specifier: ^0.25.12
+      version: 0.25.12
     eslint:
       specifier: ^9.0.0
       version: 9.29.0
@@ -1343,7 +1346,7 @@ importers:
         version: 19.2.4(react@19.2.4)
     devDependencies:
       esbuild:
-        specifier: ^0.25.12
+        specifier: 'catalog:'
         version: 0.25.12
       rimraf:
         specifier: ^5.0.7
@@ -1374,7 +1377,7 @@ importers:
         specifier: ^14.0.3
         version: 14.0.3
       esbuild:
-        specifier: ^0.25.10
+        specifier: 'catalog:'
         version: 0.25.12
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   "@types/node": "^22.15.32"
   "@types/react": ">=19.0.0"
   "@typescript-eslint/eslint-plugin": "^8.56.1"
+  esbuild: "^0.25.12"
   eslint: "^9.0.0"
   eslint-config-prettier: "^10.1.8"
   eslint-plugin-prettier: "^5.5.5"


### PR DESCRIPTION
## What

`esbuild` was pinned independently in two internal packages, drifting between minor patch versions:

- `packages/openui-cli` — `^0.25.10` (dependencies)
- `packages/browser-bundle` — `^0.25.12` (devDependencies)

This moves `esbuild` into the shared pnpm `catalog:` at `^0.25.12` (the higher of the two, so neither package downgrades) and switches both packages to reference `catalog:`.

## Why

Follows the same pattern as the recently centralized `@types/node` (#653/#656) and the eslint/typescript tooling already in the catalog — one source of truth, bump in one place, no silent drift between packages.

## Notes

- `openui-cli` effectively moves `0.25.10 → 0.25.12`, a patch within the same `^0.25` range — no behavior change.
- Lockfile regenerated via `pnpm install --lockfile-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)