### PR TITLE
Describe OpenUI's renderer-agnostic framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 </div>
 
-OpenUI is a full-stack Generative UI framework: a compact streaming-first language, a React runtime with built-in component libraries, and ready-to-use chat interfaces that are up to 67% more token-efficient than JSON.
+OpenUI is a renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to 67% fewer tokens than JSON.
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 </div>
 
-OpenUI is a renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to 67% fewer tokens than JSON.
+OpenUI is a full-stack, renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to 67% fewer tokens than JSON.
 
 <div align="center">
 

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 
 const SITE_TITLE = "OpenUI - The Open Standard for Generative UI";
 const SITE_DESCRIPTION =
-  "Renderer-agnostic Generative UI with a streaming-first language, official React support, community integrations, and up to 67% fewer tokens than JSON.";
+  "Full-stack, renderer-agnostic Generative UI with a streaming-first language, official React support, community integrations, and up to 67% fewer tokens than JSON.";
 const SITE_IMAGE = "/meta-image.png";
 
 export const metadata: Metadata = {

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -17,7 +17,7 @@ const geistMono = Geist_Mono({
 
 const SITE_TITLE = "OpenUI - The Open Standard for Generative UI";
 const SITE_DESCRIPTION =
-  "OpenUI is a full-stack Generative UI framework with a compact streaming-first language, a React runtime with built-in components, and ready-to-use chat interfaces - using up to 67% fewer tokens than JSON.";
+  "Renderer-agnostic Generative UI with a streaming-first language, official React support, community integrations, and up to 67% fewer tokens than JSON.";
 const SITE_IMAGE = "/meta-image.png";
 
 export const metadata: Metadata = {

--- a/docs/content/docs/openui-lang/index.mdx
+++ b/docs/content/docs/openui-lang/index.mdx
@@ -5,7 +5,7 @@ title: Introduction
 import { StreamingComparison } from "@/app/docs/openui-lang/streaming-comparison";
 import { TryItOut } from "./components/try-it-out";
 
-OpenUI is a full-stack Generative UI framework (a compact streaming-first language, a React runtime with built-in component libraries, and ready-to-use chat interfaces) that is up to **[67% more token-efficient](/docs/openui-lang/benchmarks)** than JSON. Generate anything from rich chat responses to [fully interactive dashboards](/docs/openui-lang/how-it-works).
+OpenUI is a renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to **[67% fewer tokens](/docs/openui-lang/benchmarks)** than JSON. Generate anything from rich chat responses to [fully interactive dashboards](/docs/openui-lang/how-it-works).
 
 ## What is Generative UI?
 

--- a/docs/content/docs/openui-lang/index.mdx
+++ b/docs/content/docs/openui-lang/index.mdx
@@ -5,7 +5,7 @@ title: Introduction
 import { StreamingComparison } from "@/app/docs/openui-lang/streaming-comparison";
 import { TryItOut } from "./components/try-it-out";
 
-OpenUI is a renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to **[67% fewer tokens](/docs/openui-lang/benchmarks)** than JSON. Generate anything from rich chat responses to [fully interactive dashboards](/docs/openui-lang/how-it-works).
+OpenUI is a full-stack, renderer-agnostic Generative UI framework built around a compact, streaming-first language. It offers official React support with built-in component libraries and ready-to-use chat interfaces, plus community-supported integrations for other frameworks. OpenUI Lang uses up to **[67% fewer tokens](/docs/openui-lang/benchmarks)** than JSON. Generate anything from rich chat responses to [fully interactive dashboards](/docs/openui-lang/how-it-works).
 
 ## What is Generative UI?
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUI",
   "version": "1.0.1",
-  "description": "A renderer-agnostic Generative UI framework with a streaming-first language, official React support, and community integrations for other frameworks",
+  "description": "A full-stack, renderer-agnostic Generative UI framework with a streaming-first language, official React support, and community integrations for other frameworks",
   "main": "index.js",
   "scripts": {
     "test": "pnpm -r run test"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenUI",
   "version": "1.0.1",
-  "description": "The open standard for generative UI — a streaming-first language, React runtime, and component libraries for building AI-powered chat and copilot interfaces",
+  "description": "A renderer-agnostic Generative UI framework with a streaming-first language, official React support, and community integrations for other frameworks",
   "main": "index.js",
   "scripts": {
     "test": "pnpm -r run test"


### PR DESCRIPTION
## Summary

- describe OpenUI as a renderer-agnostic Generative UI framework
- clarify that React support is official while integrations for other frameworks are community-supported
- align the README, docs introduction, site SEO/social description, and package metadata
- attribute the “up to 67% fewer tokens” benchmark specifically to OpenUI Lang

## Why

The previous copy framed a React runtime as part of OpenUI's core definition, which implied that the framework itself was React-specific. OpenUI's language and core are renderer-agnostic, with React as the officially supported renderer and other framework integrations maintained by the community.

## Impact

Readers and integrators now get an accurate description of OpenUI's architecture and framework support wherever the primary product description appears.

## Validation

- `pnpm exec prettier --check README.md docs/content/docs/openui-lang/index.mdx docs/app/layout.tsx package.json`
- `git diff --check`
- parsed `package.json` with Node
