### PR TITLE
Enable sampled PostHog session recording

### DIFF
--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -9,6 +9,10 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
     posthog.init("phc_3OLW53x09ZTVZSV6BEpj5uycj3ooqR6KOemOjx04e3D", {
       api_host: "https://dgoeivjus9jfp.cloudfront.net",
       capture_pageview: "history_change",
+      disable_session_recording: false,
+      session_recording: {
+        sampleRate: 0.1,
+      },
     });
   }, []);
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;


### PR DESCRIPTION
## Summary

- explicitly enable PostHog session recording in the OpenUI docs app
- configure the client for a 10% replay sample

## Why

Session replay data is currently unavailable for OpenUI, which limits the ability to diagnose navigation and interaction issues from real sessions.

## Impact

Once replay is enabled in the PostHog project, eligible OpenUI docs sessions can be recorded while limiting collection volume through sampling.

## Root cause and prerequisite

The PostHog project currently returns `sessionRecording: false` from its remote configuration. Replay must also be enabled in PostHog's replay ingestion settings, and the intended 10% sampling policy should be confirmed there. Client configuration cannot override a project-level disable.

The existing CloudFront proxy successfully serves the PostHog recorder scripts and snapshot route.

## Validation

- `git diff --check main...codex/enable-posthog-session-recording`
- confirmed the proxy returns successful responses for `/static/recorder.js`, `/static/recorder-v2.js`, and `/s/`
