### PR TITLE
Sync secure OpenUI skill credential guidance

### DIFF
--- a/skills/openui/SKILL.md
+++ b/skills/openui/SKILL.md
@@ -87,10 +87,12 @@ If “migrate” does not establish whether Cloud should replace the self-hosted
 
 ### Scaffold
 
+Never generate, print, echo, or invent placeholder API key values, and never ask the user to paste credentials into chat. Ask the user to configure required credentials outside the agent through their secret manager or an untracked local environment file. In generated commands, name the required variable but never emit a credential `NAME=value` assignment.
+
 ```bash
 npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-hosted --no-skill --no-interactive
 cd genui-chat-app
-echo "OPENAI_API_KEY=sk-your-key-here" > .env
+# Confirm OPENAI_API_KEY is configured outside chat before starting the app.
 npm run dev
 ```
 
@@ -104,7 +106,7 @@ npx @openuidev/cli@latest create --name genui-chat-app --template openui-self-ho
 
 If scaffold install/build fails with `ERR_PNPM_IGNORED_BUILDS` for native packages such as `sharp` or `unrs-resolver`, do not treat the scaffold as broken. Run `pnpm approve-builds` or `pnpm approve-builds --all`, then rerun install/build in an environment where package build scripts are allowed. Use first-party GitHub examples for Vue, Svelte, React Native, LangGraph, Mastra, Supabase, Vercel AI SDK, and other integrations.
 
-For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope, so `OPENAI_API_KEY=sk-test pnpm run build` is a valid smoke test when no real request will be sent.
+For self-hosted template build checks, set `OPENAI_API_KEY` even if no real model call is made. The generated Next route creates the OpenAI client at module scope. For a no-call smoke test, require the variable to be preconfigured outside agent-generated commands, then run `pnpm run build`; do not emit an inline assignment or placeholder value, and never use a production credential.
 
 ### Choose OpenUI Cloud or self-hosted
 

--- a/skills/openui/references/cloud-integration.md
+++ b/skills/openui/references/cloud-integration.md
@@ -59,10 +59,9 @@ zustand@^4.5.5
 
 `@openuidev/react-ui` re-exports headless APIs, but keep `@openuidev/react-headless` installed when required as a peer dependency. Import the re-exported APIs from `@openuidev/react-ui` in React UI applications.
 
-Configure server-only environment values:
+Configure server-only environment values through the deployment secret manager or an untracked `.env.local` file. Define `THESYS_API_KEY` there without printing, echoing, or committing its value. Never output a credential `NAME=value` example, even with a placeholder value.
 
 ```bash
-THESYS_API_KEY=sk-th-your-key
 OPENUI_MODEL=google/gemini-3.1-pro-free
 ```
 
@@ -415,10 +414,11 @@ tools: [
     type: "mcp",
     server_label: "deepwiki",
     server_url: "https://mcp.deepwiki.com/mcp", // public, no auth — good smoke test
-    // headers: { Authorization: `Bearer ${process.env.MCP_TOKEN}` },
   },
 ],
 ```
+
+For an authenticated MCP server, load credentials from existing server-side secret storage and attach them only to an explicitly approved provider origin. Never put token values in generated output, client code, or logs.
 
 MCP servers do not auto-attach; every request declares its own. The stream carries an `mcp_list_tools` item once per fresh server and one `mcp_call` item per invocation. A failed connection surfaces as `mcp_list_tools` with an `error` field — check for it before concluding the model "chose not to" use the server.
 


### PR DESCRIPTION
## Summary

- mirror the OpenUI skill credential-handling fix from `thesysdev/skills#4`
- remove secret-shaped literals and inline credential assignments from setup/build guidance
- keep authenticated MCP credentials server-side and scoped to an explicitly approved provider origin

## Why

The skills.sh Snyk audit marks the OpenUI skill as **High Risk (W007)** because the instructions include literal `sk-*` values in shell commands. PR #841 restored `skills/openui` as a temporary compatibility mirror for `@openuidev/cli` 0.0.7–0.1.7, so the legacy OpenUI-repository install path needs the same correction as the canonical skills repository.

Current CLI releases continue to install from `thesysdev/skills`; that repository remains the source of truth.

## Dependency

- Canonical change: https://github.com/thesysdev/skills/pull/4
- Compatibility mirror introduced by: #841
- Tracking: [TH-2427](https://linear.app/thesys/issue/TH-2427/maintain-parity-between-thesysdevskills-and-openuiskills)

Merge `thesysdev/skills#4` first. If it changes during review, update this mirror to match its final contents before merging.

## Validation

- `skills/openui` matches the canonical PR worktree byte-for-byte
- OpenUI skill validation passes with `quick_validate.py`
- no `sk-*`, `OPENAI_API_KEY=...`, or `THESYS_API_KEY=...` literal assignments remain in the skill tree
- `git diff --check`
- forward-tested the scaffold/build instructions without emitting credential assignments
