### PR TITLE
chore: centralize @ai-sdk/openai and @ai-sdk/react with pnpm catalog

### DIFF
--- a/examples/harnesses/vercel-eve/package.json
+++ b/examples/harnesses/vercel-eve/package.json
@@ -17,7 +17,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/openai": "catalog:",
     "@openuidev/react-headless": "workspace:*",
     "@openuidev/react-lang": "workspace:*",
     "@openuidev/react-ui": "workspace:*",

--- a/examples/multi-agent-chat/package.json
+++ b/examples/multi-agent-chat/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.41",
-    "@ai-sdk/react": "^3.0.118",
+    "@ai-sdk/openai": "catalog:",
+    "@ai-sdk/react": "catalog:",
     "@openuidev/cli": "workspace:*",
     "@openuidev/react-lang": "workspace:*",
     "@openuidev/react-ui": "workspace:*",

--- a/examples/svelte-chat/package.json
+++ b/examples/svelte-chat/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/openai": "catalog:",
     "@ai-sdk/svelte": "^4.0.191",
     "@openuidev/svelte-lang": "workspace:*",
     "ai": "^6.0.116",

--- a/examples/vercel-ai-chat/package.json
+++ b/examples/vercel-ai-chat/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.41",
-    "@ai-sdk/react": "^3.0.118",
+    "@ai-sdk/openai": "catalog:",
+    "@ai-sdk/react": "catalog:",
     "@openuidev/cli": "workspace:*",
     "@openuidev/react-lang": "workspace:*",
     "@openuidev/react-ui": "workspace:*",

--- a/examples/vue-chat/package.json
+++ b/examples/vue-chat/package.json
@@ -9,7 +9,7 @@
     "generate:prompt": "node scripts/generate-prompt.mjs"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^3.0.41",
+    "@ai-sdk/openai": "catalog:",
     "@ai-sdk/vue": "^3.0.0",
     "@openuidev/lang-core": "workspace:*",
     "@openuidev/vue-lang": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,63 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@ai-sdk/openai':
+      specifier: ^3.0.41
+      version: 3.0.65
+    '@ai-sdk/react':
+      specifier: ^3.0.118
+      version: 3.0.193
+    '@types/node':
+      specifier: ^22.15.32
+      version: 22.19.19
+    '@types/react':
+      specifier: '>=19.0.0'
+      version: 19.2.14
+    '@typescript-eslint/eslint-plugin':
+      specifier: ^8.56.1
+      version: 8.59.4
+    eslint:
+      specifier: ^9.0.0
+      version: 9.29.0
+    eslint-config-prettier:
+      specifier: ^10.1.8
+      version: 10.1.8
+    eslint-plugin-prettier:
+      specifier: ^5.5.5
+      version: 5.5.5
+    eslint-plugin-react-hooks:
+      specifier: ^7.0.1
+      version: 7.1.1
+    eslint-plugin-react-refresh:
+      specifier: ^0.5.2
+      version: 0.5.2
+    eslint-plugin-storybook:
+      specifier: ^10.2.14
+      version: 10.2.14
+    eslint-plugin-unused-imports:
+      specifier: ^4.4.1
+      version: 4.4.1
+    jsdom:
+      specifier: ^26.1.0
+      version: 26.1.0
+    react:
+      specifier: ^18.3.1 || ^19.0.0
+      version: 19.2.4
+    react-dom:
+      specifier: ^18.0.0 || ^19.0.0
+      version: 19.2.4
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+    zod:
+      specifier: ^3.25.0 || ^4.0.0
+      version: 4.3.6
+    zustand:
+      specifier: ^4.5.5
+      version: 4.5.7
+
 overrides:
   langsmith@<0.6.0: ^0.6.0
   ip-address@<10.1.1: '>=10.1.1'
@@ -375,7 +432,7 @@ importers:
   examples/harnesses/vercel-eve:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^3.0.41
+        specifier: 'catalog:'
         version: 3.0.65(zod@4.4.3)
       '@openuidev/react-headless':
         specifier: workspace:*
@@ -628,10 +685,10 @@ importers:
   examples/multi-agent-chat:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^3.0.41
+        specifier: 'catalog:'
         version: 3.0.65(zod@4.3.6)
       '@ai-sdk/react':
-        specifier: ^3.0.118
+        specifier: 'catalog:'
         version: 3.0.193(react@19.2.3)(zod@4.3.6)
       '@openuidev/cli':
         specifier: workspace:*
