### PR TITLE
docs(react-ui): add Storybook stories for missing components

### DIFF
--- a/packages/react-ui/src/components/Label/stories/Label.stories.tsx
+++ b/packages/react-ui/src/components/Label/stories/Label.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Label } from "../Label";
+
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  args: {
+    children: "Just a label",
+    required: false,
+    disabled: false,
+    className: "openui-label",
+    style: { color: "black" },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic label component.",
+      },
+    },
+  },
+};
+
+export const Required: Story = {
+  args: {
+    children: "Required label",
+    required: true,
+    disabled: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A label with a required indicator.",
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Disabled label",
+    required: false,
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A disabled label state.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof Label> = {
+  title: "Components/Label",
+  component: Label,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { Label } from '@openuidev/react-ui';\n```",
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: "text",
+    },
+    required: {
+      control: "boolean",
+      table: {
+        category: "State",
+        defaultValue: { summary: "false" },
+      },
+    },
+    disabled: {
+      control: "boolean",
+      table: {
+        category: "State",
+        defaultValue: { summary: "false" },
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/Modal/stories/Modal.stories.tsx
+++ b/packages/react-ui/src/components/Modal/stories/Modal.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "../../Button";
+import { Modal } from "../Modal";
+
+type Story = StoryObj<typeof Modal>;
+
+export const Default: Story = {
+  args: {
+    title: "Modal title",
+    children: "This is the modal content.",
+    size: "md",
+  },
+  render: (args) => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setOpen(true)} variant="primary">
+          Open modal
+        </Button>
+
+        <Modal title={args.title} size={args.size} open={open} onOpenChange={setOpen}>
+          {args.children}
+        </Modal>
+      </>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic modal component opened by a button.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof Modal> = {
+  title: "Components/Modal",
+  component: Modal,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { Modal } from '@openuidev/react-ui';\n```",
+      },
+    },
+    controls: {
+      exclude: ["open", "onOpenChange"],
+    },
+  },
+  argTypes: {
+    title: {
+      control: "text",
+    },
+    children: {
+      control: "text",
+    },
+    size: {
+      control: "radio",
+      options: ["sm", "md", "lg"],
+      table: {
+        defaultValue: { summary: "md" },
+      },
+    },
+    open: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/SectionBlock/stories/SectionBlock.stories.tsx
+++ b/packages/react-ui/src/components/SectionBlock/stories/SectionBlock.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SectionV2 } from "../SectionV2";
+
+type Story = StoryObj<typeof SectionV2>;
+
+export const Default: Story = {
+  args: {
+    trigger: "Section title",
+    children: "This is the section content.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic section block with a trigger and content.",
+      },
+    },
+  },
+};
+
+export const WithLongContent: Story = {
+  args: {
+    trigger: "Details",
+    children: "This section can be used to group related content under a visual section heading.",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A section block with longer content.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof SectionV2> = {
+  title: "Components/SectionBlock",
+  component: SectionV2,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { SectionV2 } from '@openuidev/react-ui';\n```",
+      },
+    },
+  },
+  argTypes: {
+    trigger: {
+      control: "text",
+    },
+    children: {
+      control: "text",
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/ThemeProvider/stories/ThemeProvider.stories.tsx
+++ b/packages/react-ui/src/components/ThemeProvider/stories/ThemeProvider.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "../../Button";
+import { Label } from "../../Label";
+import { ThemeProvider } from "../ThemeProvider";
+
+type Story = StoryObj<typeof ThemeProvider>;
+
+export const Default: Story = {
+  args: {
+    mode: "light",
+  },
+  render: (args) => (
+    <ThemeProvider mode={args.mode} cssSelector=".openui-theme-provider-default-story">
+      <div
+        className="openui-theme-provider-default-story"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          minWidth: "280px",
+          padding: "24px",
+          borderRadius: "12px",
+          background: "var(--openui-background)",
+          color: "var(--openui-text-neutral-primary)",
+          border: "1px solid var(--openui-border-default)",
+        }}
+      >
+        <Label required>Theme provider preview</Label>
+        <Button variant="primary">Primary button</Button>
+        <Button variant="secondary">Secondary button</Button>
+      </div>
+    </ThemeProvider>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic ThemeProvider example wrapping OpenUI components.",
+      },
+    },
+  },
+};
+
+export const DarkMode: Story = {
+  args: {
+    mode: "dark",
+  },
+  render: (args) => (
+    <ThemeProvider mode={args.mode} cssSelector=".openui-theme-provider-dark-story">
+      <div
+        className="openui-theme-provider-dark-story"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          minWidth: "280px",
+          padding: "24px",
+          borderRadius: "12px",
+          background: "var(--openui-background)",
+          color: "var(--openui-text-neutral-primary)",
+          border: "1px solid var(--openui-border-default)",
+        }}
+      >
+        <Label required>Dark theme preview</Label>
+        <Button variant="primary">Primary button</Button>
+        <Button variant="secondary">Secondary button</Button>
+      </div>
+    </ThemeProvider>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "ThemeProvider rendered with dark mode enabled.",
+      },
+    },
+  },
+};
+
+export const CustomTheme: Story = {
+  args: {
+    mode: "light",
+  },
+  render: (args) => (
+    <ThemeProvider
+      mode={args.mode}
+      cssSelector=".openui-theme-provider-custom-story"
+      lightTheme={{
+        background: "oklch(96% 0.03 260)",
+        textNeutralPrimary: "oklch(20% 0.04 260)",
+        interactiveAccentDefault: "oklch(55% 0.22 260)",
+        interactiveAccentHover: "oklch(50% 0.22 260)",
+        borderDefault: "oklch(75% 0.08 260)",
+      }}
+    >
+      <div
+        className="openui-theme-provider-custom-story"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "12px",
+          minWidth: "280px",
+          padding: "24px",
+          borderRadius: "12px",
+          background: "var(--openui-background)",
+          color: "var(--openui-text-neutral-primary)",
+          border: "1px solid var(--openui-border-default)",
+        }}
+      >
+        <Label required>Custom theme preview</Label>
+        <Button variant="primary">Primary button</Button>
+        <Button variant="secondary">Secondary button</Button>
+      </div>
+    </ThemeProvider>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "ThemeProvider with custom light theme token overrides.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof ThemeProvider> = {
+  title: "Components/ThemeProvider",
+  component: ThemeProvider,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { ThemeProvider } from '@openuidev/react-ui';\n```",
+      },
+    },
+    controls: {
+      exclude: ["children", "lightTheme", "darkTheme", "theme", "cssSelector"],
+    },
+  },
+  argTypes: {
+    mode: {
+      control: "radio",
+      options: ["light", "dark"],
+      table: {
+        category: "Appearance",
+        defaultValue: { summary: "light" },
+      },
+    },
+    children: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    lightTheme: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    darkTheme: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    theme: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+    cssSelector: {
+      control: false,
+      table: {
+        disable: true,
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/ToggleItem/stories/ToggleItem.stories.tsx
+++ b/packages/react-ui/src/components/ToggleItem/stories/ToggleItem.stories.tsx
@@ -1,0 +1,105 @@
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ToggleItem } from "../ToggleItem";
+
+type Story = StoryObj<typeof ToggleItem>;
+
+export const Default: Story = {
+  args: {
+    children: "Just a toggle",
+    value: "toggle",
+    disabled: false,
+  },
+  render: (args) => (
+    <ToggleGroupPrimitive.Root type="single" defaultValue={args.value}>
+      <ToggleItem value={args.value} disabled={args.disabled}>
+        {args.children}
+      </ToggleItem>
+    </ToggleGroupPrimitive.Root>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic toggle item rendered inside a single-select toggle group.",
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    children: "Disabled toggle",
+    value: "disabled",
+    disabled: true,
+  },
+  render: (args) => (
+    <ToggleGroupPrimitive.Root type="single">
+      <ToggleItem value={args.value} disabled={args.disabled}>
+        {args.children}
+      </ToggleItem>
+    </ToggleGroupPrimitive.Root>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "A disabled toggle item.",
+      },
+    },
+  },
+};
+
+export const Multiple: Story = {
+  render: () => (
+    <ToggleGroupPrimitive.Root type="multiple" defaultValue={["bold", "italic"]}>
+      <ToggleItem value="bold">Bold</ToggleItem>
+      <ToggleItem value="italic">Italic</ToggleItem>
+      <ToggleItem value="underline">Underline</ToggleItem>
+    </ToggleGroupPrimitive.Root>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "Multiple toggle items rendered inside a multi-select toggle group.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof ToggleItem> = {
+  title: "Components/ToggleItem",
+  component: ToggleItem,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { ToggleItem } from '@openuidev/react-ui';\n```",
+      },
+    },
+    controls: {
+      exclude: ["className"],
+    },
+  },
+  argTypes: {
+    children: {
+      control: "text",
+    },
+    value: {
+      control: "text",
+      description: "Unique value that identifies this item inside the toggle group.",
+    },
+    disabled: {
+      control: "boolean",
+      table: {
+        category: "State",
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/ToolCall/stories/ToolCall.stories.tsx
+++ b/packages/react-ui/src/components/ToolCall/stories/ToolCall.stories.tsx
@@ -1,0 +1,166 @@
+import type { ToolCall } from "@openuidev/react-headless";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ToolCallComponent } from "../ToolCall";
+
+type Story = StoryObj<typeof ToolCallComponent>;
+
+const plainToolCall: ToolCall = {
+  id: "tool-call-1",
+  type: "function",
+  function: {
+    name: "search",
+    arguments: JSON.stringify(
+      {
+        query: "OpenUI Storybook components",
+        limit: 5,
+      },
+      null,
+      2,
+    ),
+  },
+};
+
+const requestResponseToolCall: ToolCall = {
+  id: "tool-call-2",
+  type: "function",
+  function: {
+    name: "get_weather",
+    arguments: JSON.stringify(
+      {
+        _request: {
+          location: "Florianópolis, SC",
+          unit: "celsius",
+        },
+        _response: {
+          temperature: 24,
+          condition: "Partly cloudy",
+        },
+      },
+      null,
+      2,
+    ),
+  },
+};
+
+const streamingToolCall: ToolCall = {
+  id: "tool-call-3",
+  type: "function",
+  function: {
+    name: "generate_report",
+    arguments: JSON.stringify(
+      {
+        _request: {
+          topic: "Weekly usage summary",
+          format: "markdown",
+        },
+      },
+      null,
+      2,
+    ),
+  },
+};
+
+export const Default: Story = {
+  args: {
+    toolCall: plainToolCall,
+    isStreaming: false,
+    toolsDone: true,
+    isLast: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A basic tool call with plain function arguments.",
+      },
+    },
+  },
+};
+
+export const WithRequestAndResponse: Story = {
+  args: {
+    toolCall: requestResponseToolCall,
+    isStreaming: false,
+    toolsDone: true,
+    isLast: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A completed tool call displaying request and response payloads.",
+      },
+    },
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    toolCall: streamingToolCall,
+    isStreaming: true,
+    toolsDone: false,
+    isLast: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A running tool call while the tool response is still streaming.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof ToolCallComponent> = {
+  title: "Components/ToolCall",
+  component: ToolCallComponent,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { ToolCallComponent } from '@openuidev/react-ui';\n```",
+      },
+    },
+    controls: {
+      exclude: ["className"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "520px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    toolCall: {
+      control: "object",
+      table: {
+        category: "Data",
+      },
+    },
+    isStreaming: {
+      control: "boolean",
+      table: {
+        category: "State",
+      },
+    },
+    toolsDone: {
+      control: "boolean",
+      table: {
+        category: "State",
+      },
+    },
+    isLast: {
+      control: "boolean",
+      table: {
+        category: "State",
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;

--- a/packages/react-ui/src/components/ToolResult/stories/ToolResult.stories.tsx
+++ b/packages/react-ui/src/components/ToolResult/stories/ToolResult.stories.tsx
@@ -1,0 +1,118 @@
+import type { ToolMessage } from "@openuidev/react-headless";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ToolResult } from "../ToolResult";
+
+type Story = StoryObj<typeof ToolResult>;
+
+const successMessage = {
+  content: JSON.stringify(
+    {
+      temperature: 24,
+      condition: "Partly cloudy",
+      location: "Florianópolis, SC",
+    },
+    null,
+    2,
+  ),
+} as ToolMessage;
+
+const errorMessage = {
+  content: JSON.stringify(
+    {
+      message: "Unable to fetch weather data.",
+    },
+    null,
+    2,
+  ),
+  error: "The weather service returned an unavailable response.",
+} as ToolMessage;
+
+const plainMessage = {
+  content: "Tool completed successfully.",
+} as ToolMessage;
+
+export const Default: Story = {
+  args: {
+    message: successMessage,
+    toolName: "get_weather",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A successful tool result with formatted output.",
+      },
+    },
+  },
+};
+
+export const Error: Story = {
+  args: {
+    message: errorMessage,
+    toolName: "get_weather",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A tool result with an error message.",
+      },
+    },
+  },
+};
+
+export const WithoutToolName: Story = {
+  args: {
+    message: plainMessage,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "A tool result without a resolved tool name.",
+      },
+    },
+  },
+};
+
+const meta: Meta<typeof ToolResult> = {
+  title: "Components/ToolResult",
+  component: ToolResult,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: "```tsx\nimport { ToolResult } from '@openuidev/react-ui';\n```",
+      },
+    },
+    controls: {
+      exclude: ["className"],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "520px" }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    message: {
+      control: "object",
+      table: {
+        category: "Data",
+      },
+    },
+    toolName: {
+      control: "text",
+      table: {
+        category: "Data",
+      },
+    },
+    className: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  tags: ["autodocs", "!dev"],
+};
+
+export default meta;


### PR DESCRIPTION
## What

Adds Storybook coverage for React UI components that were missing stories.

This improves component discoverability and gives contributors/maintainers visual examples for each component state.

Closes #552

## Changes

Added Storybook stories for:

- Label
- Modal
- SectionBlock
- ThemeProvider
- ToggleItem
- ToolCall
- ToolResult

## Test Plan

Describe how you validated this change.

- [ ] Not applicable (explain why)
- [x] Verified locally

## Checklist

- [x] I linked a related issue, if applicable
- [x] I updated docs/README when needed
- [x] I considered backwards compatibility
