### PR TITLE
Remove star-history section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,16 +220,6 @@ cp -r skills/openui .claude/skills/openui
 
 The skill covers component library design, OpenUI Lang syntax, system prompt generation, the Renderer, SDK packages, and debugging malformed LLM output.
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=thesysdev%2Fopenui&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=thesysdev/openui&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=thesysdev/openui&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=thesysdev/openui&type=date&legend=top-left" />
- </picture>
-</a>
-
 ## License
 
 This project is available under the terms described in [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## What
Remove star-history section from README

GitHub now restricts star data to repo admins/collaborators, breaking the star-history chart embed. Removed it to keep the README clean.


## Changes

- Removed Star History section (heading + <a>/<picture> embed) from README.md

## Checklist

- [x ] Ilinked a related issue, if applicable
- [x ] updated docs/README when needed
 Closes #731 