### PR TITLE
fix(react-lang): support older React versions

### DIFF
--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.0.0",
-    "react": "catalog:",
+    "react": ">=16.8.0",
     "zod": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/react-lang/src/Renderer.tsx
+++ b/packages/react-lang/src/Renderer.tsx
@@ -7,10 +7,11 @@ import type {
   ToolProvider,
 } from "@openuidev/lang-core";
 import { ToolNotFoundError, extractToolResult } from "@openuidev/lang-core";
-import React, { Component, Fragment, useEffect, useInsertionEffect, useRef } from "react";
+import React, { Component, Fragment, useEffect, useRef } from "react";
 import { OpenUIContext, useOpenUI, useRenderNode } from "./context";
 import { useOpenUIState } from "./hooks/useOpenUIState";
 import type { ComponentRenderer, Library } from "./library";
+import { useInsertionEffectCompat } from "./react-compat";
 
 export interface RendererProps {
   /** Raw response text (openui-lang code). */
@@ -210,7 +211,7 @@ export function Renderer({
   queryLoader,
   onError,
 }: RendererProps) {
-  useInsertionEffect(() => {
+  useInsertionEffectCompat(() => {
     ensureLoadingStyle();
   }, []);
 

--- a/packages/react-lang/src/__tests__/react-compat.test.ts
+++ b/packages/react-lang/src/__tests__/react-compat.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, test } from "vitest";
+
+const react18OnlyHooks = ["useInsertionEffect", "useSyncExternalStore"];
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((name) => {
+    const file = join(dir, name);
+    const stat = statSync(file);
+    if (stat.isDirectory()) {
+      if (name === "__tests__") return [];
+      return listSourceFiles(file);
+    }
+    return /\.(ts|tsx)$/.test(name) ? [file] : [];
+  });
+}
+
+describe("React compatibility", () => {
+  test("does not import React 18-only hooks directly from react", () => {
+    const srcRoot = join(process.cwd(), "src");
+    const violations = listSourceFiles(srcRoot).flatMap((file) => {
+      const source = readFileSync(file, "utf8");
+      const matches = react18OnlyHooks.filter((hook) => {
+        const namedImport = new RegExp(
+          `import\\s*\\{[^}]*\\b${hook}\\b[^}]*\\}\\s*from\\s*["']react["']`,
+        );
+        const mixedImport = new RegExp(
+          `import\\s+[^;{]+,\\s*\\{[^}]*\\b${hook}\\b[^}]*\\}\\s*from\\s*["']react["']`,
+        );
+        return namedImport.test(source) || mixedImport.test(source);
+      });
+      return matches.map((hook) => `${relative(srcRoot, file)} imports ${hook}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/react-lang/src/hooks/useOpenUIState.ts
+++ b/packages/react-lang/src/hooks/useOpenUIState.ts
@@ -19,9 +19,10 @@ import {
   type ToolProvider,
 } from "@openuidev/lang-core";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { OpenUIContextValue } from "../context";
 import type { Library } from "../library";
+import { useSyncExternalStoreCompat } from "../react-compat";
 
 /** Unwrap { value, componentType } wrapper from form field entries. Returns raw value. */
 function unwrapFieldValue(v: unknown): unknown {
@@ -139,8 +140,12 @@ export function useOpenUIState(
   }, [result?.stateDeclarations, store, initialState]);
 
   // ─── Subscribe to Store and QueryManager for re-renders ───
-  const storeSnapshot = useSyncExternalStore(store.subscribe, store.getSnapshot, store.getSnapshot);
-  const querySnapshot = useSyncExternalStore(
+  const storeSnapshot = useSyncExternalStoreCompat(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+  const querySnapshot = useSyncExternalStoreCompat(
     queryManager.subscribe,
     queryManager.getSnapshot,
     queryManager.getSnapshot,

--- a/packages/react-lang/src/react-compat.ts
+++ b/packages/react-lang/src/react-compat.ts
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+
+type SyncExternalStoreHook = <Snapshot>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot?: () => Snapshot,
+) => Snapshot;
+
+const nativeUseInsertionEffect = (React as unknown as { useInsertionEffect?: typeof useEffect })
+  .useInsertionEffect;
+
+const nativeUseSyncExternalStore = (
+  React as unknown as {
+    useSyncExternalStore?: SyncExternalStoreHook;
+  }
+).useSyncExternalStore;
+
+export const useInsertionEffectCompat = nativeUseInsertionEffect ?? useEffect;
+
+function useSyncExternalStoreFallback<Snapshot>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+): Snapshot {
+  const [snapshot, setSnapshot] = useState(() => getSnapshot());
+
+  useEffect(() => {
+    const handleStoreChange = () => {
+      setSnapshot(() => getSnapshot());
+    };
+
+    handleStoreChange();
+    return subscribe(handleStoreChange);
+  }, [subscribe, getSnapshot]);
+
+  return snapshot;
+}
+
+export function useSyncExternalStoreCompat<Snapshot>(
+  subscribe: (onStoreChange: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot?: () => Snapshot,
+): Snapshot {
+  if (nativeUseSyncExternalStore) {
+    return nativeUseSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  }
+  return useSyncExternalStoreFallback(subscribe, getSnapshot);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1710,7 +1710,7 @@ importers:
         specifier: workspace:^
         version: link:../lang-core
       react:
-        specifier: 'catalog:'
+        specifier: '>=16.8.0'
         version: 19.2.4
       zod:
         specifier: 'catalog:'


### PR DESCRIPTION


## What

Fixes #690 

## Changes

1. Change the React peer dependency from catalog to >=16.8.0.

2. Add a react-compat layer for useInsertionEffect and useSyncExternalStore.

3. Add a compatibility test to catch direct imports of React 18-only hooks.

## Test Plan

Describe how you validated this change.

- [ ] Not applicable (explain why)
- [x] Verified locally

## Checklist

- [x] I linked a related issue, if applicable
- [x ] I updated docs/README when needed
- [ x] I considered backwards compatibility
