### PR TITLE
Fix AI docs links

### DIFF
--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -21,7 +21,7 @@ export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
       <div className="flex flex-row gap-2 items-center border-b pb-6">
         <LLMCopyButton markdownUrl={`${page.url}.mdx`} />
         <ViewOptions
-          markdownUrl={`${page.url}.mdx`}
+          markdownUrl={page.url}
           githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/docs/content/docs/${page.path}`}
         />
       </div>


### PR DESCRIPTION
## What changed

- Remove the `.mdx` suffix from the docs URL passed to the external “Open in …” actions.
- Keep the raw `.mdx` endpoint for the “Copy Markdown” action.

## Why

The external AI actions were given the raw Markdown URL, which returns a 404 in that flow. They should receive the canonical rendered docs page URL instead.

## Impact

“Open in ChatGPT,” “Open in Claude,” “Open in Scira AI,” and “Open in Cursor” now reference a valid docs page while “Copy Markdown” continues to fetch raw Markdown.

## Validation

- Targeted ESLint check
- Targeted Prettier check
- `git diff --check`
