### PR TITLE
Remove OpenUI article from projects

### DIFF
--- a/docs/app/(home)/projects/page.tsx
+++ b/docs/app/(home)/projects/page.tsx
@@ -1,6 +1,5 @@
 import {
   ArrowUpRight,
-  BookOpen,
   Bot,
   Code2,
   MonitorSmartphone,
@@ -259,22 +258,6 @@ const projects: ProjectItem[] = [
       {
         label: "GitHub",
         href: "https://github.com/thesysdev/openui/tree/main/examples/fastapi-backend",
-        external: true,
-      },
-    ],
-  },
-  {
-    name: "Generative UI のためのフレームワーク OpenUI",
-    description:
-      "A Japanese deep-dive by azukiazusa exploring OpenUI Lang as a framework for safe, brand-consistent generative UI.",
-    type: "Article",
-    status: "Community",
-    accent: "purple",
-    icon: BookOpen,
-    links: [
-      {
-        label: "Article",
-        href: "https://azukiazusa.dev/blog/openui-framework-for-generative-ui/",
         external: true,
       },
     ],


### PR DESCRIPTION
## Summary

- Remove the “Generative UI のためのフレームワーク OpenUI” community article from the projects page.
- Remove the now-unused `BookOpen` icon import.

## Reason

The article is already included on the Blogs page, so this removes the duplicate listing from the projects directory while preserving access through the existing blog entry.

## Impact

No other docs content or project entries are changed.

## Validation

- `pnpm --filter @openuidev/docs exec prettier --check 'app/(home)/projects/page.tsx'`
- `pnpm --filter @openuidev/docs exec eslint 'app/(home)/projects/page.tsx'`
- `git diff --check`
