### PR TITLE
fix(react-ui): don't auto-select the last tab on Tabs initial mount

### DIFF
--- a/packages/react-ui/src/genui-lib/Tabs/index.tsx
+++ b/packages/react-ui/src/genui-lib/Tabs/index.tsx
@@ -42,6 +42,12 @@ export const Tabs = defineComponent({
     React.useEffect(() => {
       if (userHasInteracted.current) return;
 
+      // On the first pass every tab satisfies `size > 0`, which would make
+      // `candidate` end up as the LAST tab and override the first-tab default
+      // above. Only record the baseline sizes; growth relative to this
+      // baseline (or a tab appearing later) still auto-advances.
+      const isBaselinePass = Object.keys(prevContentSizes.current).length === 0;
+
       let candidate: string | null = null;
       const nextSizes: Record<string, number> = {};
 
@@ -55,6 +61,8 @@ export const Tabs = defineComponent({
       }
 
       prevContentSizes.current = nextSizes;
+
+      if (isBaselinePass) return;
 
       if (candidate && candidate !== activeTab) {
         setActiveTab(candidate);


### PR DESCRIPTION
Fixes #819

## Problem

`<Tabs>` selects the **last** tab on initial mount instead of the first, even for a fully static (non-streaming) response.

Standalone repro against the published packages: https://github.com/Shinyaigeek/openui-tabs-repro

The dependency-less auto-advance effect (streaming follow-along) runs its first pass with `prevContentSizes.current` empty, so **every** tab satisfies `size > prevSize` and `candidate` ends the loop at the last item. It runs in the same commit as — and after — the effect that defaults `activeTab` to the first tab, so the last tab wins.

## Fix

Treat the first pass as a baseline-recording pass: record `nextSizes` but skip candidate selection when `prevContentSizes.current` is empty.

Streaming follow-along is unaffected:
- content growth relative to the recorded baseline still advances the active tab;
- a tab that appears after the first pass has no baseline entry, so its content counts as growth and still advances.

## Verification

Rendered via a vite harness aliased to `react-ui` source, before/after:

| Scenario | Before | After |
| --- | --- | --- |
| Static 3-tab mount | last tab (Cherry) active | **first tab (Apple) active** |
| Streamed 3-tab response (12 chars / 150 ms) | follows growing tab, ends on Cherry | same — ends on Cherry |

Before: ![before](https://raw.githubusercontent.com/Shinyaigeek/openui-tabs-repro/main/screenshot.png)

After (top: static mount now Apple; bottom: streaming control still ends on Cherry): ![after](https://raw.githubusercontent.com/Shinyaigeek/openui-tabs-repro/main/after-fix.png)

`pnpm test` (react-ui): 13 passed. `lint:check`: 0 errors. `typecheck` failures in `UserMessageContent.tsx` / `index.ts` are pre-existing on `main` (verified by stashing this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