@@ -1233,7 +1290,7 @@ importers:
   examples/svelte-chat:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^3.0.41
+        specifier: 'catalog:'
         version: 3.0.65(zod@4.3.6)
       '@ai-sdk/svelte':
         specifier: ^4.0.191
@@ -1279,10 +1336,10 @@ importers:
   examples/vercel-ai-chat:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^3.0.41
+        specifier: 'catalog:'
         version: 3.0.65(zod@4.3.6)
       '@ai-sdk/react':
-        specifier: ^3.0.118
+        specifier: 'catalog:'
         version: 3.0.193(react@19.2.3)(zod@4.3.6)
       '@openuidev/cli':
         specifier: workspace:*
@@ -1340,7 +1397,7 @@ importers:
   examples/vue-chat:
     dependencies:
       '@ai-sdk/openai':
-        specifier: ^3.0.41
+        specifier: 'catalog:'
         version: 3.0.65(zod@4.3.6)
       '@ai-sdk/vue':
         specifier: ^3.0.0
@@ -17672,57 +17729,6 @@ packages:
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
-
-catalogs:
-  default:
-    '@types/node':
-      specifier: ^22.15.32
-      version: 22.19.19
-    '@types/react':
-      specifier: '>=19.0.0'
-      version: 19.2.14
-    '@typescript-eslint/eslint-plugin':
-      specifier: ^8.56.1
-      version: 8.59.4
-    eslint:
-      specifier: ^9.0.0
-      version: 9.29.0
-    eslint-config-prettier:
-      specifier: ^10.1.8
-      version: 10.1.8
-    eslint-plugin-prettier:
-      specifier: ^5.5.5
-      version: 5.5.5
-    eslint-plugin-react-hooks:
-      specifier: ^7.0.1
-      version: 7.1.1
-    eslint-plugin-react-refresh:
-      specifier: ^0.5.2
-      version: 0.5.2
-    eslint-plugin-storybook:
-      specifier: ^10.2.14
-      version: 10.2.14
-    eslint-plugin-unused-imports:
-      specifier: ^4.4.1
-      version: 4.4.1
-    jsdom:
-      specifier: ^26.1.0
-      version: 26.1.0
-    react:
-      specifier: ^18.3.1 || ^19.0.0
-      version: 19.2.4
-    react-dom:
-      specifier: ^18.0.0 || ^19.0.0
-      version: 19.2.4
-    typescript:
-      specifier: ^5.9.3
-      version: 5.9.3
-    zod:
-      specifier: ^3.25.0 || ^4.0.0
-      version: 4.3.6
-    zustand:
-      specifier: ^4.5.5
-      version: 4.5.7
 
 snapshots:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 # Centralized dependency versions shared across packages.
 # Reference these from a package.json with the "catalog:" protocol.
 catalog:
+  "@ai-sdk/openai": "^3.0.41"
+  "@ai-sdk/react": "^3.0.118"
   "@types/node": "^22.15.32"
   "@types/react": ">=19.0.0"
   "@typescript-eslint/eslint-plugin": "^8.56.1"


### PR DESCRIPTION
## Summary

Continues the pnpm catalog centralization (#612, #624, #634, #645, #653, #659) for the shared Vercel AI SDK packages.

Moves the duplicated `@ai-sdk/*` packages into the catalog so their versions live in one place and consumers reference them with `catalog:`:

| package | version | consumers |
|---|---|---|
| `@ai-sdk/openai` | `^3.0.41` | svelte-chat, vercel-eve, multi-agent-chat, vercel-ai-chat, vue-chat |
| `@ai-sdk/react` | `^3.0.118` | multi-agent-chat, vercel-ai-chat |

Every consumer already pinned the **same** version, so resolved versions are unchanged — this is a pure centralization with no dependency bumps. The lockfile diff is purely the catalog restructure.

## Out of scope (intentionally)
- **`ai`** — `examples/harnesses/vercel-eve` deliberately pins `7.0.0-beta.178` (deps + overrides + resolutions) while the others use `^6.x`, so it doesn't map to a single catalog value.
- **`@ai-sdk/svelte`** / **`@ai-sdk/vue`** — single-use, no dedup benefit.

## Test plan
- [x] `pnpm install --lockfile-only` resolves cleanly; catalog `default` now contains both entries
- [x] No `@ai-sdk/openai` / `@ai-sdk/react` version pins remain outside the catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)