### PR TITLE
Configure docs-only Vercel preview deployments

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "if [ \"$VERCEL_ENV\" = \"preview\" ]; then git diff --quiet HEAD^ HEAD ./; else exit 1; fi"
+}


### PR DESCRIPTION
## Summary

- add a Vercel project configuration for the `docs` app
- allow preview builds only when the latest commit changes files under `docs`
- keep production deployments unaffected

## Why

Avoid unnecessary Vercel preview builds for non-`main` changes that do not affect the documentation site.

## Validation

- parsed `docs/vercel.json` as JSON
- ran `git diff --check`
- verified the ignore command exits `1` for a preview with docs changes (build)
- verified it exits `0` for a preview without docs changes (skip)
- verified production exits `1` (build)
