### PR TITLE
chore(release): react-ui 0.13.1

### DIFF
--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.14.0",
+  "version": "0.13.1",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## react-ui 0.13.1

This release ships everything merged since 0.13.0. This PR is the version bump only (`packages/react-ui` 0.13.0 → 0.13.1); there are no code changes here. Strictly additive — no breaking changes: everything that works on 0.13.0 works unchanged on 0.13.1.

### What's new

- **`AmbientLoader` + `DotMatrixLoader` are now public** (#835). `AmbientLoader` is the new ambient loading state — blurred glow blobs breathing behind the dot-matrix loader, with a required contextual label so no surface renders a bare "Loading…". Neutral themes render soft luminance depth; branded themes tint through the accent token; freezes under `prefers-reduced-motion`. Opening a thread no longer blanks the panel while messages load. `DotMatrixLoader` — internal in 0.13.0 — is now stabilized and exported for standalone use.
- **Prompt-templates welcome API** (#831, refined in #833) — native welcome-screen prompt template chips with a first-class API, replacing hand-rolled starter arrangements.
- **Auto-focus hook** (#800) — composer focus management out of the box.
- **Improved tool-tray behavior** (#822).

### Fixes

- Collapsed-sidebar open button could become unreachable due to a reveal race (#809).
- False "unknown key" warnings for valid `*ChartPalette` theme keys (#721).
- Conversation starter max-width and padding at narrow breakpoints (#810 + follow-up polish).

### Also in the repo

- New open-ended Generative UI example (#823).

### Publishing

Patch release per the project's 0.x versioning convention (minors signal breaking changes; patches are safe upgrades). After merge, publish runs the standard prepublish gates (`check:css`, `publint`, `attw`).
