### PR TITLE
chore(release): react-headless 0.9.3

### DIFF
--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-headless",
-  "version": "0.10.0",
+  "version": "0.9.3",
   "description": "Headless React primitives for AI chat — state management, streaming adapters for OpenAI and AG-UI, message format converters, and thread management for OpenUI generative UI apps",
   "license": "MIT",
   "type": "module",

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-headless",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Headless React primitives for AI chat — state management, streaming adapters for OpenAI and AG-UI, message format converters, and thread management for OpenUI generative UI apps",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## react-headless 0.9.3

Version bump only (`packages/react-headless` 0.9.2 → 0.9.3); no code changes in this PR.

### Changes in 0.9.3

- **MCP tool-call items are now surfaced by the OpenAI Responses adapter** (#815). `openAIResponsesAdapter` previously did not handle `mcp_call` and `mcp_list_tools` response items — streams containing them lost that activity. The adapter now yields them as tool-call events and the conversation message format round-trips them, so MCP activity flows through `useToolActivities` like any other tool call (this is what powers the "Behind the Scenes" tray for MCP in consuming UIs).
- README and agent-facing docs refreshed for the fetchLLM-first examples standard (#711).

### Publishing

Patch release: completes the Responses adapter's item coverage; no exports added or removed, no breaking changes. After merge, publish via the standard workflow (package: react-headless).
