### PR TITLE
Fix mobile docs section tabs

### DIFF
--- a/docs/app/global.css
+++ b/docs/app/global.css
@@ -147,8 +147,8 @@ body {
 
 @media (max-width: 767px) {
   #nd-docs-layout {
-    --fd-banner-height: 4rem !important;
-    min-height: calc(100dvh - 4rem) !important;
-    padding-top: 4rem !important;
+    --fd-banner-height: calc(4rem + 2.5rem) !important;
+    min-height: calc(100dvh - (4rem + 2.5rem)) !important;
+    padding-top: calc(4rem + 2.5rem) !important;
   }
 }

--- a/docs/components/docs-navbar.module.css
+++ b/docs/components/docs-navbar.module.css
@@ -215,6 +215,30 @@
   }
 
   .tabsBar {
-    display: none;
+    padding-top: 0;
+    border-top: 1px solid var(--openui-border-default);
+  }
+
+  .tabsInner {
+    min-height: 2.5rem;
+    padding-inline: 0;
+  }
+
+  .tabsNav {
+    box-sizing: border-box;
+    min-height: 2.5rem;
+    gap: 0.625rem;
+    padding-inline: 0.5rem;
+    border-bottom: 1px solid var(--openui-border-default);
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tabLink {
+    min-height: 2.5rem;
+    padding: 0.5rem 0;
+    font-size: 0.8125rem;
+    line-height: 1.5rem;
   }
 }

--- a/docs/components/docs-navbar.tsx
+++ b/docs/components/docs-navbar.tsx
@@ -38,7 +38,10 @@ function SearchBar() {
   const [isMac, setIsMac] = useState(false);
 
   useEffect(() => {
-    setIsMac(/mac/i.test(navigator.userAgent));
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setIsMac(/mac/i.test(navigator.userAgent));
+    });
 
     const handler = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {
@@ -47,7 +50,10 @@ function SearchBar() {
       }
     };
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("keydown", handler);
+    };
   }, [setOpenSearch]);
 
   return (
@@ -87,7 +93,15 @@ export function DocsNavbar({ showSidebarToggle = false }: { showSidebarToggle?: 
   // theme-derived variant behind a mount flag (matching SiteMarketingHeader) to
   // avoid a hydration mismatch on the brand text color.
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) setMounted(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   const logoVariant = mounted && resolvedTheme === "dark" ? "dark" : "light";
 
   const tabValue = useMemo(() => activeTabUrl(pathname), [pathname]);


### PR DESCRIPTION
## Summary
- show the docs section tabs on mobile instead of hiding them
- make the mobile tab strip the same height as the TOC/accordion row below it
- increase spacing between the four tab labels and keep the tab group horizontally scrollable when the viewport is too tight
- reserve the mobile header + tab height so the TOC/accordion row stays visible below

## Verification
- pnpm types:check (docs)
- pnpm exec eslint components/docs-navbar.tsx (docs)
- pnpm build (docs)
- browser viewport checks at 390, 360, and 320px: page has no horizontal overflow; tab strip is not scrollable at 390px and becomes horizontally scrollable at narrower widths; “What is Generative UI?” remains visible below

## Note
- Full `pnpm lint` in docs still fails on existing unrelated lint errors outside the touched files.