### PR TITLE
Track CLI command copy analytics

### DIFF
--- a/docs/app/(home)/components/Button/Button.tsx
+++ b/docs/app/(home)/components/Button/Button.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { copyText } from "@/lib/copy-text";
+import {
+  captureCreateCliCommandCopied,
+  type CreateCliCopyAnalyticsContext,
+} from "@/lib/create-cli-copy-analytics";
 import { Check, Copy } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
@@ -60,6 +64,7 @@ interface ClipboardCommandButtonProps {
   copyIconColor?: string;
   type?: ButtonType;
   onCopyChange?: (copied: boolean) => void;
+  createCliCopyAnalytics?: CreateCliCopyAnalyticsContext;
 }
 
 export function ClipboardCommandButton({
@@ -72,6 +77,7 @@ export function ClipboardCommandButton({
   copyIconColor = "white",
   type = "button",
   onCopyChange,
+  createCliCopyAnalytics,
 }: ClipboardCommandButtonProps) {
   const [copied, setCopied] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -92,6 +98,9 @@ export function ClipboardCommandButton({
     }
     setCopied(true);
     onCopyChange?.(true);
+    if (createCliCopyAnalytics) {
+      captureCreateCliCommandCopied(command, createCliCopyAnalytics);
+    }
     if (resetTimeoutRef.current) {
       clearTimeout(resetTimeoutRef.current);
     }

--- a/docs/app/(home)/components/Button/Button.tsx
+++ b/docs/app/(home)/components/Button/Button.tsx
@@ -1,10 +1,6 @@
 "use client";
 
 import { copyText } from "@/lib/copy-text";
-import {
-  captureCreateCliCommandCopied,
-  type CreateCliCopyAnalyticsContext,
-} from "@/lib/create-cli-copy-analytics";
 import { Check, Copy } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useRef, useState, type ButtonHTMLAttributes, type ReactNode } from "react";
@@ -64,7 +60,7 @@ interface ClipboardCommandButtonProps {
   copyIconColor?: string;
   type?: ButtonType;
   onCopyChange?: (copied: boolean) => void;
-  createCliCopyAnalytics?: CreateCliCopyAnalyticsContext;
+  onCopySuccess?: (command: string) => void;
 }
 
 export function ClipboardCommandButton({
@@ -77,7 +73,7 @@ export function ClipboardCommandButton({
   copyIconColor = "white",
   type = "button",
   onCopyChange,
-  createCliCopyAnalytics,
+  onCopySuccess,
 }: ClipboardCommandButtonProps) {
   const [copied, setCopied] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -98,9 +94,7 @@ export function ClipboardCommandButton({
     }
     setCopied(true);
     onCopyChange?.(true);
-    if (createCliCopyAnalytics) {
-      captureCreateCliCommandCopied(command, createCliCopyAnalytics);
-    }
+    onCopySuccess?.(command);
     if (resetTimeoutRef.current) {
       clearTimeout(resetTimeoutRef.current);
     }

--- a/docs/app/(home)/sections/BuildChatSection/BuildChatSection.tsx
+++ b/docs/app/(home)/sections/BuildChatSection/BuildChatSection.tsx
@@ -16,6 +16,7 @@ function CtaButton() {
     <div className={styles.ctaWrap}>
       <ClipboardCommandButton
         command="npx @openuidev/cli@latest create"
+        createCliCopyAnalytics={{ source: "homepage_build_chat", interaction: "primary" }}
         className={styles.ctaButton}
         iconPosition="start"
       >

--- a/docs/app/(home)/sections/BuildChatSection/BuildChatSection.tsx
+++ b/docs/app/(home)/sections/BuildChatSection/BuildChatSection.tsx
@@ -1,11 +1,19 @@
 "use client";
 
+import { captureCreateCliCommandCopied } from "@/lib/create-cli-copy-analytics";
 import { ClipboardCommandButton } from "../../components/Button/Button";
 import styles from "./BuildChatSection.module.css";
 
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
+
+function captureBuildChatCliCopy(command: string) {
+  captureCreateCliCommandCopied(command, {
+    source: "homepage_build_chat",
+    interaction: "primary",
+  });
+}
 
 function SectionTitle() {
   return <p className={styles.title}>Build a Generative UI chat in minutes</p>;
@@ -16,7 +24,7 @@ function CtaButton() {
     <div className={styles.ctaWrap}>
       <ClipboardCommandButton
         command="npx @openuidev/cli@latest create"
-        createCliCopyAnalytics={{ source: "homepage_build_chat", interaction: "primary" }}
+        onCopySuccess={captureBuildChatCliCopy}
         className={styles.ctaButton}
         iconPosition="start"
       >

--- a/docs/app/(home)/sections/HeroSection/HeroSection.tsx
+++ b/docs/app/(home)/sections/HeroSection/HeroSection.tsx
@@ -93,6 +93,7 @@ export function NpmButton({ className = "", command }: { className?: string; com
     <div className={styles.npmButtonWrapper}>
       <ClipboardCommandButton
         command={command}
+        createCliCopyAnalytics={{ source: "homepage_hero", interaction: "primary" }}
         className={`${styles.npmButton} ${className}`.trim()}
         iconContainerClassName={styles.npmIconBadge}
         copyIconColor="currentColor"
@@ -143,6 +144,7 @@ function CommandDropdownButton({
     >
       <ClipboardCommandButton
         command={command}
+        createCliCopyAnalytics={{ source: "homepage_hero", interaction: "primary" }}
         className={styles.commandTrigger}
         iconContainerClassName={styles.commandTriggerBadge}
         copyIconColor="currentColor"
@@ -163,6 +165,7 @@ function CommandDropdownButton({
             <ClipboardCommandButton
               key={variant.id}
               command={variant.command}
+              createCliCopyAnalytics={{ source: "homepage_hero", interaction: "dropdown" }}
               className={styles.commandMenuItem}
               iconContainerClassName={styles.commandMenuItemIcon}
               copyIconColor="currentColor"

--- a/docs/app/(home)/sections/HeroSection/HeroSection.tsx
+++ b/docs/app/(home)/sections/HeroSection/HeroSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { captureCreateCliCommandCopied } from "@/lib/create-cli-copy-analytics";
 import { ArrowRight } from "lucide-react";
 import { PLATFORMS } from "../../components/PlatformLogos";
 import { useTheme } from "next-themes";
@@ -10,6 +11,14 @@ import {
   GitHubButton,
 } from "../../components/GitHubButton/GitHubButton";
 import styles from "./HeroSection.module.css";
+
+function capturePrimaryHeroCliCopy(command: string) {
+  captureCreateCliCommandCopied(command, { source: "homepage_hero", interaction: "primary" });
+}
+
+function captureDropdownHeroCliCopy(command: string) {
+  captureCreateCliCommandCopied(command, { source: "homepage_hero", interaction: "dropdown" });
+}
 
 export const heroStyles = styles;
 
@@ -93,7 +102,7 @@ export function NpmButton({ className = "", command }: { className?: string; com
     <div className={styles.npmButtonWrapper}>
       <ClipboardCommandButton
         command={command}
-        createCliCopyAnalytics={{ source: "homepage_hero", interaction: "primary" }}
+        onCopySuccess={capturePrimaryHeroCliCopy}
         className={`${styles.npmButton} ${className}`.trim()}
         iconContainerClassName={styles.npmIconBadge}
         copyIconColor="currentColor"
@@ -144,7 +153,7 @@ function CommandDropdownButton({
     >
       <ClipboardCommandButton
         command={command}
-        createCliCopyAnalytics={{ source: "homepage_hero", interaction: "primary" }}
+        onCopySuccess={capturePrimaryHeroCliCopy}
         className={styles.commandTrigger}
         iconContainerClassName={styles.commandTriggerBadge}
         copyIconColor="currentColor"
@@ -165,7 +174,7 @@ function CommandDropdownButton({
             <ClipboardCommandButton
               key={variant.id}
               command={variant.command}
-              createCliCopyAnalytics={{ source: "homepage_hero", interaction: "dropdown" }}
+              onCopySuccess={captureDropdownHeroCliCopy}
               className={styles.commandMenuItem}
               iconContainerClassName={styles.commandMenuItemIcon}
               copyIconColor="currentColor"

--- a/docs/lib/create-cli-copy-analytics.ts
+++ b/docs/lib/create-cli-copy-analytics.ts
@@ -1,0 +1,57 @@
+import posthog from "posthog-js";
+
+export const CREATE_CLI_COMMAND_COPIED_EVENT = "create_cli_command_copied";
+
+export type CreateCliPackageManager = "pnpm" | "bun" | "yarn" | "npm" | "unknown";
+
+export interface CreateCliCopyAnalyticsContext {
+  source: string;
+  interaction?: string;
+}
+
+interface CreateCliCommandCopiedProperties {
+  package_manager: CreateCliPackageManager;
+  source: string;
+  interaction?: string;
+}
+
+const CREATE_CLI_COMMAND_PATTERN = /@openuidev\/cli(?:@\S+)?\s+create(?:\s|$)/i;
+
+export function getCreateCliPackageManager(command: string): CreateCliPackageManager | null {
+  const normalized = command.trim().replace(/\s+/g, " ");
+  if (!CREATE_CLI_COMMAND_PATTERN.test(normalized)) return null;
+
+  if (/^pnpx\s/i.test(normalized)) return "pnpm";
+  if (/^bunx\s/i.test(normalized)) return "bun";
+  if (/^yarn dlx\s/i.test(normalized)) return "yarn";
+  if (/^npx\s/i.test(normalized)) return "npm";
+  return "unknown";
+}
+
+export function getCreateCliCommandCopiedProperties(
+  command: string,
+  context: CreateCliCopyAnalyticsContext,
+): CreateCliCommandCopiedProperties | null {
+  const packageManager = getCreateCliPackageManager(command);
+  if (!packageManager) return null;
+
+  return {
+    package_manager: packageManager,
+    source: context.source,
+    ...(context.interaction ? { interaction: context.interaction } : {}),
+  };
+}
+
+export function captureCreateCliCommandCopied(
+  command: string,
+  context: CreateCliCopyAnalyticsContext,
+): void {
+  const properties = getCreateCliCommandCopiedProperties(command, context);
+  if (!properties || typeof window === "undefined") return;
+
+  try {
+    posthog.capture(CREATE_CLI_COMMAND_COPIED_EVENT, properties);
+  } catch {
+    // Analytics must never interfere with a successful clipboard action.
+  }
+}


### PR DESCRIPTION
## Summary

- emit `create_cli_command_copied` only after a successful clipboard write
- infer `package_manager` for pnpm, bun, yarn, and npm, with stable `source` and `interaction` properties
- keep the shared clipboard button analytics-agnostic with a generic `onCopySuccess(command)` callback
- let the homepage sections own their `source` and `interaction` metadata

## Why

PostHog autocapture records DOM click text, which leaves many CLI copy clicks unattributable and does not confirm clipboard success. A dedicated generalized event gives reliable counts across the homepage and future docs placements.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- focused ESLint checks on the changed files; the touched Hero file was also checked with its unrelated pre-existing hook/image findings suppressed
- parser smoke test covering pnpm, bun, yarn, npm, and unrelated commands
