### PR TITLE
docs: support Requesty as an OpenAI-compatible provider in examples

### DIFF
--- a/examples/openui-chat/README.md
+++ b/examples/openui-chat/README.md
@@ -38,7 +38,7 @@ OPENAI_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_MODEL=openai/gpt-5.5
 ```
 
-This also works with other OpenAI-compatible providers.
+This also works with other OpenAI-compatible providers, such as [Requesty](https://requesty.ai) (base URL `https://router.requesty.ai/v1`).
 
 ## Learn More
 

--- a/examples/openui-dashboard/README.md
+++ b/examples/openui-dashboard/README.md
@@ -19,6 +19,7 @@ export OPENAI_API_KEY=sk-...
 # export LLM_API_KEY=your-key
 # export LLM_BASE_URL=https://openrouter.ai/api/v1
 # export LLM_MODEL=your-model
+# (e.g. Requesty (https://requesty.ai), base URL https://router.requesty.ai/v1)
 
 # Install dependencies
 pnpm install

--- a/examples/supabase-chat/.env.local.example
+++ b/examples/supabase-chat/.env.local.example
@@ -1,5 +1,11 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-OPENROUTER_API_KEY=sk-or-v1-...
+OPENROUTER_API_KEY=***
 # Optional: defaults to openai/gpt-5.5
 # OPENROUTER_MODEL=openai/gpt-5.5
+
+# Optional: use any OpenAI-compatible provider instead of OpenRouter.
+# Leave these unset to keep the default OpenRouter behavior.
+# Example - Requesty (https://requesty.ai), keys at https://app.requesty.ai/api-keys:
+# LLM_BASE_URL=https://router.requesty.ai/v1
+# LLM_API_KEY=your-requesty-key

--- a/examples/supabase-chat/README.md
+++ b/examples/supabase-chat/README.md
@@ -14,7 +14,7 @@ Demonstrates:
 
 - Node.js 18+ and [pnpm](https://pnpm.io)
 - A [Supabase](https://supabase.com) project (free tier is fine)
-- An [OpenRouter](https://openrouter.ai) API key, or any OpenAI-compatible LLM provider
+- An [OpenRouter](https://openrouter.ai) API key, or any OpenAI-compatible LLM provider (e.g. [Requesty](https://requesty.ai) — see [Using a different OpenAI-compatible provider](#using-a-different-openai-compatible-provider))
 
 ## Setup
 
@@ -68,6 +68,29 @@ cp .env.local.example .env.local
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase dashboard → Settings → API → anon/public key |
 | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | `OPENROUTER_MODEL` _(optional)_ | Defaults to `openai/gpt-5.5` |
+
+### Using a different OpenAI-compatible provider
+
+The chat route talks to an OpenAI-compatible endpoint, so any OpenAI-compatible
+gateway works. By default it uses OpenRouter, but you can point it at another
+provider without editing any code by setting two optional environment variables:
+
+| Variable | Where to find it |
+|---|---|
+| `LLM_BASE_URL` _(optional)_ | The provider's OpenAI-compatible base URL. Defaults to `https://openrouter.ai/api/v1`. |
+| `LLM_API_KEY` _(optional)_ | The provider's API key. Defaults to `OPENROUTER_API_KEY`. |
+
+For example, to use [Requesty](https://requesty.ai) (an OpenAI-compatible LLM
+gateway with the same `provider/model` naming):
+
+```bash
+LLM_BASE_URL=https://router.requesty.ai/v1
+LLM_API_KEY=your-requesty-key   # create one at https://app.requesty.ai/api-keys
+OPENROUTER_MODEL=openai/gpt-4o-mini   # any provider/model the gateway supports
+```
+
+When `LLM_BASE_URL` / `LLM_API_KEY` are unset, the example behaves exactly as
+before and uses OpenRouter.
 
 ### 5. Install and run
 

--- a/examples/supabase-chat/src/app/api/chat/route.ts
+++ b/examples/supabase-chat/src/app/api/chat/route.ts
@@ -5,6 +5,12 @@ import type { ChatCompletionMessageParam } from "openai/resources/chat/completio
 
 const MODEL = process.env.OPENROUTER_MODEL ?? "openai/gpt-5.5";
 
+// OpenAI-compatible provider configuration. Defaults to OpenRouter, but you can
+// point this at any OpenAI-compatible gateway (e.g. Requesty —
+// https://router.requesty.ai/v1) by setting LLM_BASE_URL and LLM_API_KEY.
+const LLM_BASE_URL = process.env.LLM_BASE_URL ?? "https://openrouter.ai/api/v1";
+const LLM_API_KEY = process.env.LLM_API_KEY ?? process.env.OPENROUTER_API_KEY;
+
 /**
  * POST /api/chat
  *
@@ -24,8 +30,8 @@ export async function POST(req: NextRequest) {
   const supabase = await createSupabaseServer();
 
   const client = new OpenAI({
-    apiKey: process.env.OPENROUTER_API_KEY,
-    baseURL: "https://openrouter.ai/api/v1",
+    apiKey: LLM_API_KEY,
+    baseURL: LLM_BASE_URL,
   });
 
   const stream = await client.chat.completions.create({


### PR DESCRIPTION
## Summary

This makes the OpenAI-compatible LLM provider in the **example apps** configurable via environment variables, and documents [Requesty](https://requesty.ai) as a drop-in OpenAI-compatible alternative to the OpenRouter usage already present in these examples.

The `supabase-chat` README already says you can use "an OpenRouter API key, **or any OpenAI-compatible LLM provider**", but the chat route hard-coded the OpenRouter base URL, so switching providers required a code edit. This change lets users point the example at any OpenAI-compatible gateway without touching code.

## Changes

- `examples/supabase-chat/src/app/api/chat/route.ts` — make the client base URL and API key env-configurable, **defaulting to the existing OpenRouter values** so behavior is identical when the new envs are unset:
  - `baseURL: process.env.LLM_BASE_URL ?? "https://openrouter.ai/api/v1"`
  - `apiKey: process.env.LLM_API_KEY ?? process.env.OPENROUTER_API_KEY`
- `examples/supabase-chat/README.md` — document the optional `LLM_BASE_URL` / `LLM_API_KEY` envs and add a "Using a different OpenAI-compatible provider" section with a Requesty example (base URL `https://router.requesty.ai/v1`, `REQUESTY_API_KEY`, same `provider/model` naming).
- `examples/supabase-chat/.env.local.example` — add commented Requesty alternative mirroring the existing var style.
- `examples/openui-chat/README.md` and `examples/openui-dashboard/README.md` — one-line note that other OpenAI-compatible gateways such as Requesty work too.

No behavior change when the new env vars are unset; OpenRouter remains the default everywhere. The project's own hosted docs/demo routes are intentionally left untouched.

## Verification

- `npx tsc --noEmit` passes in `examples/supabase-chat` (the change is a pure `process.env.X ?? <existing literal>` fallback, type-equivalent to the original).
- Live sanity check against the documented Requesty endpoint: a real chat completion to `https://router.requesty.ai/v1/chat/completions` with model `openai/gpt-4o-mini` returned HTTP 200 with valid content — confirming the documented base URL and `provider/model` naming work as written.

## Links

- Requesty: https://requesty.ai
- Docs: https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
