### PR TITLE
chore: centralize vite version with pnpm catalog

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -171,7 +171,7 @@
     "tailwindcss": "^3",
     "tsx": "^4.19.2",
     "rimraf": "^5.0.7",
-    "vite": "^6.4.2",
+    "vite": "catalog:",
     "vitest": "^4.0.18",
     "webpack": "^5.104.1"
   },

--- a/packages/svelte-lang/package.json
+++ b/packages/svelte-lang/package.json
@@ -72,7 +72,7 @@
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"typescript": "catalog:",
-		"vite": "^6.0.0",
+		"vite": "catalog:",
 		"vitest": "^4.1.0"
 	}
 }

--- a/packages/vue-lang/package.json
+++ b/packages/vue-lang/package.json
@@ -66,7 +66,7 @@
 		"@vue/test-utils": "^2.4.0",
 		"jsdom": "catalog:",
 		"typescript": "catalog:",
-		"vite": "^6.0.0",
+		"vite": "catalog:",
 		"vitest": "^4.1.0",
 		"vue": "^3.5.0",
 		"vue-tsc": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ catalogs:
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
+    vite:
+      specifier: ^6.4.2
+      version: 6.4.2
     zod:
       specifier: ^3.25.0 || ^4.0.0
       version: 4.3.6
@@ -1792,7 +1795,7 @@ importers:
         specifier: ^4.19.2
         version: 4.20.3
       vite:
-        specifier: ^6.4.2
+        specifier: 'catalog:'
         version: 6.4.2(@types/node@22.19.19)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.0.18
@@ -1832,7 +1835,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0
@@ -1860,7 +1863,7 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
-        specifier: ^6.0.0
+        specifier: 'catalog:'
         version: 6.4.2(@types/node@25.3.2)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,5 +23,6 @@ catalog:
   react: "^18.3.1 || ^19.0.0"
   react-dom: "^18.0.0 || ^19.0.0"
   typescript: "^5.9.3"
+  vite: "^6.4.2"
   zod: "^3.25.0 || ^4.0.0"
   zustand: "^4.5.5"


### PR DESCRIPTION
## What

Centralize the `vite` version through the shared pnpm catalog.

- Add `vite: "^6.4.2"` to the `catalog:` in `pnpm-workspace.yaml`.
- Reference it via the `catalog:` protocol from `react-ui`, `svelte-lang`, and `vue-lang`.

## Why

`vite` had drifted across the workspace packages — `^6.4.2` in `react-ui` but `^6.0.0` in `svelte-lang`/`vue-lang`. Centralizing aligns them in one place (using the higher floor so no package loses its minimum), consistent with the other already-centralized deps.

## Scope

Following the established convention, only `packages/*` use the `catalog:` protocol; `examples/*` keep their literal ranges.

## Notes

- All three packages already resolved to `6.4.2`, so the resolved version is unchanged — pure centralization, no behavioral impact.
- `pnpm install --frozen-lockfile` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
