### PR TITLE
fix(lang-core): keep multi-line ternaries intact in mergeStatements

### DIFF
--- a/packages/lang-core/src/parser/__tests__/serialize.test.ts
+++ b/packages/lang-core/src/parser/__tests__/serialize.test.ts
@@ -539,6 +539,41 @@ describe("jsonToOpenUI", () => {
       const children = result.root!.props.children as ElementNode[];
       expect(children[0].props.text).toBe("New");
     });
+
+    // A multi-line ternary is part of the accepted grammar (parse() keeps it),
+    // so merging a patch that doesn't touch it must leave it intact (#821).
+    it("keeps a multi-line ternary in an untouched statement", () => {
+      const existing = [
+        "root = Stack([a, b])",
+        "a = $ok",
+        '  ? Title("Yes")',
+        '  : Title("No")',
+        'b = Title("Footer")',
+      ].join("\n");
+
+      const merged = mergeStatements(existing, 'b = Title("Updated")');
+
+      expect(merged).toBe(
+        [
+          "root = Stack([a, b])",
+          "a = $ok",
+          '  ? Title("Yes")',
+          '  : Title("No")',
+          'b = Title("Updated")',
+        ].join("\n"),
+      );
+    });
+
+    it("replaces a multi-line ternary when the patch targets it", () => {
+      const existing = ["root = Stack([a])", "a = $ok", '  ? Title("Yes")', '  : Title("No")'].join(
+        "\n",
+      );
+
+      const merged = mergeStatements(existing, 'a = Title("Changed")');
+
+      expect(merged).toBe(["root = Stack([a])", 'a = Title("Changed")'].join("\n"));
+      expect(merged).not.toContain('? Title("Yes")');
+    });
   });
 
   // ── Edge cases ─────────────────────────────────────────────────────────

--- a/packages/lang-core/src/parser/merge.ts
+++ b/packages/lang-core/src/parser/merge.ts
@@ -18,6 +18,7 @@ interface ParsedStatement {
 function splitStatementSource(input: string): string[] {
   const stmts: string[] = [];
   let depth = 0;
+  let ternaryDepth = 0;
   let inStr: false | '"' | "'" = false;
   let esc = false;
   let start = 0;
@@ -44,7 +45,18 @@ function splitStatementSource(input: string): string[] {
 
     if (c === "(" || c === "[" || c === "{") depth++;
     else if (c === ")" || c === "]" || c === "}") depth = Math.max(0, depth - 1);
+    // Track ternary `?`/`:` at bracket depth 0 so a multi-line ternary
+    // (condition on one line, `?`/`:` continuation on the next) stays a single
+    // statement — mirrors split() in statements.ts. Without this the char-level
+    // splitter disagrees with the parser and drops the branches (#821).
+    else if (c === "?" && depth === 0) ternaryDepth++;
+    else if (c === ":" && depth === 0 && ternaryDepth > 0) ternaryDepth--;
     else if (c === "\n" && depth <= 0) {
+      if (ternaryDepth > 0) continue; // mid-ternary, awaiting the `:` branch
+      // Peek past whitespace/newlines: a `?` continuation keeps the statement.
+      let j = i + 1;
+      while (j < input.length && /\s/.test(input[j])) j++;
+      if (input[j] === "?") continue;
       const stmt = input.slice(start, i).trim();
       if (stmt) stmts.push(stmt);
       start = i + 1;


### PR DESCRIPTION
Closes #821.

A statement written as a multi-line ternary survives `parse()`, but `mergeStatements()` was silently dropping both branches even when the patch never touched that statement:

```
a = $ok
  ? Title("Yes")
  : Title("No")
```

becomes `a = $ok` after merging an unrelated patch.

The cause is the third statement splitter. `split()` in statements.ts and `scanNewCompleted()` in parser.ts both know that a `?` / `:` continuation line belongs to the same statement (they track `ternaryDepth` and peek past the newline), but `mergeStatements()` re-splits the existing program with `splitStatementSource()` in merge.ts, which only tracked bracket depth and broke on every depth-0 newline. The `? ...` / `: ...` fragments then failed the `Ident = expression` shape check and were discarded without an error.

Went with direction 1 from the issue: gave `splitStatementSource()` the same ternary handling — track ternary depth at bracket depth 0, and before treating a depth-0 newline as a boundary, skip it if we are mid-ternary or the next meaningful character is a `?`. Didn't unify onto `split()` (direction 2) because merge needs the raw source slices to round-trip the statements, and the token splitter throws that text away.

Added two tests next to the existing merge cases: the issue repro (untouched ternary stays intact) and the inverse (a patch targeting the ternary still replaces it). The first fails on the current splitter. Full lang-core suite is green, tsc/eslint/prettier clean.