### PR TITLE
Fix route canonical metadata

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import styles from "./page.module.css";
 import { CloudBanner } from "./sections/CloudBanner/CloudBanner";
 import { CloudSection } from "./sections/CloudSection/CloudSection";
@@ -9,6 +10,12 @@ import { ShiroPeek } from "./sections/ShiroPeek/ShiroPeek";
 import { StepsSection } from "./sections/StepsSection/StepsSection";
 import { TweetWallSection } from "./sections/TweetWallSection/TweetWallSection";
 import { UseCasesSection } from "./sections/UseCasesSection/UseCasesSection";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/",
+  },
+};
 
 export default function HomePage() {
   return (

--- a/docs/app/blog/[slug]/page.tsx
+++ b/docs/app/blog/[slug]/page.tsx
@@ -71,6 +71,9 @@ export async function generateMetadata(props: {
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
   };
 }
 

--- a/docs/app/blog/layout.tsx
+++ b/docs/app/blog/layout.tsx
@@ -1,6 +1,13 @@
 import "../(home)/globals.css";
 import { WebsiteThemeProvider } from "@/components/website-theme-provider";
+import type { Metadata } from "next";
 import { BlogNavbar } from "./components/BlogNavbar";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/blog",
+  },
+};
 
 export default function BlogLayout({ children }: { children: React.ReactNode }) {
   return (

--- a/docs/app/docs/[[...slug]]/page.tsx
+++ b/docs/app/docs/[[...slug]]/page.tsx
@@ -49,6 +49,9 @@ export async function generateMetadata(props: PageProps<"/docs/[[...slug]]">): P
   return {
     title: page.data.title,
     description: page.data.description,
+    alternates: {
+      canonical: page.url,
+    },
     openGraph: {
       images: getPageImage(page).url,
     },

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -43,9 +43,6 @@ export const metadata: Metadata = {
   creator: "OpenUI",
   publisher: "OpenUI",
   category: "technology",
-  alternates: {
-    canonical: "/",
-  },
   icons: {
     icon: "/shiro-logo.svg",
     shortcut: "/shiro-logo.svg",

--- a/docs/app/playground/layout.tsx
+++ b/docs/app/playground/layout.tsx
@@ -1,6 +1,13 @@
 import { WebsiteThemeProvider } from "@/components/website-theme-provider";
+import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./layout.css";
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: "/playground",
+  },
+};
 
 export default function PlaygroundLayout({ children }: { children: ReactNode }) {
   return <WebsiteThemeProvider>{children}</WebsiteThemeProvider>;


### PR DESCRIPTION
## Summary

- remove the homepage canonical from the shared root layout
- add route-specific canonicals for the homepage, playground, blog index and posts, and generated docs pages
- preserve existing canonical metadata for chat, projects, and OpenClaw OS

## Root cause

PR #398 added `canonical: "/"` while expanding homepage metadata, but placed it in `docs/app/layout.tsx`. Because that layout wraps the entire App Router site, docs and blog routes inherited the homepage canonical unless they explicitly overrode it.

Fixes #816.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- `pnpm --filter @openuidev/docs build`
- inspected the production build output for every sitemap route: 63 checked, 0 canonical mismatches
- `git diff --cached --check`

## Note

`pnpm --filter @openuidev/docs format:check` remains red on 52 pre-existing upstream files. The patch introduces no whitespace errors and does not reformat unrelated files.
