### PR TITLE
docs: add GitHub companion repo for Ollama integration

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -20,6 +20,7 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 | [openui-forge](https://github.com/OthmanAdi/openui-forge) | [OthmanAdi](https://github.com/OthmanAdi)   | Cross-IDE agent skill for OpenUI. Templates for OpenAI, Anthropic, LangChain, Vercel AI SDK, plus FastAPI / Go / Rust backends. Mirrors to 11 agent platforms.                  |
 | [Entelligence.AI](https://entelligence.ai) | [Aiswarya Sankar](https://www.linkedin.com/in/sankaraiswarya/)   | AI platform that gives developers noise-free, self-verifying code reviews to catch bugs before they ship, while providing engineering leaders with the analytics needed to measure the true ROI of their AI coding tools.            |
 | [GAIA](https://heygaia.io) | [Aryan Randeriya](https://github.com/aryanranderiya) | GAIA is a proactive personal AI assistant that uses OpenUI Lang to let its backend LLM emit rich, interactive React components inline in chat responses — rendering cards, lists, and other generative UI directly in the conversation instead of plain text. |
+| [openui-ollama-localsetup](https://github.com/shogun444/openui-ollama-localsetup) | [Sayandip Roy (shogun444)](https://github.com/shogun444) | Companion repo for OpenUI + Ollama local LLM setup guide with complete step-by-step tutorial, environment configuration, and working chat application. |
 
 <!--
 Example row, copy and edit:

--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -118,6 +118,11 @@ const projects: ProjectItem[] = [
         href: "https://dev.to/shogun444/i-tested-openui-with-ollama-models-heres-what-actually-worked-45m7",
         external: true,
       },
+      {
+        label: "GitHub",
+        href: "https://github.com/shogun444/openui-ollama-localsetup",
+        external: true,
+      },
       { label: "Ollama", href: "https://ollama.com", external: true },
     ],
   },


### PR DESCRIPTION
Adding companion repo link for the OpenUI + Ollama local setup tutorial under the Ollama Integration project card. Also adds adopter entry for openui-ollama-localsetup.