### PR TITLE
test: add OpenUI CLI helper coverage

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -14,6 +14,7 @@
     "build:templates": "node scripts/build-templates.js",
     "build": "pnpm run build:cli && pnpm run build:templates",
     "build:exec": "node dist/index.js",
+    "test": "vitest run src",
     "lint:check": "eslint ./src --ignore-pattern 'src/templates/**'",
     "lint:fix": "eslint ./src --fix --ignore-pattern 'src/templates/**'",
     "format:fix": "prettier --write './src/**' '!./src/templates/**'",
@@ -23,7 +24,8 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "rimraf": "^5.0.7"
+    "rimraf": "^5.0.7",
+    "vitest": "^4.1.0"
   },
   "keywords": [
     "openui",

--- a/packages/openui-cli/src/lib/detect-package-manager.test.ts
+++ b/packages/openui-cli/src/lib/detect-package-manager.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { detectPackageManager } from "./detect-package-manager";
+
+const originalUserAgent = process.env["npm_config_user_agent"];
+
+afterEach(() => {
+  if (originalUserAgent === undefined) {
+    delete process.env["npm_config_user_agent"];
+  } else {
+    process.env["npm_config_user_agent"] = originalUserAgent;
+  }
+});
+
+describe("detectPackageManager", () => {
+  it.each([
+    ["pnpm dlx", "pnpm/10.0.0 npm/? node/v22.0.0"],
+    ["yarn dlx", "yarn/4.0.0 npm/? node/v22.0.0"],
+    ["bunx", "bun/1.2.0 npm/? node/v22.0.0"],
+    ["npx", "npm/11.0.0 node/v22.0.0"],
+    ["npx", undefined],
+  ])("returns %s for user agent %s", (expected, userAgent) => {
+    if (userAgent === undefined) {
+      delete process.env["npm_config_user_agent"];
+    } else {
+      process.env["npm_config_user_agent"] = userAgent;
+    }
+
+    expect(detectPackageManager()).toBe(expected);
+  });
+});

--- a/packages/openui-cli/src/lib/resolve-args.test.ts
+++ b/packages/openui-cli/src/lib/resolve-args.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveArgs } from "./resolve-args";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveArgs", () => {
+  it("returns provided values without prompting", async () => {
+    await expect(
+      resolveArgs(
+        {
+          name: { value: "demo-app" },
+          template: { value: "nextjs" },
+        },
+        false,
+      ),
+    ).resolves.toEqual({
+      name: "demo-app",
+      template: "nextjs",
+    });
+  });
+
+  it("exits predictably for missing required args in non-interactive mode", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`process.exit:${code}`);
+    });
+
+    await expect(
+      resolveArgs(
+        {
+          name: {
+            prompt: { type: "input", message: "Project name" },
+            required: true,
+          },
+        },
+        false,
+      ),
+    ).rejects.toThrow("process.exit:1");
+
+    expect(errorSpy).toHaveBeenCalledWith("Error: Missing required argument --name");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/openui-cli/tsconfig.json
+++ b/packages/openui-cli/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.json",
   "include": ["src/**/*.ts"],
-  "exclude": ["src/playground", "src/templates"],
+  "exclude": ["src/playground", "src/templates", "src/**/*.test.ts", "src/**/*.spec.ts"],
   "compilerOptions": {
     "target": "es2022",
     "lib": ["es2022"],

--- a/packages/openui-cli/tsconfig.test.json
+++ b/packages/openui-cli/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "src/templates"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1432,6 +1432,9 @@ importers:
       rimraf:
         specifier: ^5.0.7
         version: 5.0.10
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0))
 
   packages/react-email:
     dependencies:


### PR DESCRIPTION
## Summary
- Add focused Vitest coverage for CLI package-manager detection.
- Add non-interactive argument resolution coverage for provided and missing required args.
- Keep CLI builds clean by excluding test files from the production tsconfig and adding a test-only tsconfig.

Fixes #554

## Verification
- `pnpm --filter @openuidev/cli run test`
- `pnpm --filter @openuidev/cli run build:cli`
- `pnpm exec prettier --check packages/openui-cli/package.json packages/openui-cli/tsconfig.json packages/openui-cli/tsconfig.test.json packages/openui-cli/src/lib/detect-package-manager.test.ts packages/openui-cli/src/lib/resolve-args.test.ts`
- `pnpm exec eslint src/lib/detect-package-manager.test.ts src/lib/resolve-args.test.ts` from `packages/openui-cli`
- `pnpm install --frozen-lockfile --ignore-scripts`
