### PR TITLE
feat(react-ui): allow rich content components in StepsItem details

### DIFF
--- a/packages/react-ui/src/genui-lib/Steps/index.tsx
+++ b/packages/react-ui/src/genui-lib/Steps/index.tsx
@@ -7,12 +7,13 @@ import { MarkDownRenderer } from "../../components/MarkDownRenderer";
 import { Steps as OpenUISteps, StepsItem as OpenUIStepsItem } from "../../components/Steps";
 import { StepsItemSchema } from "./schema";
 
-export { StepsItemSchema } from "./schema";
+export { StepsItemDetailsChildUnion, StepsItemSchema } from "./schema";
 
 export const StepsItem = defineComponent({
   name: "StepsItem",
   props: StepsItemSchema,
-  description: "title and details text for one step",
+  description:
+    "One step: title, plus details as markdown text or an array of content components (e.g. CodeBlock, Image)",
   component: () => null,
 });
 
@@ -32,7 +33,7 @@ export const Steps = defineComponent({
             typeof details === "string" ? (
               <MarkDownRenderer textMarkdown={details} />
             ) : (
-              (renderNode(details) as React.ReactElement)
+              (renderNode(details) as React.ReactNode)
             );
 
           return (

--- a/packages/react-ui/src/genui-lib/Steps/schema.ts
+++ b/packages/react-ui/src/genui-lib/Steps/schema.ts
@@ -1,6 +1,23 @@
 import { z } from "zod/v4";
 
+import { CodeBlock } from "../CodeBlock";
+import { Image } from "../Image";
+import { ImageBlock } from "../ImageBlock";
+import { MarkDownRenderer } from "../MarkDownRenderer";
+import { TextContent } from "../TextContent";
+
+// Content allowed inside a StepsItem's details.
+// Kept narrower than SectionContentChildUnion: procedural steps need prose,
+// code, and images — and referencing Steps here would be circular.
+export const StepsItemDetailsChildUnion = z.union([
+  TextContent.ref,
+  MarkDownRenderer.ref,
+  CodeBlock.ref,
+  Image.ref,
+  ImageBlock.ref,
+]);
+
 export const StepsItemSchema = z.object({
   title: z.string(),
-  details: z.string(),
+  details: z.union([z.string(), z.array(StepsItemDetailsChildUnion)]),
 });


### PR DESCRIPTION
## Motivation

`StepsItem`'s `details` prop is `z.string()` in the genui schema, which means an LLM can only express a step's body as one markdown string. Procedural content — installation guides, usage instructions — often needs real `CodeBlock`, `Image`, or `MarkDownRenderer` components alongside prose (as requested in user feedback asking for `details` to accept rich content similar to `SectionItem`'s `content`).

Notably, only the schema blocks this: the React component layer already types [`details: React.ReactNode`](https://github.com/thesysdev/openui/blob/69c8aae73be0129eb776cfa9016d790e2ba77ded/packages/react-ui/src/components/Steps/Steps.tsx#L5), and the genui renderer already has a non-string branch that renders `details` through `renderNode`:

https://github.com/thesysdev/openui/blob/69c8aae73be0129eb776cfa9016d790e2ba77ded/packages/react-ui/src/genui-lib/Steps/index.tsx#L30-L36

With `details: z.string()`, the `renderNode(details)` arm was unreachable dead code — the receiving side existed, only the schema kept the door shut.

## Change

- `details` becomes `z.union([z.string(), z.array(StepsItemDetailsChildUnion)])`
- New `StepsItemDetailsChildUnion` = `TextContent | MarkDownRenderer | CodeBlock | Image | ImageBlock`. Kept intentionally narrower than `SectionContentChildUnion`: procedural steps need prose/code/images, referencing `Steps` from its own item schema would be circular, and a small union keeps the prompt signature compact. The exact set of components that should qualify as rich content is open to discussion — I kept it to prose, code, and images, but happy to adjust.
- Renderer: only a cast relaxation (`ReactElement` → `ReactNode`) and a description update; the existing `renderNode` branch handles arrays as-is.

The prompt signature the LLM sees changes from

```
StepsItem(title: string, details: string)
```

to

```
StepsItem(title: string, details: string | (TextContent | MarkDownRenderer | CodeBlock | Image | ImageBlock)[])
```

## Screenshots

Live Vite harness rendering `openuiLibrary`. Each page shows the prompt signature from `openuiLibrary.toSpec()` at the top, panel A with string details, and panel B with component details.

### Before

`details: string` — panel B's program renders only because the runtime never validated children against the schema; the LLM never sees this form.

<img src="https://raw.githubusercontent.com/Shinyaigeek/openui/d41baf71d0f5a5dcb440b41adbab6e88d32b71af/before-fix.png" alt="before: signature shows details: string" width="720">

### After

The signature advertises the union, and panel B exercises all five members in one `Steps`: `TextContent` (steps 1, 3), `MarkDownRenderer` with `card` variant (step 2), `CodeBlock` (steps 1–3), `Image` (step 3 diagram), `ImageBlock` (step 4).

<img src="https://raw.githubusercontent.com/Shinyaigeek/openui/d41baf71d0f5a5dcb440b41adbab6e88d32b71af/after-fix.png" alt="after: signature shows the union and all five members render" width="720">

## Backward compatibility

String `details` still renders through `MarkDownRenderer`, so existing programs and prompts are unaffected.

## Verification

- Rendered both forms in a live Vite harness against `openuiLibrary`: string details (unchanged) and an example exercising all five union members inside one `Steps`
- `openuiLibrary.toSpec()` signature updated as above; `toJSONSchema()` expands to `anyOf: [{type: "string"}, {items: {anyOf: [$ref …]}}]` with correct `$defs` refs
- `react-ui` vitest: 6 passed; `lang-core` vitest: 76 passed
- `tsc --noEmit` error count identical before/after the change (pre-existing react-headless d.ts drift only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
