### PR TITLE
feat(react-ui): ambient loading state for AgentInterface + export DotMatrixLoader

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/Thread.tsx
+++ b/packages/react-ui/src/components/AgentInterface/Thread.tsx
@@ -24,11 +24,12 @@ import { Callout } from "../Callout";
 import { DotMatrixLoader } from "../DotMatrixLoader";
 import { IconButton } from "../IconButton";
 import { MarkDownRenderer } from "../MarkDownRenderer";
-import { ResizableSeparator } from "./ResizableSeparator";
-import { UserMessageContent } from "./UserMessageContent";
 import { AgentInterfaceTooltip } from "./_shared/AgentInterfaceTooltip";
 import { GalleryHorizontalEndIcon } from "./_shared/GalleryHorizontalEndIcon";
+import { AmbientLoader } from "./components/AmbientLoader";
+import { ResizableSeparator } from "./ResizableSeparator";
 import { useDetailedViewResize } from "./useDetailedViewResize";
+import { UserMessageContent } from "./UserMessageContent";
 
 export const ThreadContainer = ({
   children,
@@ -75,6 +76,15 @@ export const ThreadContainer = ({
         visibility: isLoadingMessages ? "hidden" : undefined,
       }}
     >
+      {/* Full-screen loading state while a thread's messages load. The
+          container above hides via `visibility` (keeps layout + scroll state);
+          this overlay opts back in with `visibility: visible`. */}
+      {isLoadingMessages && (
+        <AmbientLoader
+          className="openui-agent-thread-container__loading"
+          label="Loading conversation…"
+        />
+      )}
       <div className="openui-agent-thread-wrapper" ref={containerRef}>
         {/* Chat panel - always visible */}
         <div

--- a/packages/react-ui/src/components/AgentInterface/agentInterface.scss
+++ b/packages/react-ui/src/components/AgentInterface/agentInterface.scss
@@ -10,6 +10,7 @@
 @use "./components/desktopWelcomeComposer.scss";
 @use "./components/welcomePrefillChips.scss";
 @use "./components/composer.scss";
+@use "./components/ambientLoader.scss";
 @use "./artifactBrowser.scss";
 @use "./workspaceSidebar.scss";
 @use "./_shared/shared.scss";

--- a/packages/react-ui/src/components/AgentInterface/components/AmbientLoader.tsx
+++ b/packages/react-ui/src/components/AgentInterface/components/AmbientLoader.tsx
@@ -1,0 +1,24 @@
+import clsx from "clsx";
+import { DotMatrixLoader } from "../../DotMatrixLoader";
+
+/**
+ * Ambient loading state for AgentInterface surfaces: two blurred glow blobs
+ * drift and breathe behind a centered dot-matrix loader with a contextual
+ * label. Fills whatever panel hosts it (min 280px tall), adapts to light/dark
+ * through the theme tokens, and freezes under `prefers-reduced-motion`.
+ *
+ * The label is required on purpose — every loading surface should say what is
+ * actually happening ("Loading artifacts…"), never a bare "Loading…".
+ */
+export const AmbientLoader = ({ label, className }: { label: string; className?: string }) => (
+  <div className={clsx("openui-agent-ambient-loader", className)} role="status" aria-live="polite">
+    <div className="openui-agent-ambient-loader__glow openui-agent-ambient-loader__glow--a" />
+    <div className="openui-agent-ambient-loader__glow openui-agent-ambient-loader__glow--b" />
+    {/* The matrix carries its own status role; hide it so the label below is
+        the single announcement for this surface. */}
+    <span aria-hidden="true">
+      <DotMatrixLoader />
+    </span>
+    <span className="openui-agent-ambient-loader__label">{label}</span>
+  </div>
+);

--- a/packages/react-ui/src/components/AgentInterface/components/ambientLoader.scss
+++ b/packages/react-ui/src/components/AgentInterface/components/ambientLoader.scss
@@ -1,0 +1,86 @@
+@use "../../../cssUtils" as cssUtils;
+
+// Ambient loading state (components/AmbientLoader.tsx): blurred glow blobs
+// breathing behind a centered dot-matrix loader. Fills the hosting panel.
+
+.openui-agent-ambient-loader {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: cssUtils.$space-m;
+  flex: 1 1 auto;
+  width: 100%;
+  height: 100%;
+  min-height: 280px;
+  overflow: hidden;
+  // Keep the negative-z glows inside this stacking context.
+  isolation: isolate;
+}
+
+.openui-agent-ambient-loader__glow {
+  position: absolute;
+  width: min(340px, 55%);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  filter: blur(64px);
+  pointer-events: none;
+  z-index: -1;
+  will-change: transform;
+
+  &--a {
+    top: 4%;
+    left: 6%;
+    // Neutral themes render this as soft luminance depth; branded themes
+    // (a colored accent token) tint the glow automatically. Opacity lives in
+    // the keyframes so the glow breathes as it drifts.
+    background: cssUtils.$interactive-accent-default;
+    opacity: 0.14;
+    animation: openui-agent-ambient-loader-drift-a 7s ease-in-out infinite alternate;
+  }
+
+  &--b {
+    right: 4%;
+    bottom: 4%;
+    background: cssUtils.$chat-user-response-bg;
+    opacity: 0.75;
+    animation: openui-agent-ambient-loader-drift-b 9.5s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes openui-agent-ambient-loader-drift-a {
+  from {
+    transform: translate(-14%, -10%) scale(0.92);
+    opacity: 0.09;
+  }
+
+  to {
+    transform: translate(22%, 26%) scale(1.35);
+    opacity: 0.2;
+  }
+}
+
+@keyframes openui-agent-ambient-loader-drift-b {
+  from {
+    transform: translate(12%, 10%) scale(1.28);
+    opacity: 0.85;
+  }
+
+  to {
+    transform: translate(-22%, -20%) scale(0.85);
+    opacity: 0.5;
+  }
+}
+
+.openui-agent-ambient-loader__label {
+  @include cssUtils.typography(label, small);
+
+  color: cssUtils.$text-neutral-secondary;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .openui-agent-ambient-loader__glow {
+    animation: none;
+  }
+}

--- a/packages/react-ui/src/components/AgentInterface/thread.scss
+++ b/packages/react-ui/src/components/AgentInterface/thread.scss
@@ -8,10 +8,22 @@
 // 2. Mobile: Full-width chat with absolute-positioned detailed-view overlay
 
 .openui-agent-thread-container {
+  position: relative;
   flex: 1;
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+// Full-screen loading overlay while a thread's messages load. The container
+// hides its content via inline `visibility: hidden`; visibility is
+// inheritable, so this child opts back in and covers the hidden layout.
+.openui-agent-thread-container__loading {
+  visibility: visible;
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: cssUtils.$foreground;
 }
 
 // Hide conversation starters and welcome-screen starters while the user is

--- a/packages/react-ui/src/index.ts
+++ b/packages/react-ui/src/index.ts
@@ -70,6 +70,7 @@ export * from "./components/CheckBoxGroup";
 export * from "./components/CheckBoxItem";
 export * from "./components/CodeBlock";
 export * from "./components/DatePicker";
+export * from "./components/DotMatrixLoader";
 export * from "./components/FollowUpBlock";
 export * from "./components/FollowUpItem";
 export * from "./components/FormControl";


### PR DESCRIPTION
Part of the "loaders are just Loading…" cleanup across AgentInterface surfaces (the artifact-renderer side ships separately in the SDK repo).

## What

**`AmbientLoader`** — an AgentInterface-internal loading state: two blurred glow blobs (`blur(64px)`) drift and breathe on opposing 7s/9.5s cycles behind the shared dot-matrix loader, with a **required** contextual label so no call site can render a bare "Loading…" again.

- Theme-token driven: neutral themes render the glow as soft luminance depth; branded themes (a colored accent token, e.g. openui-cloud's blue) tint it automatically.
- `prefers-reduced-motion` freezes the drift; the label is the single `role="status"` announcement (the inner matrix is aria-hidden).
- Internal on purpose — not exported, no compound static.

**Wired into the one full-screen gap**: opening a thread previously hid the entire panel (`visibility: hidden`) with *nothing* shown while messages loaded. That state now renders the loader with "Loading conversation…" — same `isLoadingMessages` flag as the old hiding, so behavior parity is exact. The overlay covers only the thread panel; the sidebar stays interactive.

**`DotMatrixLoader` joins the package index** — artifact renderers are composed by consumers, and their loading states should reuse this loader instead of carrying ports of it.

**Untouched**: every existing DotMatrixLoader site (artifact view page, artifact browser, message loading) — they already do the right thing.

## Test Plan

- [x] `pnpm build` + `pnpm test` (27/27) green; both new classes present in `dist/components/index.css`; `DotMatrixLoader` verified importable from the built index
- [x] Live in the openui-cloud example: thread-open state shows the loader with the brand-blue glow over light theme; sidebar unaffected; settled artifacts still render instantly
- [x] Slow-network sweep (CDP throttling) across browser pages / full-page artifact view confirmed the existing DotMatrixLoader sites behave unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XECS4NLhz6BNd1TUYbWjfu