### PR TITLE
docs: add Noetic to projects page

### DIFF
--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -76,6 +76,22 @@ const projects: ProjectItem[] = [
     ],
   },
   {
+    name: "Noetic",
+    description:
+      "An agent framework integration for returning OpenUI interfaces through a streaming output codec, durable surface layer, and transport.",
+    type: "Framework",
+    status: "Community",
+    accent: "orange",
+    icon: Sparkles,
+    links: [
+      {
+        label: "Docs",
+        href: "https://noetic.tools/docs/framework/generative-ui",
+        external: true,
+      },
+    ],
+  },
+  {
     name: "Field Theory UI",
     description:
       "A local-first web interface for exploring X/Twitter bookmarks with OpenUI-powered interactive dashboards.",


### PR DESCRIPTION
## Summary

- Add Noetic as a community Framework entry on the OpenUI projects page.
- Link the card to Noetic's Generative UI documentation.

## Impact

This makes the Noetic OpenUI integration discoverable from the projects directory.

## Validation

- `./node_modules/.bin/eslint 'app/(home)/projects/page.tsx'`