### PR TITLE
fix(react-ui): wrap long unbreakable labels in RadioItem/CheckBoxItem

### DIFF
--- a/packages/react-ui/src/components/CheckBoxItem/checkBoxItem.scss
+++ b/packages/react-ui/src/components/CheckBoxItem/checkBoxItem.scss
@@ -54,6 +54,7 @@
 .openui-checkbox-item-content {
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .openui-checkbox-item-label {
@@ -61,6 +62,7 @@
   @include cssUtils.typography(primary, default);
   color: cssUtils.$text-neutral-primary;
   cursor: pointer;
+  overflow-wrap: anywhere;
   &:disabled {
     color: cssUtils.$text-neutral-tertiary;
     cursor: not-allowed;
@@ -70,4 +72,5 @@
 .openui-checkbox-item-description {
   @include cssUtils.typography(body, default);
   color: cssUtils.$text-neutral-secondary;
+  overflow-wrap: anywhere;
 }

--- a/packages/react-ui/src/components/RadioItem/radioItem.scss
+++ b/packages/react-ui/src/components/RadioItem/radioItem.scss
@@ -84,11 +84,18 @@
     fill: cssUtils.$border-interactive;
   }
 }
+.openui-radio-item-content {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
 .openui-radio-item-label {
   flex: 1;
   @include cssUtils.typography(primary, default);
   color: cssUtils.$text-neutral-primary;
   cursor: pointer;
+  overflow-wrap: anywhere;
   &:disabled {
     color: cssUtils.$text-neutral-tertiary;
     cursor: not-allowed;
@@ -98,4 +105,5 @@
 .openui-radio-item-description {
   @include cssUtils.typography(body, default);
   color: cssUtils.$text-neutral-secondary;
+  overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Problem

When `label` (or `description`) on `RadioItem` / `CheckBoxItem` contains a long token with no break opportunities — a URL, a hyphenated identifier, a long product code — the text overflows the item container and is silently clipped by its `overflow: hidden`, so part of the text disappears on narrow (mobile-width) viewports.

Normal prose (including long CJK sentences) already wraps fine; the clipping only bites on unbreakable tokens.

**Repro:** render at ~320px width

```tsx
<CheckBoxItem label="https://example.com/very/long/unbroken/path/segment-that-cannot-wrap-anywhere-because-it-has-no-spaces-at-all-1234567890" />
```

## Screenshots

Four cases per shot: long JA prose / long EN prose / unbroken URL / short label + long description. In *before*, the third item silently loses `unbroken/path/segment-` to clipping.

### CheckBoxItem

| Before | After |
| --- | --- |
| ![CheckBoxItem before: URL label clipped mid-string](https://raw.githubusercontent.com/Shinyaigeek/openui/assets/choice-item-long-label/checkbox-before.png) | ![CheckBoxItem after: URL label fully wrapped](https://raw.githubusercontent.com/Shinyaigeek/openui/assets/choice-item-long-label/checkbox-after.png) |

### RadioItem

| Before | After |
| --- | --- |
| ![RadioItem before: URL label clipped mid-string](https://raw.githubusercontent.com/Shinyaigeek/openui/assets/choice-item-long-label/radio-before.png) | ![RadioItem after: URL label fully wrapped](https://raw.githubusercontent.com/Shinyaigeek/openui/assets/choice-item-long-label/radio-after.png) |

## Fix

- Add `overflow-wrap: anywhere` to the label and description of both components so unbreakable tokens wrap instead of being clipped. (`anywhere` — rather than `break-word` — also affects min-content sizing, so it wraps correctly inside the flex row.)
- Add `min-width: 0` to the content wrapper so it can shrink within the flex container.
- Define `.openui-radio-item-content`, which `RadioItem.tsx` already renders but had no styles for, matching the existing `.openui-checkbox-item-content`.

CSS-only; no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)