### PR TITLE
Use GPT-5.4 and disable tools only in compare

### DIFF
--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -11,7 +11,7 @@ const openUiSystemPrompt = readFileSync(
 
 const markdownSystemPrompt = `You are a helpful assistant. Respond using clear, well-structured GitHub-Flavored Markdown.
 
-Use headings, lists, tables, links, block quotes, and fenced code blocks when they make the response easier to understand. Use the available tools when they are relevant, and incorporate their results into the answer.
+Use headings, lists, tables, links, block quotes, and fenced code blocks when they make the response easier to understand.
 
 Return only Markdown content. Do not emit OpenUI Lang, component syntax, JSON UI descriptions, or instructions for a renderer.`;
 
@@ -45,206 +45,6 @@ function parseRequestBody(body: unknown): ChatRequestBody | Response {
     messages,
     responseMode: responseMode as ResponseMode | undefined,
   };
-}
-
-// ── Tool implementations ──
-
-function getWeather({ location }: { location: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const knownTemps: Record<string, number> = {
-        tokyo: 22,
-        "san francisco": 18,
-        london: 14,
-        "new york": 25,
-        paris: 19,
-        sydney: 27,
-        mumbai: 33,
-        berlin: 16,
-      };
-      const conditions = ["Sunny", "Partly Cloudy", "Cloudy", "Light Rain", "Clear Skies"];
-      const temp = knownTemps[location.toLowerCase()] ?? Math.floor(Math.random() * 30 + 5);
-      const condition = conditions[Math.floor(Math.random() * conditions.length)];
-      resolve(
-        JSON.stringify({
-          location,
-          temperature_celsius: temp,
-          temperature_fahrenheit: Math.round(temp * 1.8 + 32),
-          condition,
-          humidity_percent: Math.floor(Math.random() * 40 + 40),
-          wind_speed_kmh: Math.floor(Math.random() * 25 + 5),
-          forecast: [
-            { day: "Tomorrow", high: temp + 2, low: temp - 4, condition: "Partly Cloudy" },
-            { day: "Day After", high: temp + 1, low: temp - 3, condition: "Sunny" },
-          ],
-        }),
-      );
-    }, 800);
-  });
-}
-
-function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const s = symbol.toUpperCase();
-      const knownPrices: Record<string, number> = {
-        AAPL: 189.84,
-        GOOGL: 141.8,
-        TSLA: 248.42,
-        MSFT: 378.91,
-        AMZN: 178.25,
-        NVDA: 875.28,
-        META: 485.58,
-      };
-      const price = knownPrices[s] ?? Math.floor(Math.random() * 500 + 20);
-      const change = parseFloat((Math.random() * 8 - 4).toFixed(2));
-      resolve(
-        JSON.stringify({
-          symbol: s,
-          price: parseFloat((price + change).toFixed(2)),
-          change,
-          change_percent: parseFloat(((change / price) * 100).toFixed(2)),
-          volume: `${(Math.random() * 50 + 10).toFixed(1)}M`,
-          day_high: parseFloat((price + Math.abs(change) + 1.5).toFixed(2)),
-          day_low: parseFloat((price - Math.abs(change) - 1.2).toFixed(2)),
-        }),
-      );
-    }, 600);
-  });
-}
-
-function searchWeb({ query }: { query: string }): Promise<string> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve(
-        JSON.stringify({
-          query,
-          results: [
-            {
-              title: `Top result for "${query}"`,
-              snippet: `Comprehensive overview of ${query} with the latest information.`,
-            },
-            {
-              title: `${query} - Latest News`,
-              snippet: `Recent developments and updates related to ${query}.`,
-            },
-            {
-              title: `Understanding ${query}`,
-              snippet: `An in-depth guide explaining everything about ${query}.`,
-            },
-          ],
-        }),
-      );
-    }, 1000);
-  });
-}
-
-// ── Tool definitions ──
-
-const tools: any[] = [
-  {
-    type: "function",
-    function: {
-      name: "get_weather",
-      description: "Get current weather for a location.",
-      parameters: {
-        type: "object",
-        properties: { location: { type: "string", description: "City name" } },
-        required: ["location"],
-      },
-      function: getWeather,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "get_stock_price",
-      description: "Get stock price for a ticker symbol.",
-      parameters: {
-        type: "object",
-        properties: { symbol: { type: "string", description: "Ticker symbol, e.g. AAPL" } },
-        required: ["symbol"],
-      },
-      function: getStockPrice,
-      parse: JSON.parse,
-    },
-  },
-  {
-    type: "function",
-    function: {
-      name: "search_web",
-      description: "Search the web for information.",
-      parameters: {
-        type: "object",
-        properties: { query: { type: "string", description: "Search query" } },
-        required: ["query"],
-      },
-      function: searchWeb,
-      parse: JSON.parse,
-    },
-  },
-];
-
-// ── SSE helpers ──
-
-function sseToolCallStart(
-  encoder: TextEncoder,
-  tc: { id: string; function: { name: string } },
-  index: number,
-) {
-  return encoder.encode(
-    `data: ${JSON.stringify({
-      id: `chatcmpl-tc-${tc.id}`,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: {
-            tool_calls: [
-              {
-                index,
-                id: tc.id,
-                type: "function",
-                function: { name: tc.function.name, arguments: "" },
-              },
-            ],
-          },
-          finish_reason: null,
-        },
-      ],
-    })}\n\n`,
-  );
-}
-
-function sseToolCallArgs(
-  encoder: TextEncoder,
-  tc: { id: string; function: { arguments: string } },
-  result: string,
-  index: number,
-) {
-  let enrichedArgs: string;
-  try {
-    enrichedArgs = JSON.stringify({
-      _request: JSON.parse(tc.function.arguments),
-      _response: JSON.parse(result),
-    });
-  } catch {
-    enrichedArgs = tc.function.arguments;
-  }
-  return encoder.encode(
-    `data: ${JSON.stringify({
-      id: `chatcmpl-tc-${tc.id}-args`,
-      object: "chat.completion.chunk",
-      choices: [
-        {
-          index: 0,
-          delta: { tool_calls: [{ index, function: { arguments: enrichedArgs } }] },
-          finish_reason: null,
-        },
-      ],
-    })}\n\n`,
-  );
 }
 
 // ── Route handler ──
