### PR TITLE
docs: add GAIA to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -19,6 +19,7 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 | [Standard Metrics](https://standardmetrics.io/) | [Elias Tounzal](https://github.com/eliasinho) | Standard Metrics combines institutional-grade infrastructure with cutting-edge AI to transform portfolio management |
 | [openui-forge](https://github.com/OthmanAdi/openui-forge) | [OthmanAdi](https://github.com/OthmanAdi)   | Cross-IDE agent skill for OpenUI. Templates for OpenAI, Anthropic, LangChain, Vercel AI SDK, plus FastAPI / Go / Rust backends. Mirrors to 11 agent platforms.                  |
 | [Entelligence.AI](https://entelligence.ai) | [Aiswarya Sankar](https://www.linkedin.com/in/sankaraiswarya/)   | AI platform that gives developers noise-free, self-verifying code reviews to catch bugs before they ship, while providing engineering leaders with the analytics needed to measure the true ROI of their AI coding tools.            |
+| [GAIA](https://heygaia.io) | [Aryan Randeriya](https://github.com/aryanranderiya) | GAIA is a proactive personal AI assistant that uses OpenUI Lang to let its backend LLM emit rich, interactive React components inline in chat responses — rendering cards, lists, and other generative UI directly in the conversation instead of plain text. |
 
 <!--
 Example row, copy and edit:


### PR DESCRIPTION
Adds GAIA to the OpenUI adopters list, per Visharad Kashyap's request.

| Field | Value |
| :-- | :-- |
| **Organization / Project** | [GAIA](https://heygaia.io) |
| **Contact** | [Aryan Randeriya](https://github.com/aryanranderiya) |
| **Use of OpenUI** | GAIA is a proactive personal AI assistant that uses OpenUI Lang to let its backend LLM emit rich, interactive React components inline in chat responses — rendering cards, lists, and other generative UI directly in the conversation instead of plain text. |

Single-row addition to the table in `ADOPTERS.md`; no other changes.