### PR TITLE
feat(cli): support non-interactive create defaults

### DIFF
--- a/docs/content/docs/api-reference/cli.mdx
+++ b/docs/content/docs/api-reference/cli.mdx
@@ -45,7 +45,7 @@ npm install -g @openuidev/cli
 
 ## `openui create`
 
-Scaffolds a new Next.js app pre-configured with OpenUI Chat.
+Scaffolds a new Next.js app from the OpenUI Self Hosted or OpenUI Cloud template.
 
 ```
 openui create [options]
@@ -53,22 +53,30 @@ openui create [options]
 
 **Options**
 
-| Flag                  | Description                                             |
-| --------------------- | ------------------------------------------------------- |
-| `-n, --name <string>` | Project name (directory to create)                      |
-| `--skill`             | Install the OpenUI agent skill for AI coding assistants |
-| `--no-skill`          | Skip installing the OpenUI agent skill                  |
-| `--no-interactive`    | Fail instead of prompting for missing input             |
+| Flag                        | Description                                                                 |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `-n, --name <string>`       | Project name (directory to create)                                          |
+| `--project-name <string>`   | Project name for agent/scripted runs; accepts defaults for optional prompts |
+| `-t, --template <template>` | Template to scaffold: `openui-self-hosted` or `openui-cloud`                |
+| `--api-key <key>`           | OpenUI Cloud API key for the cloud template; skips sign-in                  |
+| `--auth <method>`           | Cloud auth method: `oauth`, `manual`, or `skip`                             |
+| `-y, --yes`                 | Accept defaults for optional prompts and do not prompt                      |
+| `--skill`                   | Install the OpenUI agent skill for AI coding assistants                     |
+| `--no-skill`                | Skip installing the OpenUI agent skill                                      |
+| `--no-install`              | Scaffold without running the package install                                |
+| `--no-interactive`          | Do not prompt; fail if required args are missing                            |
 
-When run interactively (default), the CLI prompts for any missing options. Pass `--no-interactive` in CI or scripted environments to surface missing required flags as errors instead.
+When run interactively (default), the CLI prompts for any missing options. In CI or scripted environments, pass `--project-name <name>` to use defaults for optional prompts, or pass `--no-interactive` with all required flags.
 
 **What it does**
 
-1. Copies the bundled `openui-chat` Next.js template into `<name>/`
+1. Copies the selected bundled Next.js template into `<name>/`
 2. Rewrites `workspace:*` dependency versions to `latest`
 3. Auto-detects your package manager (npm, pnpm, yarn, bun)
 4. Installs dependencies
 5. Optionally installs the [OpenUI agent skill](/docs/openui-lang/agent-skill) for AI coding assistants (e.g. Claude, Cursor, Copilot)
+
+If `--template` is omitted in a scripted run, the CLI defaults to `openui-self-hosted`.
 
 The generated project includes a `generate:prompt` script that runs `openui generate` as part of `dev` and `build`.
 
@@ -76,17 +84,28 @@ The generated project includes a `generate:prompt` script that runs `openui gene
 
 When run interactively, `openui create` asks whether to install the OpenUI agent skill. The skill teaches AI coding assistants how to build with OpenUI Lang — covering component definitions, system prompts, the Renderer, and debugging.
 
-Pass `--skill` or `--no-skill` to skip the prompt. In `--no-interactive` mode the skill is skipped unless `--skill` is explicitly passed.
+Pass `--skill` or `--no-skill` to skip the prompt. In non-interactive runs the skill is skipped unless `--skill` is explicitly passed.
+
+**Cloud auth**
+
+For the `openui-cloud` template, pass `--api-key <key>` to write `THESYS_API_KEY` without a sign-in flow. You can also pass `--auth oauth`, `--auth manual`, or `--auth skip`.
+
+With `--yes` or `--project-name`, cloud auth defaults to `skip` when no key or auth method is supplied. With `--no-interactive --template openui-cloud`, missing cloud auth fails with an actionable error unless you pass `--api-key` or `--auth skip`.
 
 **Examples**
 
 ```bash
-# Interactive — prompts for project name and skill installation
+# Interactive — prompts for project name, template, and optional setup
 openui create
 
-# Non-interactive
-openui create --name my-app
-openui create --no-interactive --name my-app
+# Agent/scripted — no prompts
+openui create --project-name my-app
+openui create --project-name my-app --no-install
+openui create --yes --name my-app --no-install
+
+# Explicit template and cloud auth
+openui create --project-name my-app --template openui-cloud --api-key tk_your_key
+openui create --no-interactive --name my-app --template openui-cloud --auth skip
 
 # Explicitly install or skip the agent skill
 openui create --name my-app --skill

--- a/packages/openui-cli/README.md
+++ b/packages/openui-cli/README.md
@@ -32,6 +32,13 @@ Create a new app (you'll be prompted to pick a template):
 npx @openuidev/cli@latest create
 ```
 
