### PR TITLE
Serve docs as Markdown when requested

### DIFF
--- a/docs/proxy.ts
+++ b/docs/proxy.ts
@@ -1,0 +1,16 @@
+import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
+import { type NextRequest, NextResponse } from "next/server";
+
+const { rewrite: rewriteLLM } = rewritePath("/docs{/*path}", "/llms.mdx/docs{/*path}");
+
+export default function proxy(request: NextRequest) {
+  if (isMarkdownPreferred(request)) {
+    const markdownPath = rewriteLLM(request.nextUrl.pathname);
+
+    if (markdownPath) {
+      return NextResponse.rewrite(new URL(markdownPath, request.nextUrl));
+    }
+  }
+
+  return NextResponse.next();
+}


### PR DESCRIPTION
## Summary

- detect when a docs request prefers Markdown using Fumadocs content negotiation
- rewrite matching `/docs` requests to the existing processed Markdown route
- preserve the normal HTML response for browser requests

## Why

The docs already expose processed Markdown through the `llms.mdx` route, but clients requesting `Accept: text/markdown` still received the HTML page at the canonical docs URL. This adds the Fumadocs-recommended negotiation layer for AI agents and other Markdown clients.

## Validation

- `pnpm --filter @openuidev/docs types:check`

closes #783 
