### PR TITLE
Bump openui-cloud template + example default model to Gemini 3.6 Flash

### DIFF
--- a/examples/openui-cloud/README.md
+++ b/examples/openui-cloud/README.md
@@ -17,7 +17,7 @@ cp .env.example .env.local   # then fill THESYS_API_KEY
 | Var              | Required | Default                       | Purpose                                                          |
 | ---------------- | -------- | ----------------------------- | ---------------------------------------------------------------- |
 | `THESYS_API_KEY` | yes      | —                             | Org master key. **Server-side only**; never reaches the browser. |
-| `OPENUI_MODEL`   | no       | `anthropic/claude-sonnet-4.6` | Bare `provider/model` id for generation.                         |
+| `OPENUI_MODEL`   | no       | `google/gemini-3.6-flash-free` | Bare `provider/model` id for generation.                        |
 | `DEMO_USER_ID`   | no       | `demo-user`                   | End-user identity stamped into the frontend token.               |
 
 `.env.local` is gitignored. Restart `pnpm dev` after editing env.

--- a/examples/openui-cloud/src/app/api/chat/route.ts
+++ b/examples/openui-cloud/src/app/api/chat/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request) {
   try {
     stream = (await client.responses.create(
       {
-        model: envOr("OPENUI_MODEL", "anthropic/claude-sonnet-4.6"),
+        model: envOr("OPENUI_MODEL", "google/gemini-3.6-flash-free"),
         conversation: threadId, // store:true persists to the conversation
         input,
         stream: true,

--- a/packages/openui-cli/src/templates/openui-cloud/README.md
+++ b/packages/openui-cli/src/templates/openui-cloud/README.md
@@ -43,7 +43,7 @@ list](https://models.dev/providers/openrouter/).
 To set the initial server fallback, add `OPENUI_MODEL` to your `.env` file:
 
 ```bash
-OPENUI_MODEL=google/gemini-3.1-pro-free
+OPENUI_MODEL=google/gemini-3.6-flash-free
 ```
 
 ## SDK packages

--- a/packages/openui-cli/src/templates/openui-cloud/src/lib/models.ts
+++ b/packages/openui-cli/src/templates/openui-cloud/src/lib/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MODEL = "google/gemini-3.5-flash-free";
+export const DEFAULT_MODEL = "google/gemini-3.6-flash-free";
 
 export interface ModelOption {
   id: string;
@@ -15,6 +15,13 @@ export const MODEL_OPTIONS: ModelOption[] = [
     name: "Gemini 3.1 Flash Lite",
     badge: "Free",
   },
+  {
+    provider: "Google",
+    id: "google/gemini-3.6-flash-free",
+    name: "Gemini 3.6 Flash",
+    badge: "Free",
+  },
+  { provider: "Google", id: "google/gemini-3.6-flash", name: "Gemini 3.6 Flash" },
   {
     provider: "Google",
     id: "google/gemini-3.5-flash-free",


### PR DESCRIPTION
## What

Moves the OpenUI Cloud starter **template** and the **example** app to **Gemini 3.6 Flash** as the default model.

**Template** (`packages/openui-cli/src/templates/openui-cloud`)
- `DEFAULT_MODEL` → `google/gemini-3.6-flash-free`
- Adds Gemini 3.6 Flash (free + standard) to the curated model-switcher list
- Updates the `OPENUI_MODEL` example in the README

**Example** (`examples/openui-cloud`)
- `OPENUI_MODEL` fallback `anthropic/claude-sonnet-4.6` → `google/gemini-3.6-flash-free`
- Updates the README default column

## Why

Gemini 3.6 Flash is now available on OpenUI Cloud and is a faster, higher-quality default than the previous defaults for the starter experience.

## Verification

- `google/gemini-3.6-flash-free` and `google/gemini-3.6-flash` both resolve and respond on the hosted Responses API.
- Scaffolded the template fresh, left `OPENUI_MODEL` unset, and ran it: the UI defaults to **Gemini 3.6 Flash (Free)** and renders real components end-to-end (card + button, stat card) over the streaming path, with conversation persistence working.
- The previous defaults still resolve — no regression.

> Note: the `CLI Template Package Manager Parity` check is currently red on `main` as well (unrelated npm/pnpm patch drift of `openai` / `@radix-ui/react-tooltip`); not introduced by this PR.