### PR TITLE
Avoid mangling the docs production build

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "generate:prompts": "pnpm --filter @openuidev/cli build && pnpm exec openui generate lib/chat-library.ts --out generated/chat-system-prompt.txt && pnpm exec openui generate lib/playground-library.ts --out generated/playground-system-prompt.txt && pnpm exec openui generate lib/playground-library.ts --json-schema --out generated/playground-component-spec.json",
     "fetch:tweets": "node scripts/fetch-static-tweets.mjs",
-    "build": "next build",
+    "build": "next build --no-mangling",
     "dev": "pnpm generate:prompts && next dev",
     "start": "next start",
     "types:check": "fumadocs-mdx && next typegen && tsc --noEmit",


### PR DESCRIPTION
## Summary

- disable identifier mangling in the docs production build

## Why

Next.js 16.2.6 mangles the `@openuidev/thesys` client bundle into invalid JavaScript with a duplicate identifier declaration. The affected dynamic chunk fails to parse on `openui.com/chat`, leaving OpenUI Cloud on its loading fallback even when the Cloud feature flag and API key are configured.

Using the supported `--no-mangling` build flag avoids the corrupting optimizer pass. This may increase the generated JavaScript size, but restores valid production output.

## Validation

- `pnpm --filter @openuidev/docs exec prettier --check package.json`
- verified that the installed Next CLI supports `next build --no-mangling`
- `git diff --check`
