### PR TITLE
fix(react-lang): stop ElementErrorBoundary from crashing the host with a commit-phase insertBefore error

### DIFF
--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -81,6 +81,8 @@
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "react-dom": "catalog:",
     "vitest": "^4.0.18"
   }
 }

--- a/packages/react-lang/src/Renderer.tsx
+++ b/packages/react-lang/src/Renderer.tsx
@@ -67,14 +67,17 @@ interface ErrorBoundaryState {
 }
 
 /**
- * Error boundary that intentionally shows the last successfully rendered
- * children when a render error occurs. This "show last good state" behavior
- * prevents the UI from going blank during streaming or transient evaluation
- * errors, and auto-recovers when new valid children arrive.
+ * Error boundary that isolates a single rendered element: when a child throws
+ * during render it renders nothing for that element (instead of tearing down
+ * the whole tree) and auto-recovers as soon as new valid children arrive, e.g.
+ * the next streaming update.
+ *
+ * It deliberately does NOT re-present the previously rendered children on error.
+ * Those are element instances from an earlier render whose DOM React has already
+ * reconciled/moved, so re-inserting them desyncs the fiber tree from the live
+ * DOM and throws an uncatchable `insertBefore` error in the commit phase (#727).
  */
-class ElementErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  private lastValidChildren: React.ReactNode = null;
-
+export class ElementErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false };
@@ -84,16 +87,7 @@ class ElementErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     return { hasError: true };
   }
 
-  componentDidMount(): void {
-    if (!this.state.hasError) {
-      this.lastValidChildren = this.props.children;
-    }
-  }
-
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {
-    if (!this.state.hasError) {
-      this.lastValidChildren = this.props.children;
-    }
     if (this.state.hasError && prevProps.children !== this.props.children) {
       this.setState({ hasError: false });
     }
@@ -111,7 +105,7 @@ class ElementErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   render() {
     if (this.state.hasError) {
-      return this.lastValidChildren;
+      return null;
     }
     return this.props.children;
   }

--- a/packages/react-lang/src/__tests__/ElementErrorBoundary.test.tsx
+++ b/packages/react-lang/src/__tests__/ElementErrorBoundary.test.tsx
@@ -1,0 +1,61 @@
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ElementErrorBoundary } from "../Renderer";
+
+// Throws when `explode` is set, otherwise renders a marker we can assert on.
+function Child({ explode, label }: { explode: boolean; label: string }) {
+  if (explode) throw new Error("boom");
+  return <span>{label}</span>;
+}
+
+describe("ElementErrorBoundary", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // React logs boundary-caught render errors to console.error; silence them.
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    consoleError.mockRestore();
+  });
+
+  const render = (node: ReactNode) => act(() => root.render(node));
+
+  it("renders nothing on error instead of re-presenting stale children, then recovers", () => {
+    const onError = vi.fn();
+    const wrap = (explode: boolean, label: string) => (
+      <ElementErrorBoundary componentName="Child" onError={onError}>
+        <Child explode={explode} label={label} />
+      </ElementErrorBoundary>
+    );
+
+    render(wrap(false, "good"));
+    expect(container.textContent).toBe("good");
+
+    // Child throws: the boundary must render nothing, not re-present the stale
+    // "good" subtree (whose DOM React has already moved) — that desync is what
+    // crashes the host app with a commit-phase insertBefore error (#727).
+    render(wrap(true, "good"));
+    expect(container.textContent).toBe("");
+    // (React may retry the throwing render, so onError can fire more than once.)
+    expect(onError).toHaveBeenCalled();
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({
+      code: "render-error",
+      component: "Child",
+    });
+
+    // New valid children arrive: the boundary auto-recovers.
+    render(wrap(false, "recovered"));
+    expect(container.textContent).toBe("recovered");
+  });
+});

--- a/packages/react-lang/vitest.config.ts
+++ b/packages/react-lang/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1670,6 +1670,12 @@ importers:
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.14)
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
       vitest:
         specifier: ^4.0.18
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.3.2)(jsdom@29.1.1)(vite@8.1.1(@types/node@25.3.2)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.89.2)(terser@5.48.0)(tsx@4.20.3)(yaml@2.9.0))


### PR DESCRIPTION
Closes #727.

`ElementErrorBoundary` catches a render error and then returns `this.lastValidChildren` — element instances captured from an earlier render. React has already reconciled and moved the DOM for those elements, so re-inserting them desyncs the fiber tree from the live DOM and throws `NotFoundError: Failed to execute 'insertBefore' on 'Node'` in the commit phase. Because it's a mutation-phase error it can't be caught by a nested boundary — it escalates to the app root and unmounts the whole subtree. It shows up in streaming chat UIs and whenever a sibling re-render forces an already-rendered `Renderer` subtree to re-render.

The fix is to render `null` on error rather than re-presenting the stale children. The boundary still auto-recovers as soon as new valid children arrive (the existing `componentDidUpdate` reset), so a transient streaming error clears on the next update instead of crashing. This matches the workaround the reporter verified. The trade-off is losing the "show last good state" for the one frame an element is broken, which seems well worth not tearing down the app — but happy to reconsider if you'd rather keep last-good-state via a keyed remount instead.

The package had no test setup, so I added a jsdom vitest config and a regression test driving the boundary through error → recovery: it asserts the boundary renders nothing after a child throws (not the stale subtree) and recovers when valid children return. Confirmed it fails against the old `return this.lastValidChildren`. typecheck/eslint/prettier clean.