### PR TITLE
Refine AppLess nav card

### DIFF
--- a/docs/components/site-primary-nav.module.css
+++ b/docs/components/site-primary-nav.module.css
@@ -288,8 +288,8 @@
 
 .dropdownDescription {
   font-family: "Inter", sans-serif;
-  font-size: 14px;
-  line-height: 1.57;
+  font-size: 13px;
+  line-height: 1.5;
   color: var(--openui-text-neutral-secondary);
   opacity: 0.8;
 }

--- a/docs/components/site-primary-nav.tsx
+++ b/docs/components/site-primary-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowRight } from "@phosphor-icons/react";
+import { ArrowRight, ArrowUpRight } from "@phosphor-icons/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
@@ -89,7 +89,7 @@ export const PRIMARY_SITE_NAV_ITEMS: NavItem[] = [
       },
       {
         title: "AppLess",
-        description: "A no-app phone experience powered by OpenUI-generated native interfaces.",
+        description: "An open-source concept for an OS without any apps.",
         href: "https://github.com/thesysdev/appless",
         newTab: true,
         preview: {
@@ -170,7 +170,11 @@ function DropdownCard({ child, onNavigate }: { child: NavDropdownChild; onNaviga
         <span className={styles.dropdownTitleRow}>
           <span className={styles.dropdownTitle}>{child.title}</span>
           <span className={styles.dropdownArrow} aria-hidden="true">
-            <ArrowRight size={12} weight="bold" />
+            {child.newTab ? (
+              <ArrowUpRight size={12} weight="bold" />
+            ) : (
+              <ArrowRight size={12} weight="bold" />
+            )}
           </span>
         </span>
         {child.description && (


### PR DESCRIPTION
## Summary
- use outward arrow for external nav cards
- update AppLess dropdown copy
- reduce dropdown description size

## Test
- pnpm build