### PR TITLE
Fix modal text color in dark mode

### DIFF
--- a/packages/react-ui/src/components/Modal/Modal.scss
+++ b/packages/react-ui/src/components/Modal/Modal.scss
@@ -20,6 +20,7 @@
   transform: translate(-50%, -50%);
   z-index: 10000;
   background: cssUtils.$foreground;
+  color: cssUtils.$text-neutral-primary;
   border: 1px solid cssUtils.$border-default;
   border-radius: 12px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Summary: Adds the themed neutral-primary foreground color to Modal content so dialog titles and default text render correctly on dark surfaces. Verification: pnpm --config.verify-deps-before-run=false --filter @openuidev/react-ui run build:scss; pnpm --config.verify-deps-before-run=false --filter @openuidev/react-ui run check:css.