### PR TITLE
Add CLI OIDC start telemetry

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "CLI for OpenUI — scaffold generative UI chat apps and generate LLM system prompts from component libraries",
   "bin": {
     "openui": "dist/index.js"

--- a/packages/openui-cli/src/auth/mint.ts
+++ b/packages/openui-cli/src/auth/mint.ts
@@ -15,6 +15,7 @@ export type ResolvedAuthMethod = CloudAuthMethod | "apikey-flag";
 /** Sign in via the browser and mint an OpenUI Cloud API key for the user's org. */
 export async function mintCloudApiKey(projectName: string): Promise<string> {
   const auth = new Authenticator({ issuerUrl: THESYS_ISSUER_URL, clientId: THESYS_CLIENT_ID });
+  telemetry.capture("cli_cloud_oidc_started");
   await auth.initialize();
   const { accessToken, userInfo } = await auth.authenticate();
 


### PR DESCRIPTION
## Summary
- Capture a `cli_cloud_oidc_started` telemetry event before the CLI starts OIDC initialization
- Bump `@openuidev/cli` from `0.1.3` to `0.1.4`

## Verification
- `pnpm --dir packages/openui-cli run build:cli`