@@ -324,16 +124,10 @@ export async function POST(req: NextRequest) {
         }
       };
 
-      const pendingCalls: Array<{ id: string; name: string; arguments: string }> = [];
-      let callIdx = 0;
-      let resultIdx = 0;
-
-      const runner = (client.chat.completions as any).runTools(
+      const runner = client.chat.completions.stream(
         {
           model: MODEL,
           messages: chatMessages,
-          tools,
-          stream: true,
         },
         { signal: req.signal },
       );
@@ -350,28 +144,6 @@ export async function POST(req: NextRequest) {
         activeRunner = undefined;
         close();
       };
-
-      runner.on("functionToolCall", (fc: any) => {
-        const id = `tc-${callIdx}`;
-        pendingCalls.push({ id, name: fc.name, arguments: fc.arguments });
-        enqueue(sseToolCallStart(encoder, { id, function: { name: fc.name } }, callIdx));
-        callIdx++;
-      });
-
-      runner.on("functionToolCallResult", (result: string) => {
-        const tc = pendingCalls[resultIdx];
-        if (tc) {
-          enqueue(
-            sseToolCallArgs(
-              encoder,
-              { id: tc.id, function: { arguments: tc.arguments } },
-              result,
-              resultIdx,
-            ),
-          );
-        }
-        resultIdx++;
-      });
 
       runner.on("chunk", (chunk: any) => {
         // Keep credit handling to non-2xx responses. Provider-specific mid-stream

--- a/docs/app/api/chat/route.ts
+++ b/docs/app/api/chat/route.ts
@@ -9,17 +9,20 @@ const openUiSystemPrompt = readFileSync(
   "utf-8",
 );
 
-const markdownSystemPrompt = `You are a helpful assistant. Respond using clear, well-structured GitHub-Flavored Markdown.
+function createMarkdownSystemPrompt(toolsAvailable: boolean): string {
+  return `You are a helpful assistant. Respond using clear, well-structured GitHub-Flavored Markdown.
 
-Use headings, lists, tables, links, block quotes, and fenced code blocks when they make the response easier to understand.
+Use headings, lists, tables, links, block quotes, and fenced code blocks when they make the response easier to understand.${toolsAvailable ? " Use the available tools when they are relevant, and incorporate their results into the answer." : ""}
 
 Return only Markdown content. Do not emit OpenUI Lang, component syntax, JSON UI descriptions, or instructions for a renderer.`;
+}
 
 type ResponseMode = "markdown" | "openui";
 
 interface ChatRequestBody {
   messages: unknown[];
   responseMode?: ResponseMode;
+  comparisonMode?: boolean;
 }
 
 function invalidRequest(message: string) {
@@ -31,7 +34,7 @@ function parseRequestBody(body: unknown): ChatRequestBody | Response {
     return invalidRequest("Request body must be a JSON object");
   }
 
-  const { messages, responseMode } = body as Record<string, unknown>;
+  const { messages, responseMode, comparisonMode } = body as Record<string, unknown>;
 
   if (!Array.isArray(messages)) {
     return invalidRequest("messages must be an array");
@@ -41,10 +44,215 @@ function parseRequestBody(body: unknown): ChatRequestBody | Response {
     return invalidRequest('responseMode must be either "markdown" or "openui"');
   }
 
+  if (comparisonMode !== undefined && typeof comparisonMode !== "boolean") {
+    return invalidRequest("comparisonMode must be a boolean");
+  }
+
   return {
     messages,
     responseMode: responseMode as ResponseMode | undefined,
+    comparisonMode: comparisonMode as boolean | undefined,
   };
+}
+
+// ── Tool implementations ──
+
+function getWeather({ location }: { location: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const knownTemps: Record<string, number> = {
+        tokyo: 22,
+        "san francisco": 18,
+        london: 14,
+        "new york": 25,
+        paris: 19,
+        sydney: 27,
+        mumbai: 33,
+        berlin: 16,
+      };
+      const conditions = ["Sunny", "Partly Cloudy", "Cloudy", "Light Rain", "Clear Skies"];
+      const temp = knownTemps[location.toLowerCase()] ?? Math.floor(Math.random() * 30 + 5);
+      const condition = conditions[Math.floor(Math.random() * conditions.length)];
+      resolve(
+        JSON.stringify({
+          location,
+          temperature_celsius: temp,
+          temperature_fahrenheit: Math.round(temp * 1.8 + 32),
+          condition,
+          humidity_percent: Math.floor(Math.random() * 40 + 40),
+          wind_speed_kmh: Math.floor(Math.random() * 25 + 5),
+          forecast: [
+            { day: "Tomorrow", high: temp + 2, low: temp - 4, condition: "Partly Cloudy" },
+            { day: "Day After", high: temp + 1, low: temp - 3, condition: "Sunny" },
+          ],
+        }),
+      );
+    }, 800);
+  });
+}
+
+function getStockPrice({ symbol }: { symbol: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      const s = symbol.toUpperCase();
+      const knownPrices: Record<string, number> = {
+        AAPL: 189.84,
+        GOOGL: 141.8,
+        TSLA: 248.42,
+        MSFT: 378.91,
+        AMZN: 178.25,
+        NVDA: 875.28,
+        META: 485.58,
+      };
+      const price = knownPrices[s] ?? Math.floor(Math.random() * 500 + 20);
+      const change = parseFloat((Math.random() * 8 - 4).toFixed(2));
+      resolve(
+        JSON.stringify({
+          symbol: s,
+          price: parseFloat((price + change).toFixed(2)),
+          change,
+          change_percent: parseFloat(((change / price) * 100).toFixed(2)),
+          volume: `${(Math.random() * 50 + 10).toFixed(1)}M`,
+          day_high: parseFloat((price + Math.abs(change) + 1.5).toFixed(2)),
+          day_low: parseFloat((price - Math.abs(change) - 1.2).toFixed(2)),
+        }),
+      );
+    }, 600);
+  });
+}
+
+function searchWeb({ query }: { query: string }): Promise<string> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(
+        JSON.stringify({
+          query,
+          results: [
+            {
+              title: `Top result for "${query}"`,
+              snippet: `Comprehensive overview of ${query} with the latest information.`,
+            },
+            {
+              title: `${query} - Latest News`,
+              snippet: `Recent developments and updates related to ${query}.`,
+            },
+            {
+              title: `Understanding ${query}`,
+              snippet: `An in-depth guide explaining everything about ${query}.`,
+            },
+          ],
+        }),
+      );
+    }, 1000);
+  });
+}
+
+// ── Tool definitions ──
+
+const tools: any[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description: "Get current weather for a location.",
+      parameters: {
+        type: "object",
+        properties: { location: { type: "string", description: "City name" } },
+        required: ["location"],
+      },
+      function: getWeather,
+      parse: JSON.parse,
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "get_stock_price",
+      description: "Get stock price for a ticker symbol.",
+      parameters: {
+        type: "object",
+        properties: { symbol: { type: "string", description: "Ticker symbol, e.g. AAPL" } },
+        required: ["symbol"],
+      },
+      function: getStockPrice,
+      parse: JSON.parse,
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "search_web",
+      description: "Search the web for information.",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string", description: "Search query" } },
+        required: ["query"],
+      },
+      function: searchWeb,
+      parse: JSON.parse,
+    },
+  },
+];
+
+// ── SSE helpers ──
+
+function sseToolCallStart(
+  encoder: TextEncoder,
+  tc: { id: string; function: { name: string } },
+  index: number,
+) {
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      id: `chatcmpl-tc-${tc.id}`,
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index,
+                id: tc.id,
+                type: "function",
+                function: { name: tc.function.name, arguments: "" },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+  );
+}
+
+function sseToolCallArgs(
+  encoder: TextEncoder,
+  tc: { id: string; function: { arguments: string } },
+  result: string,
+  index: number,
+) {
+  let enrichedArgs: string;
+  try {
+    enrichedArgs = JSON.stringify({
+      _request: JSON.parse(tc.function.arguments),
+      _response: JSON.parse(result),
+    });
+  } catch {
+    enrichedArgs = tc.function.arguments;
+  }
+  return encoder.encode(
+    `data: ${JSON.stringify({
+      id: `chatcmpl-tc-${tc.id}-args`,
+      object: "chat.completion.chunk",
+      choices: [
+        {
+          index: 0,
+          delta: { tool_calls: [{ index, function: { arguments: enrichedArgs } }] },
+          finish_reason: null,
+        },
+      ],
+    })}\n\n`,
+  );
 }
 
 // ── Route handler ──
@@ -62,7 +270,7 @@ export async function POST(req: NextRequest) {
     return parsedBody;
   }
 
-  const { messages, responseMode = "openui" } = parsedBody;
+  const { messages, responseMode = "openui", comparisonMode = false } = parsedBody;
 
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) {
@@ -95,7 +303,10 @@ export async function POST(req: NextRequest) {
   const chatMessages: ChatCompletionMessageParam[] = [
     {
       role: "system" as const,
-      content: responseMode === "markdown" ? markdownSystemPrompt : openUiSystemPrompt,
+      content:
+        responseMode === "markdown"
+          ? createMarkdownSystemPrompt(!comparisonMode)
+          : openUiSystemPrompt,
     },
     ...cleanMessages,
   ];
@@ -124,13 +335,29 @@ export async function POST(req: NextRequest) {
         }
       };
 
-      const runner = client.chat.completions.stream(
-        {
-          model: MODEL,
-          messages: chatMessages,
-        },
-        { signal: req.signal },
-      );
+      const pendingCalls: Array<{ id: string; name: string; arguments: string }> = [];
+      let callIdx = 0;
+      let resultIdx = 0;
+
+      // Markdown and OpenUI OSS comparisons intentionally run without tools.
+      // Other /api/chat consumers retain the existing tool-enabled behavior.
+      const runner: any = comparisonMode
+        ? client.chat.completions.stream(
+            {
+              model: MODEL,
+              messages: chatMessages,
+            },
+            { signal: req.signal },
+          )
+        : (client.chat.completions as any).runTools(
+            {
+              model: MODEL,
+              messages: chatMessages,
+              tools,
+              stream: true,
+            },
+            { signal: req.signal },
+          );
       activeRunner = runner;
 
       const handleAbort = () => {
@@ -144,6 +371,30 @@ export async function POST(req: NextRequest) {
         activeRunner = undefined;
         close();
       };
+
+      if (!comparisonMode) {
+        runner.on("functionToolCall", (fc: any) => {
+          const id = `tc-${callIdx}`;
+          pendingCalls.push({ id, name: fc.name, arguments: fc.arguments });
+          enqueue(sseToolCallStart(encoder, { id, function: { name: fc.name } }, callIdx));
+          callIdx++;
+        });
+
+        runner.on("functionToolCallResult", (result: string) => {
+          const tc = pendingCalls[resultIdx];
+          if (tc) {
+            enqueue(
+              sseToolCallArgs(
+                encoder,
+                { id: tc.id, function: { arguments: tc.arguments } },
+                result,
+                resultIdx,
+              ),
+            );
+          }
+          resultIdx++;
+        });
+      }
 
       runner.on("chunk", (chunk: any) => {
         // Keep credit handling to non-2xx responses. Provider-specific mid-stream

--- a/docs/app/compare/_components/agent-surfaces/use-comparison-chat-llm.ts
+++ b/docs/app/compare/_components/agent-surfaces/use-comparison-chat-llm.ts
@@ -23,6 +23,7 @@ export function useComparisonChatLLM(
           body: JSON.stringify({
             messages: openAIMessageFormat.toApi(messages),
             responseMode,
+            comparisonMode: true,
           }),
           signal,
         });

--- a/docs/lib/openui-cloud/models.ts
+++ b/docs/lib/openui-cloud/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MODEL = "anthropic/claude-sonnet-4.6";
+export const DEFAULT_MODEL = "openai/gpt-5.4";
 
 export interface ModelOption {
   id: string;


### PR DESCRIPTION
## Summary

- remove the mock web search, weather, and stock tools from the Markdown and OpenUI OSS comparison path
- use a plain streaming chat completion when serving those local comparison modes
- change the OpenUI Cloud default model from Claude Sonnet 4.6 to GPT-5.4

## Why

The compare experience describes built-in tools as a Cloud-only capability, but the Markdown and OpenUI OSS endpoint was still exposing three mock tools. Removing those tools keeps the comparison aligned with the product behavior it presents. Using GPT-5.4 as the Cloud default also lets the surfaces be evaluated with the requested model.

## Impact

Markdown and OpenUI OSS no longer invoke local function tools. OpenUI Cloud keeps its existing built-in tools and now starts with `openai/gpt-5.4`.

## Validation

- `pnpm exec eslint app/api/chat/route.ts lib/openui-cloud/models.ts`
- `pnpm exec prettier --check app/api/chat/route.ts lib/openui-cloud/models.ts`
- `pnpm types:check`
- live compare smoke test: Markdown and OpenUI Cloud both completed successfully
- direct Cloud stream metadata confirmed `openai/gpt-5.4`
