### PR TITLE
fix/react-headless tool call events

### DIFF
--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-headless",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Headless React primitives for AI chat — state management, streaming adapters for OpenAI and AG-UI, message format converters, and thread management for OpenUI generative UI apps",
   "license": "MIT",
   "type": "module",

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -58,9 +58,7 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                   toolCallName: item.name,
                 };
               } else if (item.type === "function_call_output") {
-                // Fired when a function_call_output we submitted as input is
-                // integrated into a conversation-linked response — surfaces
-                // server-side tool execution to the SDK store.
+                const isError = item.status === "incomplete";
                 yield {
                   type: EventType.TOOL_CALL_RESULT,
                   messageId: item.id,
@@ -68,10 +66,6 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                   content: stringifyOutput(item.output),
                 };
               } else if (item.type === "web_search_call") {
-                // web_search is a native OpenAI tool: it opens with a
-                // web_search_call item rather than a plain function_call and
-                // carries no separate call_id, so key the tool call on the item
-                // id (its result + query arrive on output_item.done below).
                 yield {
                   type: EventType.TOOL_CALL_START,
                   toolCallId: item.id,
@@ -144,15 +138,11 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
               }
 
               const content = stringifyOutput(item.output);
-              const isError = item.status === "failed" || item.error != null;
               yield {
                 type: EventType.TOOL_CALL_RESULT,
                 messageId: toolCallId,
                 toolCallId,
                 content,
-                ...(isError
-                  ? { isError: true, error: typeof item.error === "string" ? item.error : content }
-                  : {}),
               };
               break;
             }

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -58,7 +58,6 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                   toolCallName: item.name,
                 };
               } else if (item.type === "function_call_output") {
-                const isError = item.status === "incomplete";
                 yield {
                   type: EventType.TOOL_CALL_RESULT,
                   messageId: item.id,

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -102,6 +102,33 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
               break;
             }
 
+            case "response.web_search_call.in_progress":
+              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
+              yield {
+                type: EventType.TOOL_CALL_START,
+                toolCallName: "web_search",
+                toolCallId: callId,
+              };
+              break;
+
+            case "response.web_search_call.searching": {
+              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
+              yield {
+                type: EventType.TOOL_CALL_CHUNK,
+                toolCallId: callId,
+              };
+              break;
+            }
+
+            case "response.web_search_call.completed": {
+              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
+              yield {
+                type: EventType.TOOL_CALL_END,
+                toolCallId: callId,
+              };
+              break;
+            }
+
             case "error":
               yield {
                 type: EventType.RUN_ERROR,

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -67,22 +67,15 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                   toolCallId: item.call_id,
                   content: stringifyOutput(item.output),
                 };
-              } else if (typeof item.type === "string" && item.type.endsWith("_call")) {
-                // Native server-executed tools (currently web_search) open with a
-                // `<type>_call` item, not a plain function_call. Key on the item
-                // id (no separate call_id) and name it by the tool, falling back
-                // to the type minus `_call`. (MCP is a separate follow-up — see
-                // .claude/plans/mcp-tool-streaming.md.)
-                const toolItem = item as {
-                  id?: string;
-                  call_id?: string;
-                  name?: string;
-                  type: string;
-                };
+              } else if (item.type === "web_search_call") {
+                // web_search is a native OpenAI tool: it opens with a
+                // web_search_call item rather than a plain function_call and
+                // carries no separate call_id, so key the tool call on the item
+                // id (its result + query arrive on output_item.done below).
                 yield {
                   type: EventType.TOOL_CALL_START,
-                  toolCallId: toolItem.id ?? toolItem.call_id ?? toolItem.type,
-                  toolCallName: toolItem.name ?? toolItem.type.replace(/_call$/, ""),
+                  toolCallId: item.id,
+                  toolCallName: "web_search",
                 };
               }
               break;
@@ -123,23 +116,21 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
             }
 
             case "response.output_item.done": {
-              // Native server-executed tools (currently web_search) deliver their
-              // result on the done item — there's no function_call_output for
-              // them. function_call closes via function_call_arguments.done and
-              // message via output_text.done, so both are excluded here.
+              // web_search delivers its result on the done item — there's no
+              // function_call_output for it. Every other item type closes via its
+              // own event (function_call → function_call_arguments.done, message →
+              // output_text.done), so this case handles web_search only.
               const item = event.item as {
                 type?: string;
                 id?: string;
-                call_id?: string;
                 status?: string;
                 output?: unknown;
                 error?: unknown;
                 action?: unknown;
               };
-              const itemType = item.type ?? "";
-              if (!itemType.endsWith("_call") || itemType === "function_call") break;
+              if (item.type !== "web_search_call") break;
 
-              const toolCallId = item.id ?? item.call_id ?? itemType;
+              const toolCallId = item.id ?? "web_search_call";
 
               // web_search streams no argument deltas — its query lives in
               // `action`. Surface it as the tool-call args so the card shows the
@@ -184,9 +175,10 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
 
             // Intentionally unhandled — these are lifecycle/metadata events:
             // response.created, response.in_progress, response.completed,
-            // response.content_part.added, response.content_part.done, the
-            // per-tool *.in_progress/searching/completed status events (the
-            // generic output_item.added/.done handling above covers them), etc.
+            // response.content_part.added, response.content_part.done, and
+            // web_search's *.in_progress/searching/completed status events (the
+            // web_search_call output_item.added/.done handling above covers it),
+            // etc.
             default:
               break;
           }

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -69,7 +69,7 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                 yield {
                   type: EventType.TOOL_CALL_START,
                   toolCallId: item.id,
-                  toolCallName: "web_search",
+                  toolCallName: "thesys_web_search",
                 };
               }
               break;

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -4,6 +4,10 @@ import type {
 } from "openai/resources/responses/responses";
 import { AGUIEvent, EventType, StreamProtocolAdapter } from "../../types";
 
