### PR TITLE
chore(release): react-ui 0.13.0

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## react-ui 0.13.0

This release delivers the AgentInterface refresh from #787 to npm. This PR is the version bump only (`packages/react-ui` 0.12.1 → 0.13.0); there are no code changes here.

### What's new in 0.13.0

- **Welcome screen, reworked** — new glow treatment via the `WelcomeGlow` component and the optional `glowAnimation` prop (also available as `AgentInterface.WelcomeGlow`), staggered entrance, and full `prefers-reduced-motion` support.
- **Thread list & sidebar refinements** — a flat "Threads" list, theme-aware sidebar shadows, and better handling of long thread and agent names.
- **Artifact browser polish** — refreshed loading states, clearer empty-search text, and updated spacing and icon sizing.
- **Theme updates** — the default brand swatch is now `blue`, user message bubbles use `highlight-strong`, and generated theme variables have been refreshed for both color schemes.

### Breaking change

- **`MessageLoading` has been removed** from the public API; built-in surfaces now use an internal loading indicator. If you imported `MessageLoading`, render your own instead — `@openuidev/react-headless` provides the state you need:

  ```tsx
  const isRunning = useThread((s) => s.isRunning);
  return isRunning ? <MyLoader /> : null;
  ```

Because 0.x minors carry breaking changes, this ships as **0.13.0** rather than a patch.

### Not exported (yet)

You may notice `DotMatrixLoader` and `ConversationStarter` in the source; they are intentionally internal for now. `ConversationStarter` is planned to surface later as `AgentInterface.ConversationStarter`. Custom loaders and starter chips are fully supported today through `@openuidev/react-headless` hooks.

### Publishing

After merge, the package is published with the standard prepublish gates (`check:css`, `publint`, `attw`). The open PRs #721 and #737 may ride along in this release if reviewed in time, in which case this PR rebases over them first.
