### PR TITLE
feat(openui-cloud): add image-search starter prompt

### DIFF
--- a/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
+++ b/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
@@ -74,6 +74,11 @@ export function CloudChat() {
         theme={{ mode }}
         starters={[
           {
+            displayText: "Flagship store tour",
+            prompt:
+              "Put together retail design inspiration. Use photos of Apple Fifth Avenue, Nike House of Innovation, and Gentle Monster's Seoul flagship, with a visual card for each highlighting one design idea worth borrowing.",
+          },
+          {
             displayText: "Summarize EV trends",
             prompt: "In a few sentences, summarize the biggest EV market trends this quarter.",
           },


### PR DESCRIPTION
Adds a **"Flagship store tour"** starter prompt to the `openui-cloud` CLI template.

The prompt asks the assistant to put together retail design inspiration using **photos** of real flagship stores (Apple Fifth Avenue, Nike House of Innovation, Gentle Monster Seoul), rendering a visual card per store — showcasing the image-search capability out of the box for anyone scaffolding a new app.

## Change
- `packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx` — prepend the new starter to the `starters` array.

## Notes
- Template-only, no behavioral/build changes.
- The matching example (`examples/openui-cloud`) picks up the same starter via the separate build-fix PR (which restructures the example's page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)