### PR TITLE
chore: centralize rimraf version with pnpm catalog

### DIFF
--- a/packages/browser-bundle/package.json
+++ b/packages/browser-bundle/package.json
@@ -57,6 +57,6 @@
   },
   "devDependencies": {
     "esbuild": "^0.25.12",
-    "rimraf": "^5.0.7"
+    "rimraf": "catalog:"
   }
 }

--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "rimraf": "^5.0.7"
+    "rimraf": "catalog:"
   },
   "keywords": [
     "openui",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -170,7 +170,7 @@
     "storybook": "^8.5.3",
     "tailwindcss": "^3",
     "tsx": "^4.19.2",
-    "rimraf": "^5.0.7",
+    "rimraf": "catalog:",
     "vite": "^6.4.2",
     "vitest": "^4.0.18",
     "webpack": "^5.104.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ catalogs:
     react-dom:
       specifier: ^18.0.0 || ^19.0.0
       version: 19.2.4
+    rimraf:
+      specifier: ^5.0.7
+      version: 5.0.10
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
@@ -1459,7 +1462,7 @@ importers:
         specifier: ^0.25.12
         version: 0.25.12
       rimraf:
-        specifier: ^5.0.7
+        specifier: 'catalog:'
         version: 5.0.10
 
   packages/lang-core:
@@ -1494,7 +1497,7 @@ importers:
         specifier: 'catalog:'
         version: 22.19.19
       rimraf:
-        specifier: ^5.0.7
+        specifier: 'catalog:'
         version: 5.0.10
 
   packages/react-email:
@@ -1777,7 +1780,7 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       rimraf:
-        specifier: ^5.0.7
+        specifier: 'catalog:'
         version: 5.0.10
       sass:
         specifier: ^1.83.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ catalog:
   jsdom: "^26.1.0"
   react: "^18.3.1 || ^19.0.0"
   react-dom: "^18.0.0 || ^19.0.0"
+  rimraf: "^5.0.7"
   typescript: "^5.9.3"
   zod: "^3.25.0 || ^4.0.0"
   zustand: "^4.5.5"


### PR DESCRIPTION
## What

Centralize the `rimraf` version through the shared pnpm catalog.

- Add `rimraf: "^5.0.7"` to the `catalog:` in `pnpm-workspace.yaml`.
- Reference it via the `catalog:` protocol from the three workspace packages that use it: `react-ui`, `openui-cli`, `browser-bundle`.

## Why

`rimraf` was declared independently in three packages (all `^5.0.7`). Centralizing keeps it aligned in one place, consistent with the other already-centralized deps (`react`, `eslint`, `typescript`, …).

## Scope

Following the established convention, only `packages/*` use the `catalog:` protocol.

## Notes

- Resolved version is unchanged (`5.0.10`) — pure centralization, no behavioral impact.
- Lockfile diff is limited to the catalog entry + the three `catalog:` specifiers.
- `pnpm install --frozen-lockfile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
