### PR TITLE
fix(react-ui): collapsed-sidebar open button could become unreachable (reveal keyed to animation state)

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/sidebar.scss
+++ b/packages/react-ui/src/components/AgentInterface/sidebar.scss
@@ -207,13 +207,6 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
   }
 }
 
-// On hover (collapsed), swap the logo out for the toggle button. Gated on the
-// settled `data-sidebar-visual-state="collapsed"` state so the swap only runs
-// once the collapse animation has finished — keying it on the `--collapsed`
-// class instead would let the button flash in mid-collapse, while the still-wide
-// sidebar is momentarily under the cursor. (No-op when there is no logo: the
-// button is already shown at rest via the :has() rule above — which is what
-// fixes the reported TH-2392 no-logo case.)
 .openui-agent-sidebar-container[data-sidebar-visual-state="collapsed"]:hover {
   .openui-agent-sidebar-header__logo {
     opacity: 0;

--- a/packages/react-ui/src/components/AgentInterface/sidebar.scss
+++ b/packages/react-ui/src/components/AgentInterface/sidebar.scss
@@ -160,7 +160,7 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
     // Hide the toggle button at rest ONLY when a logo fills the slot (detected
     // with :has) — the logo is the resting face and the button appears on hover.
     // With no logo the slot is empty, so the button stays visible at rest
-    // instead, keeping the open control discoverable (TH-2392).
+    // instead, keeping the open control discoverable.
     &:has(.openui-agent-sidebar-header__logo) .openui-agent-sidebar-header__toggle-button {
       opacity: 0;
       pointer-events: none;
@@ -207,7 +207,14 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
   }
 }
 
-.openui-agent-sidebar-container[data-sidebar-visual-state="collapsed"]:hover {
+// Collapsed rail: logo at rest, open button on hover or keyboard focus. Key off
+// the binary --collapsed class (the same isCollapsedLayout state that hides the
+// button above), never data-sidebar-visual-state — its transitional values open
+// a window where the button is hidden but cannot be revealed. Keyboard focus is
+// matched via :focus-visible so the residual focus a mouse click leaves on the
+// toggle doesn't pin the button over the logo at rest.
+.openui-agent-sidebar-container--collapsed:hover,
+.openui-agent-sidebar-container--collapsed:has(:focus-visible) {
   .openui-agent-sidebar-header__logo {
     opacity: 0;
     pointer-events: none;
@@ -216,6 +223,23 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
   .openui-agent-sidebar-header__toggle-button {
     opacity: 1;
     pointer-events: auto;
+  }
+}
+
+// No hover on touch devices: show the open button at rest instead of the logo.
+// The header class keeps specificity equal to the :has() hide rule above so
+// source order lets this win.
+@media (hover: none) {
+  .openui-agent-sidebar-container--collapsed {
+    .openui-agent-sidebar-header__logo {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .openui-agent-sidebar-header--collapsed .openui-agent-sidebar-header__toggle-button {
+      opacity: 1;
+      pointer-events: auto;
+    }
   }
 }
 

--- a/packages/react-ui/src/components/AgentInterface/sidebar.scss
+++ b/packages/react-ui/src/components/AgentInterface/sidebar.scss
@@ -156,10 +156,14 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
       top: 0;
       left: 0;
     }
-
-    .openui-agent-sidebar-header__toggle-button {
+    .openui-agent-sidebar-header__logo {
       opacity: 0;
       pointer-events: none;
+    }
+
+    .openui-agent-sidebar-header__toggle-button {
+      opacity: 1;
+      pointer-events: auto;
     }
   }
 }
@@ -200,18 +204,6 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
 
   .openui-agent-container--mobile & {
     display: none;
-  }
-}
-
-.openui-agent-sidebar-container[data-sidebar-visual-state="collapsed"]:hover {
-  .openui-agent-sidebar-header__logo {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .openui-agent-sidebar-header__toggle-button {
-    opacity: 1;
-    pointer-events: auto;
   }
 }
 

--- a/packages/react-ui/src/components/AgentInterface/sidebar.scss
+++ b/packages/react-ui/src/components/AgentInterface/sidebar.scss
@@ -156,14 +156,14 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
       top: 0;
       left: 0;
     }
-    .openui-agent-sidebar-header__logo {
+
+    // Hide the toggle button at rest ONLY when a logo fills the slot (detected
+    // with :has) — the logo is the resting face and the button appears on hover.
+    // With no logo the slot is empty, so the button stays visible at rest
+    // instead, keeping the open control discoverable (TH-2392).
+    &:has(.openui-agent-sidebar-header__logo) .openui-agent-sidebar-header__toggle-button {
       opacity: 0;
       pointer-events: none;
-    }
-
-    .openui-agent-sidebar-header__toggle-button {
-      opacity: 1;
-      pointer-events: auto;
     }
   }
 }
