### PR TITLE
Automate OpenUI skill submodule updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/auto-merge-skills.yml
+++ b/.github/workflows/auto-merge-skills.yml
@@ -1,0 +1,35 @@
+name: Auto-merge skills updates
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check whether this only updates the skills submodule
+        id: scope
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          changed_files="$(gh pr diff "$PR_URL" --name-only)"
+          if [ "$changed_files" = "skills" ]; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping auto-merge because this PR changes paths other than the skills submodule."
+          fi
+
+      - name: Enable squash auto-merge
+        if: steps.scope.outputs.eligible == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "skills"]
 	path = skills
 	url = https://github.com/thesysdev/skills.git
+	branch = main


### PR DESCRIPTION
## Summary

- configure Dependabot to check the `skills` Git submodule daily
- explicitly track the `main` branch of `thesysdev/skills`
- enable squash auto-merge only for Dependabot PRs whose sole changed path is the `skills` gitlink
- advance the submodule baseline to `1af136f`, the merged commit from `thesysdev/skills#2`

## Why

The canonical OpenUI skill is maintained in `thesysdev/skills`, while OpenUI keeps a submodule link for repository discoverability. This automation keeps that pointer current without requiring maintainers to prepare each update PR manually.

Auto-merge remains review-gated. The workflow does not approve PRs, so OpenUI's existing requirement for one approving review still applies. Dependabot PRs that change any path other than `skills` do not have auto-merge enabled.

## Tracking issue

- [TH-2427: Maintain parity between thesysdev/skills and openui/skills](https://linear.app/thesys/issue/TH-2427/maintain-parity-between-thesysdevskills-and-openuiskills)

## Alternative

- [#839](https://github.com/thesysdev/openui/pull/839) removes the submodule entirely instead of automating pointer updates. Merge one approach, not both.

## Validation

- parsed both YAML files successfully with Ruby's YAML parser
- checked both YAML files with Prettier
- ran `git diff --cached --check`
- verified the submodule commit exactly matches `thesysdev/skills` `main`
