### PR TITLE
Update Cloud demo model options

### DIFF
--- a/docs/app/chat/_components/agent-surfaces/cloud-agent-surface.tsx
+++ b/docs/app/chat/_components/agent-surfaces/cloud-agent-surface.tsx
@@ -23,8 +23,9 @@ const { artifactRenderers, artifactCategories } = defineArtifactCategories([
 
 const CLOUD_STARTERS = [
   {
-    displayText: "Summarize EV trends",
-    prompt: "In a few sentences, summarize the biggest EV market trends this quarter.",
+    displayText: "Flagship store tour",
+    prompt:
+      "Put together retail design inspiration. Use photos of Apple Fifth Avenue, Nike House of Innovation, and Gentle Monster's Seoul flagship, with a visual card for each highlighting one design idea worth borrowing.",
   },
   {
     displayText: "Pricing strategy tips",

--- a/docs/app/chat/_components/agent-surfaces/cloud-model-switcher.tsx
+++ b/docs/app/chat/_components/agent-surfaces/cloud-model-switcher.tsx
@@ -31,9 +31,6 @@ export function CloudModelSwitcher({ selectedModel, onModelChange }: CloudModelS
           title={selectedOption?.id ?? selectedModel}
         >
           <span className={styles.modelSwitcherValue}>{selectedOption?.name ?? selectedModel}</span>
-          {selectedOption?.badge ? (
-            <span className={styles.modelBadge}>{selectedOption.badge}</span>
-          ) : null}
         </SelectTrigger>
         <SelectContent align="start" className={styles.modelSwitcherContent}>
           {groupedModels.map(([provider, providerModels]) => (
@@ -44,9 +41,6 @@ export function CloudModelSwitcher({ selectedModel, onModelChange }: CloudModelS
                   <span className={styles.modelOption}>
                     <span className={styles.modelOptionHeading}>
                       <span className={styles.modelOptionName}>{model.name}</span>
-                      {model.badge ? (
-                        <span className={styles.modelBadge}>{model.badge}</span>
-                      ) : null}
                     </span>
                     <span className={styles.modelOptionId}>{model.id}</span>
                   </span>

--- a/docs/app/chat/chat-page.module.css
+++ b/docs/app/chat/chat-page.module.css
@@ -306,20 +306,6 @@
   white-space: nowrap;
 }
 
-.modelBadge {
-  display: inline-flex;
-  flex: none;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  background: var(--openui-success-background);
-  padding: 3px 7px;
-  color: var(--openui-text-success-primary);
-  font-size: 10px;
-  font-weight: 600;
-  line-height: 1;
-}
-
 .modelSwitcherContent {
   width: min(360px, calc(100vw - 32px));
   max-height: 360px;

--- a/docs/lib/openui-cloud/models.ts
+++ b/docs/lib/openui-cloud/models.ts
@@ -1,27 +1,23 @@
-export const DEFAULT_MODEL = "google/gemini-3.1-pro-free";
+export const DEFAULT_MODEL = "anthropic/claude-sonnet-4.6";
 
 export interface ModelOption {
   id: string;
   name: string;
   provider: "Anthropic" | "Google" | "OpenAI";
-  badge?: string;
 }
 
 export const MODEL_OPTIONS: readonly ModelOption[] = [
-  { provider: "Google", id: "google/gemini-3.1-pro-free", name: "Gemini 3.1 Pro", badge: "Free" },
+  { provider: "Google", id: "google/gemini-3.1-pro-free", name: "Gemini 3.1 Pro" },
   {
     provider: "Google",
     id: "google/gemini-3.1-flash-lite-free",
     name: "Gemini 3.1 Flash Lite",
-    badge: "Free",
   },
   {
     provider: "Google",
     id: "google/gemini-3.5-flash-free",
     name: "Gemini 3.5 Flash",
-    badge: "Free",
   },
-  { provider: "Google", id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash" },
   { provider: "Google", id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
   { provider: "OpenAI", id: "openai/gpt-5.5", name: "GPT-5.5" },
   { provider: "OpenAI", id: "openai/gpt-5.4", name: "GPT-5.4" },

--- a/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
+++ b/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
@@ -79,10 +79,6 @@ export function CloudChat() {
               "Put together retail design inspiration. Use photos of Apple Fifth Avenue, Nike House of Innovation, and Gentle Monster's Seoul flagship, with a visual card for each highlighting one design idea worth borrowing.",
           },
           {
-            displayText: "Summarize EV trends",
-            prompt: "In a few sentences, summarize the biggest EV market trends this quarter.",
-          },
-          {
             displayText: "Pricing strategy tips",
             prompt: "List five quick tips for pricing a new electric vehicle competitively.",
           },


### PR DESCRIPTION
## Summary

- add the flagship store tour starter and remove the EV trends starter
- remove redundant model pricing badges and the duplicate Gemini 3.5 Flash entry
- make Claude Sonnet 4.6 the default Cloud model

## Validation

- `git diff --check`

Formatting validation could not run because `prettier-plugin-organize-imports` is not installed in this workspace.
