### PR TITLE
fix: handle hosted demo credit-limit errors

### DIFF
--- a/docs/lib/demo-credits.ts
+++ b/docs/lib/demo-credits.ts
@@ -50,9 +50,21 @@ function hasPaymentRequiredCode(value: unknown, depth = 0): boolean {
   return false;
 }
 
+function hasCreditsExhaustedMessage(value: unknown, depth = 0): boolean {
+  if (depth > 4 || value == null) return false;
+
+  if (typeof value === "string") {
+    return /credit|quota|rate[\s_-]*limit|too many requests|insufficient funds/i.test(value);
+  }
+
+  if (typeof value !== "object") return false;
+
+  return Object.values(value).some((child) => hasCreditsExhaustedMessage(child, depth + 1));
+}
+
 export function isDemoCreditsExhaustedError(error: unknown, status?: number): boolean {
-  if (status === 402) return true;
-  return hasPaymentRequiredCode(error);
+  if (status === 402 || status === 429) return true;
+  return hasPaymentRequiredCode(error) || hasCreditsExhaustedMessage(error);
 }
 
 export function createDemoCreditsExhaustedResponse(): Response {


### PR DESCRIPTION
## Summary

Improves the hosted demo credit-limit handling so OpenRouter credit/rate-limit failures show the existing friendly demo-credits dialog instead of surfacing as a generic server error.

## Related issue

Fixes #514

## Changes

- Keep the existing HTTP 402 handling.
- Treat HTTP 429 provider responses as demo-credit exhaustion for the hosted demos.
- Detect nested provider messages mentioning credits, quota, rate limits, too many requests, or insufficient funds.
- Reuse the existing `createDemoCreditsExhaustedResponse()` payload so both playground and GitHub demo routes benefit without route-specific duplication.

## Testing

- `pnpm --filter @openuidev/docs run types:check`
- `pnpm exec prettier --check docs/lib/demo-credits.ts`
- `git diff --check`