@@ -204,6 +204,25 @@ $sidebar-shadow: inset -10px 0 18px -18px cssUtils.$sunk-deep;
 
   .openui-agent-container--mobile & {
     display: none;
+  }
+}
+
+// On hover (collapsed), swap the logo out for the toggle button. Gated on the
+// settled `data-sidebar-visual-state="collapsed"` state so the swap only runs
+// once the collapse animation has finished — keying it on the `--collapsed`
+// class instead would let the button flash in mid-collapse, while the still-wide
+// sidebar is momentarily under the cursor. (No-op when there is no logo: the
+// button is already shown at rest via the :has() rule above — which is what
+// fixes the reported TH-2392 no-logo case.)
+.openui-agent-sidebar-container[data-sidebar-visual-state="collapsed"]:hover {
+  .openui-agent-sidebar-header__logo {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .openui-agent-sidebar-header__toggle-button {
+    opacity: 1;
+    pointer-events: auto;
   }
 }
 


### PR DESCRIPTION
Fixes the "open sidebar icon is randomly not visible" bug and keeps the collapsed rail's logo/button hover swap.

## Problem

The collapsed rail hides the open button via the header's `--collapsed` class (binary, driven by `isCollapsedLayout`), but the hover rule that reveals it keyed off `[data-sidebar-visual-state="collapsed"]` — a four-state animation attribute (`expanded → collapsing → collapsed → expanding`) advanced by chained timeouts. During the collapse animation the attribute still reads `"collapsing"`, so hovering revealed nothing (~170ms measured on every collapse, with the button visibly fading out under the cursor); and if the timeout chain is interrupted (rapid toggling, layout switches), the attribute can strand there — a collapsed rail whose open button can never be revealed. That's the randomness.

## Change

All in `sidebar.scss`; behavior:

* **The resting face is contextual** (`:has`): with a logo configured, the logo is the resting face and the button appears on hover; with no logo the slot is empty, so the button stays visible at rest instead — the open control is always discoverable.
* **The reveal rule keys off `.openui-agent-sidebar-container--collapsed`** — the same binary `isCollapsedLayout` state as the hiding rule, set in the same render — so hidden-but-unrevealable is impossible by construction.
* **Keyboard focus reveals the swap** via `:has(:focus-visible)`, so tabbing never lands on an invisible button. (`:focus-visible` rather than `:focus-within`, so the residual focus a mouse click leaves on the toggle doesn't pin the button over the logo at rest.)
* **`@media (hover: none)` shows the open button at rest on touch devices**, which have no hover to trigger the swap.

## Test Plan

- [x] Playwright probe against the openui-cloud example, with and without a `logoUrl`:
  - rest shows the logo (or the button when no logo is set); hover swaps, unhover swaps back
  - hovering **mid-collapse-animation** (the old bug window, attribute = `"collapsing"`) keeps the button fully visible — zero dead-window samples
  - after a mouse-click collapse the rail rests on the logo (click focus doesn't pin the button)
  - Tab reveals the button and Enter expands the sidebar
  - emulated `hover: none` shows the button at rest
- [x] SCSS compiles clean; CSS artifact check passes