### PR TITLE
Enable sampled PostHog session recording

### DIFF
--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -9,6 +9,10 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
     posthog.init("phc_3OLW53x09ZTVZSV6BEpj5uycj3ooqR6KOemOjx04e3D", {
       api_host: "https://dgoeivjus9jfp.cloudfront.net",
       capture_pageview: "history_change",
+      disable_session_recording: false,
+      session_recording: {
+        sampleRate: 0.1,
+      },
     });
   }, []);
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;


### PR DESCRIPTION
## Summary

- explicitly enable PostHog session recording for the docs site
- sample 10% of sessions to control recording volume

## Why

Session recordings provide representative UX diagnostics while sampling limits ingestion volume and cost.

## Impact

Approximately 10% of docs-site sessions will be recorded. Existing pageview capture remains unchanged.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- `git diff --check`