+Create a new app without prompts, using defaults for optional choices:
+
+```bash
+npx @openuidev/cli@latest create --project-name my-app
+npx @openuidev/cli@latest create --project-name my-app --no-install
+```
+
 Skip the prompt and pick a template directly:
 
 ```bash
@@ -64,7 +71,9 @@ openui create [options]
 Options:
 
 - `-n, --name <string>`: Project name
+- `--project-name <string>`: Project name for agent/scripted runs; accepts defaults for optional prompts
 - `-t, --template <template>`: Template to scaffold — `openui-self-hosted` or `openui-cloud`
+- `-y, --yes`: Accept defaults for optional prompts and do not prompt
 - `--skill`: Install the OpenUI agent skill for AI coding assistants
 - `--no-skill`: Skip installing the OpenUI agent skill
 - `--no-install`: Scaffold without running the package install
@@ -74,8 +83,9 @@ Options:
 
 What it does:
 
-- prompts for the project name if you do not pass `--name`
-- prompts for the template if you do not pass `--template`
+- prompts for the project name if you do not pass `--name` or `--project-name`
+- prompts for the template if you do not pass `--template` in interactive mode
+- defaults to `openui-self-hosted` for scripted runs when `--template` is omitted
 - copies the bundled template into a new directory
 - rewrites monorepo-local dependencies (`workspace:`, `file:`, `catalog:`) in the generated `package.json` to `latest`
 - installs dependencies automatically using the detected package manager (unless `--no-install`)
@@ -91,17 +101,22 @@ What it does:
     - `oauth` — sign in with Thesys in the browser and mint a key for your org
     - `manual` — paste an existing key
     - `skip` — leave `THESYS_API_KEY` empty and add it later (get one at <https://console.thesys.dev/keys>)
-  - in non-interactive mode without `--api-key`, the cloud template fails because a key is required
+  - `--yes` or `--project-name` defaults cloud auth to `skip` when no key/auth flag is supplied
+  - `--no-interactive` with `--template openui-cloud` fails unless you pass `--api-key` or `--auth skip`
 
 Examples:
 
 ```bash
 openui create
+openui create --project-name my-app
+openui create --project-name my-app --no-install
 openui create --name my-app --template openui-self-hosted
 openui create --name my-app --template openui-cloud --auth oauth
 openui create --name my-app --template openui-cloud --api-key tk_your_key
 openui create --name my-app --no-skill --no-install
+openui create --yes --name my-app --no-install
 openui create --no-interactive --name my-app --template openui-cloud --api-key tk_your_key
