### PR TITLE
Remove the OpenUI skills submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "skills"]
-	path = skills
-	url = https://github.com/thesysdev/skills.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Use the package name that matches the area you are changing.
 
 ## OpenUI Agent Skill
 
-The OpenUI agent skill is maintained in the [thesysdev/skills repository](https://github.com/thesysdev/skills/tree/main/skills/openui), which is its source of truth. The `skills` directory in this repository is a Git submodule linked to that repository.
+The OpenUI agent skill is maintained in the [thesysdev/skills repository](https://github.com/thesysdev/skills/tree/main/skills/openui), which is its source of truth. The skill is not vendored in this repository.
 
 To propose changes to the skill or its supporting references, open a pull request in `thesysdev/skills` rather than editing the linked files through this repository.
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,6 @@ openui/
 │   ├── svelte-lang/      # Svelte runtime bindings for OpenUI Lang
 │   ├── browser-bundle/   # Script-tag bundle for CDN / iframe / no-build embeds
 │   └── openui-cli/       # CLI for scaffolding & prompt generation
-├── skills/
-│   └── openui/           # Claude Code skill for AI-assisted development
 ├── examples/
 │   └── openui-chat/      # Full working example app (Next.js)
 ├── docs/                 # Documentation site (openui.com)


### PR DESCRIPTION
## Summary

- remove the `skills` Git submodule and its `.gitmodules` configuration
- remove the obsolete `skills/openui` entry from the repository structure in the README
- clarify that the canonical skill is not vendored in OpenUI and that changes belong in `thesysdev/skills`

## Why

The submodule exists only as a repository-level link, but Git requires it to pin a specific external commit. Removing it avoids submodule initialization and ongoing pointer-update maintenance while keeping `thesysdev/skills` as the single source of truth.

The existing `/skills.md` redirect, documented installation command, and OpenUI CLI behavior remain unchanged. The CLI continues to install the skill directly from `thesysdev/skills`.

## Related work

- Alternative to [#837](https://github.com/thesysdev/openui/pull/837), which automates updates to the submodule pointer. Merge this PR instead if OpenUI should not retain a submodule.
- [TH-2427: Maintain parity between thesysdev/skills and openui/skills](https://linear.app/thesys/issue/TH-2427/maintain-parity-between-thesysdevskills-and-openuiskills)

## Validation

- checked README and contribution-guide formatting with Prettier
- ran `git diff --cached --check`
- verified `.gitmodules` and the `skills` gitlink are absent from the resulting index
- verified the canonical skill links, install commands, CLI source, and docs redirect remain present
