### PR TITLE
fix(react-ui): sync generated openui-defaults.scss with generator output

### DIFF
--- a/packages/react-ui/src/openui-defaults.scss
+++ b/packages/react-ui/src/openui-defaults.scss
@@ -244,6 +244,7 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
+
     // Surface / Background Colors
 
     --openui-background: oklch(0.145 0 0 / 1);
@@ -477,12 +478,11 @@
     // Shadows
 
     --openui-shadow-0: none;
-    --openui-shadow-s: 0 1px 3px -2px oklch(0 0 0 / 0.06), 0 2px 5px -2px oklch(0 0 0 / 0.1);
+    --openui-shadow-s: 0 1px 3px -2px oklch(0 0 0 / 0.06), 0 2px 5px -2px oklch(0 0 0 / 0.10);
     --openui-shadow-m: 0 4px 6px -2px oklch(0 0 0 / 0.08), 0 2px 2px -2px oklch(0 0 0 / 0.12);
-    --openui-shadow-l: 0 4px 4px -2px oklch(0 0 0 / 0.12), 0 4px 8px -2px oklch(0 0 0 / 0.1);
-    --openui-shadow-xl: 0 8px 16px -4px oklch(0 0 0 / 0.16), 0 16px 32px -6px oklch(0 0 0 / 0.2);
-    --openui-shadow-2xl: 0 12px 24px -6px oklch(0 0 0 / 0.2), 0 24px 48px -8px oklch(0 0 0 / 0.24);
-    --openui-shadow-3xl:
-      0 16px 32px -8px oklch(0 0 0 / 0.24), 0 32px 64px -12px oklch(0 0 0 / 0.28);
+    --openui-shadow-l: 0 4px 4px -2px oklch(0 0 0 / 0.12), 0 4px 8px -2px oklch(0 0 0 / 0.10);
+    --openui-shadow-xl: 0 8px 16px -4px oklch(0 0 0 / 0.16), 0 16px 32px -6px oklch(0 0 0 / 0.20);
+    --openui-shadow-2xl: 0 12px 24px -6px oklch(0 0 0 / 0.20), 0 24px 48px -8px oklch(0 0 0 / 0.24);
+    --openui-shadow-3xl: 0 16px 32px -8px oklch(0 0 0 / 0.24), 0 32px 64px -12px oklch(0 0 0 / 0.28);
   }
 }


### PR DESCRIPTION
## What

Commits `packages/react-ui/src/openui-defaults.scss` exactly as `generate:css-utils` currently produces it. The changes are cosmetic only — alpha formatting (`0.1` → `0.10`), line wrapping, and one blank line; every CSS value is identical.

## Why

react-ui's `prepare` script runs `build`, whose first step regenerates this file on every `pnpm install`. The committed copy had drifted from the generator's output (the generator was updated in #787 without re-committing the file), so any fresh checkout — including the **Publish NPM packages** workflow — ends up with an unclean working tree, and `pnpm publish` fails its git check:

```
ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.
```

That is what blocked the two react-ui 0.13.0 publish attempts today (runs 29833608212 and 29833815945). With this synced, install is idempotent again: the tree stays clean, `prettier --check` passes on the regenerated content (verified — it also passed in the failed CI runs), and publish can proceed.

## Verification

Reproduced the CI environment (pnpm 9.15.4, `install --frozen-lockfile`) on a pristine clone: before this change the tree dirties on install; with this file, regeneration is a no-op.