### PR TITLE
fix(react-ui): don't auto-open the last Accordion item on initial mount

### DIFF
--- a/packages/react-ui/src/genui-lib/Accordion/__tests__/Accordion.ssr.test.tsx
+++ b/packages/react-ui/src/genui-lib/Accordion/__tests__/Accordion.ssr.test.tsx
@@ -1,0 +1,33 @@
+import { Renderer } from "@openuidev/react-lang";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { openuiLibrary } from "../../openuiLibrary";
+
+// Regression test: a fully static response must open the FIRST section, not
+// the last. The auto-open branch treated the baseline render (0 -> N items)
+// as streaming growth and opened items[items.length - 1].
+// See https://github.com/thesysdev/openui/issues/861
+
+const STATIC_PROGRAM = `root = Accordion([i1, i2, i3])
+i1 = AccordionItem("a", "Apple", [c1])
+i2 = AccordionItem("b", "Banana", [c2])
+i3 = AccordionItem("c", "Cherry", [c3])
+c1 = TextContent("Apple section content")
+c2 = TextContent("Banana section content")
+c3 = TextContent("Cherry section content")`;
+
+describe("Accordion initial open state", () => {
+  it("opens the first section on a static mount", () => {
+    const html = renderToString(
+      <Renderer response={STATIC_PROGRAM} library={openuiLibrary} />,
+    );
+
+    const expandedStates = [...html.matchAll(/aria-expanded="(true|false)"/g)].map(
+      (m) => m[1],
+    );
+    expect(expandedStates).toEqual(["true", "false", "false"]);
+
+    expect(html).toContain("Apple section content");
+    expect(html).not.toContain("Cherry section content");
+  });
+});

--- a/packages/react-ui/src/genui-lib/Accordion/__tests__/Accordion.ssr.test.tsx
+++ b/packages/react-ui/src/genui-lib/Accordion/__tests__/Accordion.ssr.test.tsx
@@ -18,13 +18,9 @@ c3 = TextContent("Cherry section content")`;
 
 describe("Accordion initial open state", () => {
   it("opens the first section on a static mount", () => {
-    const html = renderToString(
-      <Renderer response={STATIC_PROGRAM} library={openuiLibrary} />,
-    );
+    const html = renderToString(<Renderer response={STATIC_PROGRAM} library={openuiLibrary} />);
 
-    const expandedStates = [...html.matchAll(/aria-expanded="(true|false)"/g)].map(
-      (m) => m[1],
-    );
+    const expandedStates = [...html.matchAll(/aria-expanded="(true|false)"/g)].map((m) => m[1]);
     expect(expandedStates).toEqual(["true", "false", "false"]);
 
     expect(html).toContain("Apple section content");

--- a/packages/react-ui/src/genui-lib/Accordion/index.tsx
+++ b/packages/react-ui/src/genui-lib/Accordion/index.tsx
@@ -30,12 +30,24 @@ export const Accordion = defineComponent({
     const items = props.items ?? [];
     const [openItem, setOpenItem] = React.useState<string>("");
     const userHasInteracted = React.useRef(false);
-    const prevItemCount = React.useRef(0);
+    const prevItemCount = React.useRef<number | null>(null);
+    const autoOpenIndex = React.useRef(-1);
 
-    // Auto-open: only when a NEW item arrives during streaming
-    if (!userHasInteracted.current && items.length > prevItemCount.current) {
-      const newest = items[items.length - 1];
-      if (newest) setOpenItem(newest.props.value);
+    // Auto-open: the FIRST item on the baseline pass (a static response
+    // mounts with all items already present, which is growth from 0 and
+    // must not open the newest), then the newest item whenever one arrives
+    // during streaming. Tracking the index rather than the value keeps the
+    // open section in sync while its value string is still streaming in.
+    if (!userHasInteracted.current) {
+      if (prevItemCount.current === null) {
+        if (items.length) autoOpenIndex.current = 0;
+      } else if (items.length > prevItemCount.current) {
+        autoOpenIndex.current = items.length - 1;
+      }
+      const autoOpenValue = items[autoOpenIndex.current]?.props.value;
+      if (autoOpenValue && autoOpenValue !== openItem) {
+        setOpenItem(autoOpenValue);
+      }
     }
     prevItemCount.current = items.length;
 


### PR DESCRIPTION
## Summary

Fixes #861 — `<Accordion>` opens the **last** item on initial mount for a fully static (non-streaming) response, instead of the first.

The auto-open branch treats any growth in item count as "a new item arrived during streaming". On the baseline render `prevItemCount` is `0`, so a static N-item response satisfies `items.length > prevItemCount.current` and opens `items[items.length - 1]`. This is the same defect shape as the `<Tabs>` issue #819: a streaming follow-along heuristic that doesn't exclude the initial mount.

## Changes

- **Baseline pass opens the first item.** `prevItemCount` now starts at `null` so the very first render is distinguishable from streaming growth. A static mount opens the first section — restoring the behavior from before the #485 refactor removed the first-item mount effect. Streaming follow-along is unchanged: an item arriving after the baseline still auto-opens the newest one (an accordion that mounts empty mid-stream records a `0` baseline, so its first item still auto-opens on arrival).
- **Track the auto-opened item by index, not by value.** Previously, when a new item arrived before its `value` string had finished streaming, `setOpenItem` latched a prefix of the value (e.g. `"ov"` for `"overview"`); since the only re-sync trigger was count growth, the completed value never re-synced and every section ended up closed. Tracking the index re-syncs `openItem` once the value completes.

## Reproduction / verification

Standalone repro against the published packages: https://github.com/Shinyaigeek/openui-accordion-repro

| Before (published `react-ui@0.13.1`) | After (this branch, local build) |
| --- | --- |
| ![before: Cherry open](https://raw.githubusercontent.com/Shinyaigeek/openui-accordion-repro/main/screenshot.png) | ![after: Apple open](https://raw.githubusercontent.com/Shinyaigeek/openui-accordion-repro/main/after-fix.png) |

- Added an SSR regression test (`Accordion.ssr.test.tsx`) that renders the static three-section program through the real `Renderer` + `openuiLibrary` and asserts the first section is the open one. It fails on the previous implementation with `[ 'false', 'false', 'true' ]` (last open) and passes with this change.
- `pnpm test` in `packages/react-ui`: 28 passed.
- Verified in a browser via the repro with a local build of this branch: the first section (`Apple`) is open on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