+/** A tool result's `output` as a string (JSON-encoded if structured, "" if absent). */
+const stringifyOutput = (output: unknown): string =>
+  typeof output === "string" ? output : output != null ? JSON.stringify(output) : "";
+
 export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
   async *parse(response: Response): AsyncIterable<AGUIEvent> {
     const reader = response.body?.getReader();
@@ -61,8 +65,24 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                   type: EventType.TOOL_CALL_RESULT,
                   messageId: item.id,
                   toolCallId: item.call_id,
-                  content:
-                    typeof item.output === "string" ? item.output : JSON.stringify(item.output),
+                  content: stringifyOutput(item.output),
+                };
+              } else if (typeof item.type === "string" && item.type.endsWith("_call")) {
+                // Native server-executed tools (currently web_search) open with a
+                // `<type>_call` item, not a plain function_call. Key on the item
+                // id (no separate call_id) and name it by the tool, falling back
+                // to the type minus `_call`. (MCP is a separate follow-up — see
+                // .claude/plans/mcp-tool-streaming.md.)
+                const toolItem = item as {
+                  id?: string;
+                  call_id?: string;
+                  name?: string;
+                  type: string;
+                };
+                yield {
+                  type: EventType.TOOL_CALL_START,
+                  toolCallId: toolItem.id ?? toolItem.call_id ?? toolItem.type,
+                  toolCallName: toolItem.name ?? toolItem.type.replace(/_call$/, ""),
                 };
               }
               break;
@@ -102,29 +122,46 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
               break;
             }
 
-            case "response.web_search_call.in_progress":
-              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
-              yield {
-                type: EventType.TOOL_CALL_START,
-                toolCallName: "web_search",
-                toolCallId: callId,
+            case "response.output_item.done": {
+              // Native server-executed tools (currently web_search) deliver their
+              // result on the done item — there's no function_call_output for
+              // them. function_call closes via function_call_arguments.done and
+              // message via output_text.done, so both are excluded here.
+              const item = event.item as {
+                type?: string;
+                id?: string;
+                call_id?: string;
+                status?: string;
+                output?: unknown;
+                error?: unknown;
+                action?: unknown;
               };
-              break;
+              const itemType = item.type ?? "";
+              if (!itemType.endsWith("_call") || itemType === "function_call") break;
 
-            case "response.web_search_call.searching": {
-              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
-              yield {
-                type: EventType.TOOL_CALL_CHUNK,
-                toolCallId: callId,
-              };
-              break;
-            }
+              const toolCallId = item.id ?? item.call_id ?? itemType;
 
-            case "response.web_search_call.completed": {
-              const callId = itemIdToCallId[event.item_id] ?? event.item_id;
+              // web_search streams no argument deltas — its query lives in
+              // `action`. Surface it as the tool-call args so the card shows the
+              // query live, matching a reload's persisted function_call args.
+              if (item.action && typeof item.action === "object") {
+                yield {
+                  type: EventType.TOOL_CALL_ARGS,
+                  toolCallId,
+                  delta: JSON.stringify(item.action),
+                };
+              }
+
+              const content = stringifyOutput(item.output);
+              const isError = item.status === "failed" || item.error != null;
               yield {
-                type: EventType.TOOL_CALL_END,
-                toolCallId: callId,
+                type: EventType.TOOL_CALL_RESULT,
+                messageId: toolCallId,
+                toolCallId,
+                content,
+                ...(isError
+                  ? { isError: true, error: typeof item.error === "string" ? item.error : content }
+                  : {}),
               };
               break;
             }
@@ -147,8 +184,9 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
 
             // Intentionally unhandled — these are lifecycle/metadata events:
             // response.created, response.in_progress, response.completed,
-            // response.content_part.added, response.content_part.done,
-            // response.output_item.done, etc.
+            // response.content_part.added, response.content_part.done, the
+            // per-tool *.in_progress/searching/completed status events (the
+            // generic output_item.added/.done handling above covers them), etc.
             default:
               break;
           }


### PR DESCRIPTION
## What

Adds cases for different `function_call`, `function_call_output` and `web_search` streaming events, to render web & image search tool calls.
