### PR TITLE
chore: centralize @types/react-dom version with pnpm catalog

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -149,7 +149,7 @@
     "@types/node": "catalog:",
     "@types/node-fetch": "2.6.13",
     "@types/react": "catalog:",
-    "@types/react-dom": ">=19.0.0",
+    "@types/react-dom": "catalog:",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "concurrently": "^9.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@types/react':
       specifier: '>=19.0.0'
       version: 19.2.14
+    '@types/react-dom':
+      specifier: '>=19.0.0'
+      version: 19.2.3
     '@typescript-eslint/eslint-plugin':
       specifier: ^8.56.1
       version: 8.59.4
@@ -1726,7 +1729,7 @@ importers:
         specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: '>=19.0.0'
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       '@types/react-syntax-highlighter':
         specifier: ^15.5.13

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   "@ai-sdk/react": "^3.0.118"
   "@types/node": "^22.15.32"
   "@types/react": ">=19.0.0"
+  "@types/react-dom": ">=19.0.0"
   "@typescript-eslint/eslint-plugin": "^8.56.1"
   eslint: "^9.0.0"
   eslint-config-prettier: "^10.1.8"


### PR DESCRIPTION
## What

Centralize the `@types/react-dom` version through the shared pnpm catalog, completing the React types set that is already centralized (`@types/react`, `react`, `react-dom`).

- Add `@types/react-dom: ">=19.0.0"` to the `catalog:` in `pnpm-workspace.yaml` (same range as the existing `@types/react` entry).
- Reference it from `packages/react-ui` via the `catalog:` protocol instead of the inline `>=19.0.0`.

## Why

`@types/react`, `react`, and `react-dom` are already in the catalog, but `@types/react-dom` was the odd one out, pinned inline in `react-ui`. This fills that gap so the React typing versions stay aligned in one place.

## Scope

Following the established convention in this repo, only `packages/*` use the `catalog:` protocol; `examples/*`, `docs`, and `src/templates/*` intentionally keep their literal ranges. `react-ui` is the only `packages/*` consumer of `@types/react-dom`.

## Notes

- Resolved version is unchanged (`19.2.3`) — this is a pure centralization with no behavioral impact.
- `pnpm install` succeeds and `pnpm --filter @openuidev/react-ui typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
