### PR TITLE
added prox to ADOPTERS.MD

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -21,7 +21,7 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 | [GAIA](https://heygaia.io) | [Aryan Randeriya](https://github.com/aryanranderiya) | GAIA is a proactive personal AI assistant that uses OpenUI Lang to let its backend LLM emit rich, interactive React components inline in chat responses — rendering cards, lists, and other generative UI directly in the conversation instead of plain text. |
 | [&facts](https://www.andfacts.com) | [Sohaib Ahmed](https://www.linkedin.com/in/sohaibacma/) | A market insights platform to help eCommerce brands better understand their customers. |
 | [Oodle](https://www.oodle.ai/) | [Gaurav Maheshwari](https://blog.oodle.ai/how-we-taught-our-ai-to-draw/) | Oodle uses OpenUI Lang to let its AI assistant render streaming, composable observability UI for metrics, logs, traces, charts, timelines, and incident investigations. | 
-| [prox](https://useprox.com/) | [Gregory Makodzeba](https://www.linkedin.com/in/gregory-makodzeba/) | Prox is an AI product-support platform that turns manuals and product data into cited, interactive answers like troubleshooters, selectors, calculators, and guides. |
+| [prox](https://useprox.com/) | [Gregory Makodzeba](https://www.linkedin.com/in/gregory-makodzeba/) | Prox is an AI product-support platform that turns manuals and product data into cited, interactive answers like troubleshooters, selectors, calculators, and guides. | 
 <!--
 Example row, copy and edit:
 

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -20,8 +20,8 @@ To add your organization to this list, [open a PR](https://github.com/thesysdev/
 | [Entelligence.AI](https://entelligence.ai) | [Aiswarya Sankar](https://www.linkedin.com/in/sankaraiswarya/)   | AI platform that gives developers noise-free, self-verifying code reviews to catch bugs before they ship, while providing engineering leaders with the analytics needed to measure the true ROI of their AI coding tools.            |
 | [GAIA](https://heygaia.io) | [Aryan Randeriya](https://github.com/aryanranderiya) | GAIA is a proactive personal AI assistant that uses OpenUI Lang to let its backend LLM emit rich, interactive React components inline in chat responses — rendering cards, lists, and other generative UI directly in the conversation instead of plain text. |
 | [&facts](https://www.andfacts.com) | [Sohaib Ahmed](https://www.linkedin.com/in/sohaibacma/) | A market insights platform to help eCommerce brands better understand their customers. |
-| [Oodle](https://www.oodle.ai/) | [Gaurav Maheshwari](https://blog.oodle.ai/how-we-taught-our-ai-to-draw/) | Oodle uses OpenUI Lang to let its AI assistant render streaming, composable observability UI for metrics, logs, traces, charts, timelines, and incident investigations. |
-
+| [Oodle](https://www.oodle.ai/) | [Gaurav Maheshwari](https://blog.oodle.ai/how-we-taught-our-ai-to-draw/) | Oodle uses OpenUI Lang to let its AI assistant render streaming, composable observability UI for metrics, logs, traces, charts, timelines, and incident investigations. | 
+| [prox](https://useprox.com/) | [Gregory Makodzeba](https://www.linkedin.com/in/gregory-makodzeba/) | Prox is an AI product-support platform that turns manuals and product data into cited, interactive answers like troubleshooters, selectors, calculators, and guides. |
 <!--
 Example row, copy and edit:
 


### PR DESCRIPTION
## What

Adds Prox to `ADOPTERS.md` as an organization using OpenUI.

## Changes

* Added Prox to the adopters list
* Included a link to the Prox website and Gregory Makodzeba’s LinkedIn profile
* Added a brief description of how Prox uses OpenUI for interactive product-support experiences

## Test Plan

This is a documentation-only change, so no functional testing was required.

* [x] Not applicable — documentation-only change
* [ ] Verified locally

## Checklist

* [ ] I linked a related issue, if applicable
* [x] I updated docs/README when needed
* [x] I considered backwards compatibility
