### PR TITLE
Prioritize Try Demo CTA for OpenUI Cloud

### DIFF
--- a/docs/app/(home)/sections/CloudSection/CloudSection.module.css
+++ b/docs/app/(home)/sections/CloudSection/CloudSection.module.css
@@ -37,8 +37,12 @@
   top: -0.06em;
 }
 
-/* Spacing for the "View Documentation" CTA (BevelButton) under the subtitle. */
-.headerCta {
+/* Primary and secondary CTAs under the subtitle. */
+.headerCtas {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
   margin-top: 2rem;
 }
 
@@ -196,6 +200,12 @@
     margin-bottom: 2.5rem;
   }
 
+  .headerCtas {
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+  }
+
   .grid {
     gap: 0;
   }
@@ -321,11 +331,8 @@
   border-color: rgba(0, 0, 0, 0.85);
 }
 
-/* The two CTAs flip tone so they read on the inverted light surface: the header
-   "View Documentation" goes black (like the dark BevelButton variant) and the
-   "Talk to our team" CTA goes white (like the light variant). Light mode keeps
-   the default look (white header CTA / black contact CTA on the black band). */
-[data-theme="dark"] .headerCta {
+/* The CTAs flip tone so they read on the inverted light surface. */
+[data-theme="dark"] .headerPrimaryCta {
   background: #0a0a0a;
   border-color: rgba(255, 255, 255, 0.2);
   box-shadow: var(--home-bevel-on-dark);
@@ -334,6 +341,7 @@
   --bevel-badge-fg: #0a0a0a;
 }
 
+[data-theme="dark"] .headerSecondaryCta,
 [data-theme="dark"] .contactCta {
   background: var(--home-surface-raised);
   border-color: rgba(0, 0, 0, 0.08);
@@ -402,4 +410,3 @@
     color: rgba(0, 0, 0, 0.55);
   }
 }
-

--- a/docs/app/(home)/sections/CloudSection/CloudSection.tsx
+++ b/docs/app/(home)/sections/CloudSection/CloudSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ArrowRight,
   ArrowUpRight,
   Browsers,
   Eye,
@@ -111,12 +112,21 @@ export function CloudSection() {
             }
             subtitle="Production-ready Generative UI"
           >
-            <BevelButton
-              className={styles.headerCta}
-              href="/docs/agent/getting-started/openui-cloud"
-              label="View Documentation"
-              badge={<ArrowUpRight size={16} weight="bold" />}
-            />
+            <div className={styles.headerCtas}>
+              <BevelButton
+                className={styles.headerPrimaryCta}
+                href="/compare"
+                label="Try Demo"
+                badge={<ArrowRight size={16} weight="bold" />}
+              />
+              <BevelButton
+                variant="dark"
+                className={styles.headerSecondaryCta}
+                href="/docs/agent/getting-started/openui-cloud"
+                label="View Documentation"
+                badge={<ArrowUpRight size={16} weight="bold" />}
+              />
+            </div>
           </SectionHeader>
         </div>
 


### PR DESCRIPTION
## What changed

- Added a primary **Try Demo** CTA to the OpenUI Cloud section that links to `/compare`.
- Restyled **View Documentation** as the secondary CTA.
- Added responsive CTA grouping so the actions sit side by side on desktop and stack at full width on mobile.
- Preserved the primary/secondary hierarchy when the Cloud section inverts in dark mode.

## Why

The Cloud section previously offered documentation as its only action. This makes the interactive comparison demo the clearest next step while keeping documentation immediately available.

## Impact

Homepage visitors can now enter the comparison demo directly from the OpenUI Cloud section, with a clear secondary path to the Cloud documentation.

## Validation

- `pnpm --filter @openuidev/docs exec eslint 'app/(home)/sections/CloudSection/CloudSection.tsx'`
- `pnpm --filter @openuidev/docs types:check`
- `git diff --check`
- Browser QA at 1280px and 390px
- Verified both CTA destinations and light/dark theme contrast
