### PR TITLE
Codex/add thesys link attribution

### DIFF
--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { addThesysLinkAttribution } from "@/lib/thesys-link-attribution";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import { useEffect } from "react";
@@ -10,6 +11,61 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
       api_host: "https://dgoeivjus9jfp.cloudfront.net",
       capture_pageview: "history_change",
     });
+
+    const decorateLink = (anchor: HTMLAnchorElement) => {
+      const href = anchor.getAttribute("href");
+      if (!href) return;
+
+      const attributedHref = addThesysLinkAttribution(
+        href,
+        window.location.href,
+        posthog.get_distinct_id(),
+      );
+
+      if (attributedHref !== href) anchor.setAttribute("href", attributedHref);
+    };
+
+    const decorateLinksWithin = (root: ParentNode) => {
+      if (root instanceof HTMLAnchorElement) decorateLink(root);
+      root.querySelectorAll<HTMLAnchorElement>("a[href]").forEach(decorateLink);
+    };
+
+    decorateLinksWithin(document);
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "attributes") {
+          if (mutation.target instanceof HTMLAnchorElement) decorateLink(mutation.target);
+          continue;
+        }
+
+        for (const node of mutation.addedNodes) {
+          if (node instanceof Element) decorateLinksWithin(node);
+        }
+      }
+    });
+
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["href"],
+      childList: true,
+      subtree: true,
+    });
+
+    const refreshLinkAtInteraction = (event: Event) => {
+      if (!(event.target instanceof Element)) return;
+      const anchor = event.target.closest<HTMLAnchorElement>("a[href]");
+      if (anchor) decorateLink(anchor);
+    };
+
+    document.addEventListener("pointerdown", refreshLinkAtInteraction, true);
+    document.addEventListener("click", refreshLinkAtInteraction, true);
+
+    return () => {
+      observer.disconnect();
+      document.removeEventListener("pointerdown", refreshLinkAtInteraction, true);
+      document.removeEventListener("click", refreshLinkAtInteraction, true);
+    };
   }, []);
   return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
 }

--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -20,6 +20,7 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
         href,
         window.location.href,
         posthog.get_distinct_id(),
+        posthog.get_session_id(),
       );
 
       if (attributedHref !== href) anchor.setAttribute("href", attributedHref);

--- a/docs/lib/thesys-link-attribution.ts
+++ b/docs/lib/thesys-link-attribution.ts
@@ -7,6 +7,7 @@ const UTM_PARAMS = {
 } as const;
 
 export const POSTHOG_DISTINCT_ID_PARAM = "posthog_distinct_id";
+export const POSTHOG_SESSION_ID_PARAM = "posthog_session_id";
 
 function isThesysHost(hostname: string) {
   return hostname === THESYS_HOST || hostname.endsWith(`.${THESYS_HOST}`);
@@ -16,6 +17,7 @@ export function addThesysLinkAttribution(
   href: string,
   baseUrl: string,
   posthogDistinctId: string | undefined,
+  posthogSessionId: string | undefined,
 ) {
   let url: URL;
 
@@ -33,6 +35,10 @@ export function addThesysLinkAttribution(
 
   if (posthogDistinctId) {
     url.searchParams.set(POSTHOG_DISTINCT_ID_PARAM, posthogDistinctId);
+  }
+
+  if (posthogSessionId) {
+    url.searchParams.set(POSTHOG_SESSION_ID_PARAM, posthogSessionId);
   }
 
   return url.toString();

--- a/docs/lib/thesys-link-attribution.ts
+++ b/docs/lib/thesys-link-attribution.ts
@@ -1,0 +1,39 @@
+const THESYS_HOST = "thesys.dev";
+
+const UTM_PARAMS = {
+  utm_source: "openui",
+  utm_medium: "referral",
+  utm_campaign: "openui_to_thesys",
+} as const;
+
+export const POSTHOG_DISTINCT_ID_PARAM = "posthog_distinct_id";
+
+function isThesysHost(hostname: string) {
+  return hostname === THESYS_HOST || hostname.endsWith(`.${THESYS_HOST}`);
+}
+
+export function addThesysLinkAttribution(
+  href: string,
+  baseUrl: string,
+  posthogDistinctId: string | undefined,
+) {
+  let url: URL;
+
+  try {
+    url = new URL(href, baseUrl);
+  } catch {
+    return href;
+  }
+
+  if (!isThesysHost(url.hostname)) return href;
+
+  for (const [key, value] of Object.entries(UTM_PARAMS)) {
+    if (!url.searchParams.has(key)) url.searchParams.set(key, value);
+  }
+
+  if (posthogDistinctId) {
+    url.searchParams.set(POSTHOG_DISTINCT_ID_PARAM, posthogDistinctId);
+  }
+
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

- add UTM attribution to all browser links targeting `thesys.dev` and its subdomains
- attach the current PostHog distinct and session IDs as `posthog_distinct_id` and `posthog_session_id`
- cover React, MDX-rendered, and dynamically inserted anchors while preserving existing query parameters, hashes, and explicit UTM values
- refresh both IDs immediately before link interaction so identified visitors and rotated sessions use the latest values

## User impact

Outbound Thesys URLs now include:

- `utm_source=openui`
- `utm_medium=referral`
- `utm_campaign=openui_to_thesys`
- `posthog_distinct_id=<current PostHog ID>`
- `posthog_session_id=<current PostHog session ID>`




## Validation

- `pnpm --filter @openuidev/docs types:check`
- `pnpm --dir docs exec eslint app/providers.tsx lib/thesys-link-attribution.ts`
- `pnpm --dir docs exec prettier --check app/providers.tsx lib/thesys-link-attribution.ts`
- focused URL-helper assertions for subdomains, query parameters, hashes, custom UTMs, missing IDs, stale ID replacement, and non-Thesys URLs

## Note

`pnpm --filter @openuidev/docs build` entered the Turbopack compile phase without reporting a code error, but remained silent for several minutes and was manually stopped.