+openui create --no-interactive --name my-app --template openui-cloud --auth skip
 ```
 
 ### `openui generate`

--- a/packages/openui-cli/src/auth/mint.ts
+++ b/packages/openui-cli/src/auth/mint.ts
@@ -63,8 +63,8 @@ export async function resolveCloudApiKey(opts: {
   if (!method) {
     if (!opts.interactive) {
       throw new Error(
-        `An API key is required in non-interactive mode. Pass --api-key <key> ` +
-          `(get one at ${THESYS_KEYS_URL}).`,
+        `OpenUI Cloud requires auth in non-interactive mode. Pass --api-key <key> ` +
+          `or --auth skip (keys: ${THESYS_KEYS_URL}).`,
       );
     }
     const { select } = await import("@inquirer/prompts");
@@ -81,6 +81,9 @@ export async function resolveCloudApiKey(opts: {
   if (method === "skip") return { key: null, method: "skip" };
 
   if (method === "manual") {
+    if (!opts.interactive) {
+      throw new Error("`--auth manual` requires an interactive prompt. Pass --api-key <key>.");
+    }
     const { password } = await import("@inquirer/prompts");
     const key = (
       await password({ message: "Paste your OpenUI Cloud API key:", mask: true })

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -10,12 +10,14 @@ import { resolveArgs } from "../lib/resolve-args";
 import { CreateError, telemetry } from "../lib/telemetry";
 
 export type TemplateName = "openui-self-hosted" | "openui-cloud";
+const DEFAULT_CREATE_TEMPLATE: TemplateName = "openui-self-hosted";
 
 export interface CreateAppOptions {
   name?: string;
   template?: TemplateName;
   skill?: boolean;
   noInteractive?: boolean;
+  acceptDefaults?: boolean;
   noInstall?: boolean;
   // cloud-only
   apiKey?: string;
@@ -32,6 +34,7 @@ function shouldCopyTemplatePath(templateDir: string, src: string): boolean {
 
 export async function runCreateApp(options: CreateAppOptions): Promise<void> {
   const interactive = !options.noInteractive;
+  const useDefaults = options.acceptDefaults || !interactive;
   const t0 = Date.now();
   telemetry.register({ is_interactive: interactive });
 
@@ -39,31 +42,50 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     {
       name: options.name
         ? { value: options.name }
-        : { prompt: { type: "input", message: "Project name?" }, required: true },
+        : {
+            prompt: { type: "input", message: "Project name?" },
+            required: true,
+            flagName: "--project-name <name> (or --name <name>)",
+          },
       template: options.template
         ? { value: options.template }
-        : {
-            prompt: {
-              type: "select",
-              message: "Which template?",
-              choices: [
-                {
-                  value: "openui-cloud",
-                  name: "OpenUI Cloud — managed conversations, artifacts & streaming",
-                },
-                {
-                  value: "openui-self-hosted",
-                  name: "OpenUI Self Hosted — starter setup with OpenAI SDK",
-                },
-              ],
+        : useDefaults
+          ? { value: DEFAULT_CREATE_TEMPLATE }
+          : {
+              prompt: {
+                type: "select",
+                message: "Which template?",
+                choices: [
+                  {
+                    value: "openui-cloud",
+                    name: "OpenUI Cloud — managed conversations, artifacts & streaming",
+                  },
+                  {
+                    value: "openui-self-hosted",
+                    name: "OpenUI Self Hosted — starter setup with OpenAI SDK",
+                  },
+                ],
+              },
+              required: true,
             },
-            required: true,
-          },
     },
     interactive,
   );
 
   const { name, template } = args as { name: string; template: TemplateName };
+  if (
+    template === "openui-cloud" &&
+    !interactive &&
+    !options.acceptDefaults &&
+    !options.apiKey &&
+    !options.auth
+  ) {
+    throw new CreateError(
+      "cloud_auth",
+      "OpenUI Cloud requires auth in non-interactive mode. Pass --api-key <key> or --auth skip.",
+    );
+  }
+
   telemetry.register({ template });
   telemetry.capture("cli_create_started", { interactive });
   telemetry.capture("cli_template_selected", { template });
@@ -179,7 +201,7 @@ async function writeCloudEnv(
   try {
     const resolved = await resolveCloudApiKey({
       apiKey: options.apiKey,
-      auth: options.auth,
+      auth: options.acceptDefaults && !options.apiKey && !options.auth ? "skip" : options.auth,
       projectName: name,
       interactive,
     });
@@ -190,6 +212,9 @@ async function writeCloudEnv(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
+    if (!interactive) {
+      throw new CreateError("cloud_auth", msg);
+    }
     console.error(`\n⚠ Could not obtain an API key: ${msg}`);
     console.error(`  Add THESYS_API_KEY to .env later (keys: ${THESYS_KEYS_URL}).\n`);
   }

--- a/packages/openui-cli/src/index.ts
+++ b/packages/openui-cli/src/index.ts
@@ -8,7 +8,7 @@ import { Command } from "commander";
 import { runCreateApp } from "./commands/create-app";
 import { runGenerate } from "./commands/generate";
 import { resolveArgs } from "./lib/resolve-args";
-import { telemetry } from "./lib/telemetry";
+import { CreateError, telemetry } from "./lib/telemetry";
 import { handleCliError, normalizeAuth, normalizeTemplate } from "./lib/utils"; // Ensure utils.ts is included for type declarations
 
 const program = new Command();
@@ -18,6 +18,20 @@ const cliVersion = (
     version: string;
   }
 ).version;
+
+function canPrompt(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
+}
+
+function resolveProjectName(name?: string, projectName?: string): string | undefined {
+  if (name && projectName && name !== projectName) {
+    throw new CreateError(
+      "bad_args",
+      `conflicting project names: --name "${name}" and --project-name "${projectName}".`,
+    );
+  }
+  return projectName ?? name;
+}
 
 program.name("openui").description("CLI for OpenUI").version(cliVersion);
 program.option("--no-telemetry", "Disable anonymous usage analytics");
@@ -32,31 +46,46 @@ program
   .command("create")
   .description("Scaffold a new Next.js app (OpenUI Self Hosted or OpenUI Cloud)")
   .option("-n, --name <string>", "Project name")
-  .option("-t, --template <template>", "Template: openui-self-hosted | openui-cloud")
+  .option(
+    "--project-name <string>",
+    "Project name for agent/scripted runs; accepts defaults for optional prompts",
+  )
+  .option(
+    "-t, --template <template>",
+    "Template: openui-self-hosted | openui-cloud (defaults to openui-self-hosted without prompts)",
+  )
   .option("--api-key <key>", "OpenUI Cloud API key (cloud template; skips sign-in)")
   .option("--auth <method>", "Cloud auth method: oauth | manual | skip")
+  .option("-y, --yes", "Accept defaults for optional prompts and do not prompt")
   .option("--skill", "Install the OpenUI agent skill for AI coding assistants")
   .option("--no-skill", "Skip installing the OpenUI agent skill")
-  .option("--no-interactive", "Fail with error if required args are missing")
+  .option("--no-interactive", "Do not prompt; fail if required args are missing")
   .option("--no-install", "Scaffold without running the package install")
   .action(
     async (options: {
       name?: string;
+      projectName?: string;
       template?: string;
       apiKey?: string;
       auth?: string;
+      yes?: boolean;
       skill?: boolean;
       interactive: boolean;
       install: boolean;
     }) => {
       try {
+        const projectName = resolveProjectName(options.name, options.projectName);
+        const acceptsDefaults = Boolean(options.yes || options.projectName);
+        const interactive = options.interactive && !acceptsDefaults && canPrompt();
+
         await runCreateApp({
-          name: options.name,
+          name: projectName,
           template: normalizeTemplate(options.template),
           apiKey: options.apiKey,
           auth: normalizeAuth(options.auth),
           skill: options.skill,
-          noInteractive: !options.interactive,
+          noInteractive: !interactive,
+          acceptDefaults: acceptsDefaults,
           noInstall: !options.install,
         });
       } catch (e) {

--- a/packages/openui-cli/src/lib/resolve-args.ts
+++ b/packages/openui-cli/src/lib/resolve-args.ts
@@ -12,7 +12,7 @@ type SelectPromptConfig = {
 
 type PromptConfig = InputPromptConfig | SelectPromptConfig;
 
-export type ArgDef<T> = { value: T } | { prompt: PromptConfig; required: true };
+export type ArgDef<T> = { value: T } | { prompt: PromptConfig; required: true; flagName?: string };
 
 type ResolvedArgs<T extends Record<string, ArgDef<unknown>>> = {
   [K in keyof T]: T[K] extends { value: infer V } ? V : string;
@@ -39,7 +39,7 @@ export async function resolveArgs<T extends Record<string, ArgDef<unknown>>>(
     }
 
     if (!interactive) {
-      console.error(`Error: Missing required argument --${key}`);
+      console.error(`Error: Missing required argument ${def.flagName ?? `--${key}`}`);
       process.exit(1);
     }
 


### PR DESCRIPTION
Closes #717

## Summary
- add `--project-name` and `--yes` paths for prompt-free `openui create` runs
- default scripted create runs to `openui-self-hosted` when no template is provided
- make non-interactive cloud auth fail before scaffolding unless `--api-key` or `--auth skip` is supplied
- document the new create flags and scripted/cloud auth behavior

