### PR TITLE
fix: tab reference

### DIFF
--- a/docs/content/docs/agent/getting-started/quickstart.mdx
+++ b/docs/content/docs/agent/getting-started/quickstart.mdx
@@ -9,7 +9,7 @@ The CLI scaffolds a complete Next.js app: a streaming chat with a sidebar, threa
 
 Run the create command and answer the prompts. One prompt asks **OpenUI Cloud or self-hosted?** Your choice decides which backend the scaffold wires up.
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest create
 ```
 

--- a/docs/content/docs/api-reference/cli.mdx
+++ b/docs/content/docs/api-reference/cli.mdx
@@ -9,7 +9,7 @@ A command-line tool for scaffolding OpenUI chat apps and generating system promp
 
 Run without installing:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest <command>
 ```
 

--- a/docs/content/docs/api-reference/react-ui.mdx
+++ b/docs/content/docs/api-reference/react-ui.mdx
@@ -113,7 +113,7 @@ import {
 
 Generate the system prompt at build time with the CLI:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest generate ./src/library.ts --out src/generated/system-prompt.txt
 ```
 

--- a/docs/content/docs/openui-lang/quickstart.mdx
+++ b/docs/content/docs/openui-lang/quickstart.mdx
@@ -14,7 +14,7 @@ description: Bootstrap a GenUI chat app in under a minute.
 
 ## Create the app
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest create --name genui-chat-app
 ```
 

--- a/docs/content/docs/openui-lang/standard-library.mdx
+++ b/docs/content/docs/openui-lang/standard-library.mdx
@@ -37,7 +37,7 @@ import { openuiLibrary } from "@openuidev/react-ui";
 
 Use the CLI to generate the system prompt at build time:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest generate ./src/library.ts --out src/generated/system-prompt.txt
 ```
 

--- a/docs/content/docs/openui-lang/system-prompts.mdx
+++ b/docs/content/docs/openui-lang/system-prompts.mdx
@@ -9,7 +9,7 @@ The system prompt tells the LLM how to output valid OpenUI Lang. There are two w
 
 The fastest way to generate a system prompt — works with any backend language:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest generate ./src/library.ts
 ```
 
@@ -27,7 +27,7 @@ npx @openuidev/cli@latest generate ./src/library.ts
 
 Write to a file:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest generate ./src/library.ts --out system-prompt.txt
 ```
 
@@ -45,7 +45,7 @@ npx @openuidev/cli@latest generate ./src/library.ts --out system-prompt.txt
 
 Generate the component spec as JSON (for use with `generatePrompt`):
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli@latest generate ./src/library.ts --json-schema
 ```
 
@@ -69,7 +69,7 @@ For backends that need dynamic prompts - different tools, preambles, or feature 
 
 First, generate the component spec JSON via the CLI:
 
-```bash tab="pnpx" tab-group="pkg"
+```bash tab="pnpm" tab-group="pkg"
 pnpx @openuidev/cli generate ./src/library.ts --json-schema --out generated/component-spec.json
 ```
 


### PR DESCRIPTION
Fixes tab references in docs where `pnpx` vs `pnpm` were clashing. All references now are `pnpm`