### PR TITLE
style(react-ui): adjust max-width and padding for conversation starter component

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
+++ b/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
@@ -3,8 +3,6 @@
 // Container styles
 .openui-agent-conversation-starter {
   width: 100%;
-  // Match the composer box so the pills stay aligned with the input at every
-  // breakpoint (TH-2374).
   max-width: calc(880px + cssUtils.$space-m-l * 2);
   margin: 0 auto;
   padding: 0 cssUtils.$space-m-l cssUtils.$space-m;
@@ -18,7 +16,6 @@
     transform 0.2s ease,
     max-height 0.2s ease,
     padding-bottom 0.2s ease;
-
   // Short variant - horizontal pill buttons
   &--short {
     display: block;

--- a/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
+++ b/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
@@ -3,7 +3,10 @@
 // Container styles
 .openui-agent-conversation-starter {
   width: 100%;
-  max-width: calc(880px + cssUtils.$space-m-l * 2);
+  // Starters sit above the composer input, so track the composer's 768px
+  // column (see components/composer.scss), not the 880px thread column —
+  // otherwise the row starts left of the input once both hit max-width.
+  max-width: calc(768px + cssUtils.$space-m-l * 2);
   margin: 0 auto;
   padding: 0 cssUtils.$space-m-l cssUtils.$space-m;
   box-sizing: border-box;

--- a/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
+++ b/packages/react-ui/src/components/AgentInterface/conversationStarter.scss
@@ -3,9 +3,11 @@
 // Container styles
 .openui-agent-conversation-starter {
   width: 100%;
-  max-width: 880px;
+  // Match the composer box so the pills stay aligned with the input at every
+  // breakpoint (TH-2374).
+  max-width: calc(880px + cssUtils.$space-m-l * 2);
   margin: 0 auto;
-  padding: 0 0 cssUtils.$space-m;
+  padding: 0 cssUtils.$space-m-l cssUtils.$space-m;
   box-sizing: border-box;
   max-height: 480px;
   overflow: hidden;


### PR DESCRIPTION
Fixes the suggestion-prompt (conversation starter) row's padding and alignment across breakpoints.

## Problem

Two related geometry issues, measured in the openui-cloud example:

1. **Narrow widths (content column under 880px)**: the starter container was `max-width: 880px` with no horizontal padding, so the chips sat flush against the content edge — 0px gutter — while the composer input below kept its inset.
2. **Wide widths**: the starter row was based on the 880px *thread* column while the composer input uses the narrower 768px column, so once both hit max-width they centered independently and the chip row started ~56px left of the input's edge.

## Change

`conversationStarter.scss` only:

* Add the same `$space-m-l` horizontal gutter the thread and composer already use, with `max-width` compensated by 2× the gutter so the content width is unchanged when uncapped.
* Base the container on the **composer's 768px column** (see `components/composer.scss`) instead of the thread's 880px — the chips belong to the input, so the row now tracks the input's edges at every desktop width.

## Test Plan

- [x] Playwright sweep across 20 viewport widths (360–2560) against the openui-cloud example:
  - chip gutter never below 16px on desktop (was 0px flush at 820–1050)
  - chip row's left edge aligns with the composer input's edge (delta 0) at **every** desktop width — was −16px when squeezed and −56px when wide
  - mobile layout unchanged (its own 18px padding override still wins)
  - no horizontal overflow, no chip clipping, clean behavior through the mobile↔desktop flip and the max-width transition
