### PR TITLE
ci: increase build heap limit

### DIFF
--- a/.github/workflows/build-js.yml
+++ b/.github/workflows/build-js.yml
@@ -26,7 +26,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build affected projects
-        run: pnpm -r build
+        run: pnpm -r --workspace-concurrency=1 build
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
 
       - name: Check affected projects
         run: pnpm -r run ci


### PR DESCRIPTION
## What

Increase the available Node.js heap and run workspace builds sequentially.

## Why

The `openui-react-native/backend` Next.js build exceeded Node’s default ~4 GB heap limit during type-checking, causing CI to terminate with:

> JavaScript heap out of memory

## Changes

- Set `NODE_OPTIONS=--max-old-space-size=6144`
- Set pnpm workspace build concurrency to `1`

## Validation

- Workflow YAML parses successfully
- Confirmed `--workspace-concurrency` is supported by the configured pnpm version