### PR TITLE
fix(react-ui): avoid nested button in foldable section trigger

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -112,6 +112,7 @@
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slider": "^1.2.2",
+    "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.1.2",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toggle-group": "^1.1.2",

--- a/packages/react-ui/src/components/IconButton/IconButton.tsx
+++ b/packages/react-ui/src/components/IconButton/IconButton.tsx
@@ -1,3 +1,4 @@
+import { Slot, Slottable } from "@radix-ui/react-slot";
 import clsx from "clsx";
 import { ButtonHTMLAttributes, forwardRef, ReactNode } from "react";
 
@@ -19,6 +20,12 @@ export interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement>
   shape?: IconButtonShape;
   className?: string;
   appearance?: IconButtonAppearance;
+  /**
+   * Render as the provided child element instead of a `<button>`. Useful when the
+   * icon button is nested inside another interactive element (e.g. an accordion
+   * trigger) where a nested `<button>` would be invalid HTML.
+   */
+  asChild?: boolean;
 }
 
 const normalIconButtonVariants = {
@@ -55,14 +62,18 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props,
     size = "medium",
     shape = "square",
     appearance = "normal",
+    asChild = false,
+    children,
     ...rest
   } = props;
 
   const iconButtonVariants =
     appearance === "normal" ? normalIconButtonVariants : destructiveIconButtonVariants;
 
+  const Comp = asChild ? Slot : "button";
+
   return (
-    <button
+    <Comp
       ref={ref}
       className={clsx(
         "openui-icon-button",
@@ -73,8 +84,9 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>((props,
       )}
       {...rest}
     >
+      <Slottable>{children}</Slottable>
       {icon && <span className="openui-icon-button-icon">{icon}</span>}
-    </button>
+    </Comp>
   );
 });
 

--- a/packages/react-ui/src/components/SectionBlock/FoldableSection.tsx
+++ b/packages/react-ui/src/components/SectionBlock/FoldableSection.tsx
@@ -63,13 +63,16 @@ export const FoldableSectionTrigger = forwardRef<
         <Separator className="openui-foldable-section-trigger-content-separator" />
         <div className="openui-foldable-section-trigger-content-icon-button-wrapper">
           <IconButton
+            asChild
             icon={
               <ChevronRight className="openui-foldable-section-trigger-content-icon-button-icon" />
             }
             size="3-extra-small"
             variant="secondary"
             className="openui-foldable-section-trigger-content-icon-button"
-          />
+          >
+            <span aria-hidden="true" />
+          </IconButton>
           <div className="openui-foldable-section-trigger-content-text">{text}</div>
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1543,6 +1543,9 @@ importers:
       '@radix-ui/react-slider':
         specifier: ^1.2.2
         version: 1.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@radix-ui/react-switch':
         specifier: ^1.1.2
         version: 1.2.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## What

The foldable section trigger rendered an `IconButton` (a `<button>`) inside Radix's `AccordionTrigger` (also a `<button>`). Nested `<button>` elements are invalid HTML and caused a React hydration error:

> In HTML, `<button>` cannot be a descendant of `<button>`. This will cause a hydration error.

## Changes

- Made `IconButton` polymorphic via Radix `Slot` + `Slottable` with a new `asChild` prop, so it can render as a caller-provided element instead of a `<button>` while preserving the inner `.openui-icon-button-icon` wrapper (required by the size CSS descendant selectors).
- Updated `FoldableSectionTrigger` to render the decorative chevron with `asChild` + an `aria-hidden` `<span>` host, eliminating the nested `<button>`.
- Added `@radix-ui/react-slot` as a direct dependency of `@openuidev/react-ui` (with the corresponding minimal `pnpm-lock.yaml` importer entry).

## Test Plan

Describe how you validated this change.

- [x] Verified locally
  - `pnpm --filter @openuidev/react-ui typecheck` passes.
  - `pnpm install --frozen-lockfile` passes (lockfile consistent).
  - Default (non-`asChild`) `IconButton` usage is unchanged; only the foldable trigger renders the chevron as a span, so the nested-button hydration error no longer occurs.

## Checklist

- [ ] I linked a related issue, if applicable
- [ ] I updated docs/README when needed
- [x] I considered backwards compatibility
