### PR TITLE
Update Chat navbar controls

### DIFF
--- a/docs/app/_components/build-for-free-menu.module.css
+++ b/docs/app/_components/build-for-free-menu.module.css
@@ -1,6 +1,18 @@
 .root {
+  --build-button-background: #0a0a0a;
+  --build-button-color: #fff;
+  --build-button-shadow:
+    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
+
   position: relative;
   flex: none;
+}
+
+[data-theme="dark"] .root {
+  --build-button-background: #f7f7f8;
+  --build-button-color: #0a0a0a;
+  --build-button-shadow:
+    inset 0 2px 1px -0.5px rgba(255, 255, 255, 1), inset 0 -3px 6px -1px rgba(0, 0, 0, 0.1);
 }
 
 .button {
@@ -12,13 +24,9 @@
   padding-inline: 0.625rem;
   border: 0;
   border-radius: 10px;
-  background: var(--home-surface-ink, #0a0a0a);
-  box-shadow: var(
-    --home-bevel-on-dark,
-    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16),
-    inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6)
-  );
-  color: #fff;
+  background: var(--build-button-background);
+  box-shadow: var(--build-button-shadow);
+  color: var(--build-button-color);
   font-family: "Inter", "Segoe UI", sans-serif;
   font-size: 0.9375rem;
   font-weight: 500;

--- a/docs/app/_components/build-for-free-menu.module.css
+++ b/docs/app/_components/build-for-free-menu.module.css
@@ -1,18 +1,6 @@
 .root {
-  --build-button-background: #0a0a0a;
-  --build-button-color: #fff;
-  --build-button-shadow:
-    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
-
   position: relative;
   flex: none;
-}
-
-[data-theme="dark"] .root {
-  --build-button-background: #f7f7f8;
-  --build-button-color: #0a0a0a;
-  --build-button-shadow:
-    inset 0 2px 1px -0.5px rgba(255, 255, 255, 1), inset 0 -3px 6px -1px rgba(0, 0, 0, 0.1);
 }
 
 .button {
@@ -24,9 +12,11 @@
   padding-inline: 0.625rem;
   border: 0;
   border-radius: 10px;
-  background: var(--build-button-background);
-  box-shadow: var(--build-button-shadow);
-  color: var(--build-button-color);
+  background: var(--openui-inverted-background);
+  box-shadow:
+    inset 0 2px 1px -0.5px color-mix(in srgb, var(--openui-inverted-background) 84%, white),
+    inset 0 -3px 6px -1px color-mix(in srgb, var(--openui-inverted-background) 90%, black);
+  color: var(--openui-background);
   font-family: "Inter", "Segoe UI", sans-serif;
   font-size: 0.9375rem;
   font-weight: 500;

--- a/docs/app/_components/build-for-free-menu.module.css
+++ b/docs/app/_components/build-for-free-menu.module.css
@@ -1,0 +1,144 @@
+.root {
+  position: relative;
+  flex: none;
+}
+
+.button {
+  display: flex;
+  box-sizing: border-box;
+  height: 2.25rem;
+  align-items: center;
+  gap: 0.375rem;
+  padding-inline: 0.625rem;
+  border: 0;
+  border-radius: 10px;
+  background: var(--home-surface-ink, #0a0a0a);
+  box-shadow: var(
+    --home-bevel-on-dark,
+    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16),
+    inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6)
+  );
+  color: #fff;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.button:hover {
+  opacity: 0.88;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--openui-text-neutral-primary);
+  outline-offset: 2px;
+}
+
+.arrow {
+  transition: transform 160ms ease;
+}
+
+.arrow[data-open="true"] {
+  transform: rotate(90deg);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 60;
+  width: 22.5rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.18s ease,
+    visibility 0s linear 0.18s;
+}
+
+.menuOpen {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity 0.18s ease,
+    visibility 0s;
+}
+
+.menuCard {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--openui-border-default);
+  border-radius: 12px;
+  background: var(--openui-foreground);
+  padding: 0.375rem;
+  box-shadow: var(--openui-shadow-l);
+}
+
+.menuItem {
+  display: flex;
+  width: 100%;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--openui-text-neutral-primary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.menuItem:hover {
+  background: var(--openui-highlight) !important;
+}
+
+.menuItem:focus-visible {
+  outline: 2px solid var(--openui-border-accent-emphasis);
+  outline-offset: -2px;
+}
+
+.menuItemLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.menuItemRunner {
+  color: var(--openui-text-neutral-primary);
+  font-weight: 600;
+}
+
+.menuItemIcon {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--openui-text-neutral-secondary);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.menuItem:hover .menuItemIcon,
+.menuItem:focus-visible .menuItemIcon {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .arrow,
+  .menu,
+  .menuItem {
+    transition: none;
+  }
+}

--- a/docs/app/_components/build-for-free-menu.tsx
+++ b/docs/app/_components/build-for-free-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ClipboardCommandButton } from "@/app/(home)/components/Button/Button";
+import { captureCreateCliCommandCopied } from "@/lib/create-cli-copy-analytics";
 import { ArrowRight } from "lucide-react";
 import styles from "./build-for-free-menu.module.css";
 import { useHeaderDropdown } from "./use-header-dropdown";
@@ -12,7 +13,12 @@ export const CLI_COMMANDS = [
   { id: "npm", runner: "npx", command: "npx @openuidev/cli@latest create" },
 ] as const;
 
-export function BuildForFreeMenu({ className }: { className?: string }) {
+interface BuildForFreeMenuProps {
+  analyticsSource: "chat_navbar" | "compare_navbar";
+  className?: string;
+}
+
+export function BuildForFreeMenu({ analyticsSource, className }: BuildForFreeMenuProps) {
   const { open, setOpen, wrapRef, triggerRef, handleHoverOpen, handleHoverClose } =
     useHeaderDropdown();
 
@@ -54,6 +60,12 @@ export function BuildForFreeMenu({ className }: { className?: string }) {
               className={styles.menuItem}
               iconContainerClassName={styles.menuItemIcon}
               copyIconColor="currentColor"
+              onCopySuccess={(command) =>
+                captureCreateCliCommandCopied(command, {
+                  source: analyticsSource,
+                  interaction: "dropdown",
+                })
+              }
             >
               <span className={styles.menuItemLabel}>
                 <span className={styles.menuItemRunner}>{item.runner}</span>

--- a/docs/app/_components/build-for-free-menu.tsx
+++ b/docs/app/_components/build-for-free-menu.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { ClipboardCommandButton } from "@/app/(home)/components/Button/Button";
+import { ArrowRight } from "lucide-react";
+import styles from "./build-for-free-menu.module.css";
+import { useHeaderDropdown } from "./use-header-dropdown";
+
+export const CLI_COMMANDS = [
+  { id: "pnpm", runner: "pnpx", command: "pnpx @openuidev/cli@latest create" },
+  { id: "bun", runner: "bunx", command: "bunx @openuidev/cli@latest create" },
+  { id: "yarn", runner: "yarn dlx", command: "yarn dlx @openuidev/cli@latest create" },
+  { id: "npm", runner: "npx", command: "npx @openuidev/cli@latest create" },
+] as const;
+
+export function BuildForFreeMenu({ className }: { className?: string }) {
+  const { open, setOpen, wrapRef, triggerRef, handleHoverOpen, handleHoverClose } =
+    useHeaderDropdown();
+
+  return (
+    <div
+      className={`${styles.root} ${className ?? ""}`.trim()}
+      ref={wrapRef}
+      onPointerEnter={handleHoverOpen}
+      onPointerLeave={handleHoverClose}
+    >
+      <button
+        type="button"
+        ref={triggerRef}
+        className={styles.button}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span>Build for free</span>
+        <ArrowRight
+          size={15}
+          strokeWidth={2}
+          aria-hidden="true"
+          className={styles.arrow}
+          data-open={open}
+        />
+      </button>
+
+      <div className={`${styles.menu} ${open ? styles.menuOpen : ""}`.trim()}>
+        <div
+          className={styles.menuCard}
+          role="menu"
+          aria-label="Copy the setup command for a package manager"
+        >
+          {CLI_COMMANDS.map((item) => (
+            <ClipboardCommandButton
+              key={item.id}
+              command={item.command}
+              className={styles.menuItem}
+              iconContainerClassName={styles.menuItemIcon}
+              copyIconColor="currentColor"
+            >
+              <span className={styles.menuItemLabel}>
+                <span className={styles.menuItemRunner}>{item.runner}</span>
+                {item.command.slice(item.runner.length)}
+              </span>
+            </ClipboardCommandButton>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/app/_components/use-header-dropdown.ts
+++ b/docs/app/_components/use-header-dropdown.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// Shared header-menu behavior: mouse hover with a grace delay, click toggle,
+// outside pointer-down close, and Escape close with focus restoration.
+export function useHeaderDropdown() {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    };
+  }, []);
+
+  const cancelScheduledClose = () => {
+    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = null;
+  };
+
+  const handleHoverOpen = (event: React.PointerEvent) => {
+    if (event.pointerType !== "mouse") return;
+    cancelScheduledClose();
+    setOpen(true);
+  };
+
+  const handleHoverClose = (event: React.PointerEvent) => {
+    if (event.pointerType !== "mouse") return;
+    cancelScheduledClose();
+    closeTimeoutRef.current = setTimeout(() => setOpen(false), 160);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return { open, setOpen, wrapRef, triggerRef, handleHoverOpen, handleHoverClose };
+}

--- a/docs/app/chat/_components/agent-surfaces/cloud-agent-surface.tsx
+++ b/docs/app/chat/_components/agent-surfaces/cloud-agent-surface.tsx
@@ -35,11 +35,7 @@ const CLOUD_STARTERS = [
   },
 ];
 
-interface CloudAgentSurfaceProps {
-  themeMode: "light" | "dark";
-}
-
-export function CloudAgentSurface({ themeMode }: CloudAgentSurfaceProps) {
+export function CloudAgentSurface() {
   const [selectedModel, setSelectedModel] = useState(DEFAULT_MODEL);
   const [userId] = useState(getOrCreateCloudUserId);
   const [llm] = useState(createCloudChatLLM);
@@ -84,7 +80,6 @@ export function CloudAgentSurface({ themeMode }: CloudAgentSurfaceProps) {
         agentName="OpenUI Cloud"
         scrollVariant="always"
         scrollOnLoad={false}
-        theme={{ mode: themeMode }}
         starterVariant="short"
         starters={CLOUD_STARTERS}
       >

--- a/docs/app/chat/_components/agent-surfaces/oss-agent-surface.tsx
+++ b/docs/app/chat/_components/agent-surfaces/oss-agent-surface.tsx
@@ -11,7 +11,6 @@ import { openuiChatLibrary } from "@openuidev/react-ui/genui-lib";
 import { useMemo } from "react";
 
 interface OssAgentSurfaceProps {
-  themeMode: "light" | "dark";
   onCreditsExhausted: () => void;
 }
 
@@ -38,7 +37,7 @@ const OSS_STARTERS = [
   },
 ];
 
-export function OssAgentSurface({ themeMode, onCreditsExhausted }: OssAgentSurfaceProps) {
+export function OssAgentSurface({ onCreditsExhausted }: OssAgentSurfaceProps) {
   const llm = useMemo<ChatLLM>(
     () => ({
       send: async ({ messages, signal }) => {
@@ -79,7 +78,6 @@ export function OssAgentSurface({ themeMode, onCreditsExhausted }: OssAgentSurfa
         llm={llm}
         componentLibrary={openuiChatLibrary}
         agentName="OpenUI OSS"
-        theme={{ mode: themeMode }}
         starterVariant="short"
         starters={OSS_STARTERS}
       >

--- a/docs/app/chat/_components/chat-page-client.tsx
+++ b/docs/app/chat/_components/chat-page-client.tsx
@@ -2,7 +2,6 @@
 
 import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
 import { OPENUI_CLOUD_UNAVAILABLE_MESSAGE } from "@/lib/openui-cloud/errors";
-import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
 import { Component, useCallback, useState, type ReactNode } from "react";
 import styles from "../chat-page.module.css";
@@ -39,11 +38,9 @@ class CloudSurfaceErrorBoundary extends Component<
 }
 
 export function ChatPageClient() {
-  const { resolvedTheme } = useTheme();
   const [mode, setMode] = useState<ChatMode>("oss");
   const [announcement, setAnnouncement] = useState("");
   const [creditsDialogOpen, setCreditsDialogOpen] = useState(false);
-  const themeMode = resolvedTheme === "dark" ? "dark" : "light";
 
   const handleCreditsExhausted = useCallback(() => {
     setCreditsDialogOpen(true);
@@ -71,10 +68,10 @@ export function ChatPageClient() {
         aria-label={`${mode === "oss" ? "OpenUI OSS" : "OpenUI Cloud"} chat`}
       >
         {mode === "oss" ? (
-          <OssAgentSurface themeMode={themeMode} onCreditsExhausted={handleCreditsExhausted} />
+          <OssAgentSurface onCreditsExhausted={handleCreditsExhausted} />
         ) : (
           <CloudSurfaceErrorBoundary>
-            <CloudAgentSurface themeMode={themeMode} />
+            <CloudAgentSurface />
           </CloudSurfaceErrorBoundary>
         )}
       </section>

--- a/docs/app/chat/_components/chat-page-header.tsx
+++ b/docs/app/chat/_components/chat-page-header.tsx
@@ -40,7 +40,7 @@ export function ChatPageHeader({ mode, onModeChange }: ChatPageHeaderProps) {
           </ToggleGroup>
         </div>
 
-        <BuildForFreeMenu className={styles.buildForFreeMenu} />
+        <BuildForFreeMenu analyticsSource="chat_navbar" className={styles.buildForFreeMenu} />
       </div>
     </header>
   );

--- a/docs/app/chat/_components/chat-page-header.tsx
+++ b/docs/app/chat/_components/chat-page-header.tsx
@@ -1,121 +1,12 @@
 "use client";
 
-import { ClipboardCommandButton } from "@/app/(home)/components/Button/Button";
+import { BuildForFreeMenu } from "@/app/_components/build-for-free-menu";
 import { ToggleGroup } from "@openuidev/react-ui/ToggleGroup";
 import { ToggleItem } from "@openuidev/react-ui/ToggleItem";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
 import styles from "../chat-page.module.css";
 import type { ChatMode } from "./chat-types";
-
-const CLI_COMMANDS = [
-  { id: "pnpm", runner: "pnpx", command: "pnpx @openuidev/cli@latest create" },
-  { id: "bun", runner: "bunx", command: "bunx @openuidev/cli@latest create" },
-  { id: "yarn", runner: "yarn dlx", command: "yarn dlx @openuidev/cli@latest create" },
-  { id: "npm", runner: "npx", command: "npx @openuidev/cli@latest create" },
-] as const;
-
-function BuildForFreeMenu() {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
-    };
-  }, []);
-
-  const cancelScheduledClose = () => {
-    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
-    closeTimeoutRef.current = null;
-  };
-
-  const handleHoverOpen = (event: React.PointerEvent) => {
-    if (event.pointerType !== "mouse") return;
-    cancelScheduledClose();
-    setOpen(true);
-  };
-
-  const handleHoverClose = (event: React.PointerEvent) => {
-    if (event.pointerType !== "mouse") return;
-    cancelScheduledClose();
-    closeTimeoutRef.current = setTimeout(() => setOpen(false), 160);
-  };
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  return (
-    <div
-      className={styles.ctaWrap}
-      ref={wrapRef}
-      onPointerEnter={handleHoverOpen}
-      onPointerLeave={handleHoverClose}
-    >
-      <button
-        type="button"
-        ref={triggerRef}
-        className={styles.ctaButton}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span>Build for free</span>
-        <ArrowRight
-          size={15}
-          strokeWidth={2}
-          aria-hidden="true"
-          className={styles.ctaArrow}
-          data-open={open}
-        />
-      </button>
-
-      <div className={`${styles.ctaMenu} ${open ? styles.ctaMenuOpen : ""}`.trim()}>
-        <div
-          className={styles.ctaMenuCard}
-          role="menu"
-          aria-label="Copy the setup command for a package manager"
-        >
-          {CLI_COMMANDS.map((item) => (
-            <ClipboardCommandButton
-              key={item.id}
-              command={item.command}
-              className={styles.ctaMenuItem}
-              iconContainerClassName={styles.ctaMenuItemIcon}
-              copyIconColor="currentColor"
-            >
-              <span className={styles.ctaMenuItemLabel}>
-                <span className={styles.ctaMenuItemRunner}>{item.runner}</span>
-                {item.command.slice(item.runner.length)}
-              </span>
-            </ClipboardCommandButton>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 interface ChatPageHeaderProps {
   mode: ChatMode;
@@ -149,7 +40,7 @@ export function ChatPageHeader({ mode, onModeChange }: ChatPageHeaderProps) {
           </ToggleGroup>
         </div>
 
-        <BuildForFreeMenu />
+        <BuildForFreeMenu className={styles.buildForFreeMenu} />
       </div>
     </header>
   );

--- a/docs/app/chat/_components/chat-page-header.tsx
+++ b/docs/app/chat/_components/chat-page-header.tsx
@@ -1,61 +1,119 @@
 "use client";
 
-import { copyText } from "@/lib/copy-text";
+import { ClipboardCommandButton } from "@/app/(home)/components/Button/Button";
 import { ToggleGroup } from "@openuidev/react-ui/ToggleGroup";
 import { ToggleItem } from "@openuidev/react-ui/ToggleItem";
-import { ArrowLeft, Check, SquareTerminal } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import styles from "../chat-page.module.css";
 import type { ChatMode } from "./chat-types";
 
-const CREATE_COMMAND = "npx @openuidev/cli@latest create";
-const COPY_FEEDBACK_MS = 1800;
+const CLI_COMMANDS = [
+  { id: "pnpm", runner: "pnpx", command: "pnpx @openuidev/cli@latest create" },
+  { id: "bun", runner: "bunx", command: "bunx @openuidev/cli@latest create" },
+  { id: "yarn", runner: "yarn dlx", command: "yarn dlx @openuidev/cli@latest create" },
+  { id: "npm", runner: "npx", command: "npx @openuidev/cli@latest create" },
+] as const;
 
-function StartLocallyButton() {
-  const [copied, setCopied] = useState(false);
-  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+function BuildForFreeMenu() {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
-      if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
     };
   }, []);
 
-  const handleCopy = async () => {
-    if (!(await copyText(CREATE_COMMAND))) return;
-
-    setCopied(true);
-    if (resetTimeoutRef.current) clearTimeout(resetTimeoutRef.current);
-    resetTimeoutRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+  const cancelScheduledClose = () => {
+    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = null;
   };
 
+  const handleHoverOpen = (event: React.PointerEvent) => {
+    if (event.pointerType !== "mouse") return;
+    cancelScheduledClose();
+    setOpen(true);
+  };
+
+  const handleHoverClose = (event: React.PointerEvent) => {
+    if (event.pointerType !== "mouse") return;
+    cancelScheduledClose();
+    closeTimeoutRef.current = setTimeout(() => setOpen(false), 160);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   return (
-    <button
-      type="button"
-      className={styles.startLocallyButton}
-      data-copied={copied}
-      onClick={handleCopy}
-      aria-label={`Copy local setup command: ${CREATE_COMMAND}`}
+    <div
+      className={styles.ctaWrap}
+      ref={wrapRef}
+      onPointerEnter={handleHoverOpen}
+      onPointerLeave={handleHoverClose}
     >
-      {copied ? (
-        <Check size={17} strokeWidth={2} aria-hidden="true" />
-      ) : (
-        <SquareTerminal size={17} strokeWidth={1.8} aria-hidden="true" />
-      )}
-      <span className={styles.startLocallyLabelGroup} aria-hidden="true">
-        <span className={`${styles.startLocallyLabel} ${styles.startLocallyDefault}`}>
-          Run on your machine
-        </span>
-        <span className={`${styles.startLocallyLabel} ${styles.startLocallyCommand}`}>
-          {CREATE_COMMAND}
-        </span>
-        <span className={`${styles.startLocallyLabel} ${styles.startLocallyCopied}`}>Copied</span>
-      </span>
-      <span className={styles.srOnly} aria-live="polite">
-        {copied ? "Local setup command copied." : ""}
-      </span>
-    </button>
+      <button
+        type="button"
+        ref={triggerRef}
+        className={styles.ctaButton}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span>Build for free</span>
+        <ArrowRight
+          size={15}
+          strokeWidth={2}
+          aria-hidden="true"
+          className={styles.ctaArrow}
+          data-open={open}
+        />
+      </button>
+
+      <div className={`${styles.ctaMenu} ${open ? styles.ctaMenuOpen : ""}`.trim()}>
+        <div
+          className={styles.ctaMenuCard}
+          role="menu"
+          aria-label="Copy the setup command for a package manager"
+        >
+          {CLI_COMMANDS.map((item) => (
+            <ClipboardCommandButton
+              key={item.id}
+              command={item.command}
+              className={styles.ctaMenuItem}
+              iconContainerClassName={styles.ctaMenuItemIcon}
+              copyIconColor="currentColor"
+            >
+              <span className={styles.ctaMenuItemLabel}>
+                <span className={styles.ctaMenuItemRunner}>{item.runner}</span>
+                {item.command.slice(item.runner.length)}
+              </span>
+            </ClipboardCommandButton>
+          ))}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -68,12 +126,9 @@ export function ChatPageHeader({ mode, onModeChange }: ChatPageHeaderProps) {
   return (
     <header className={styles.header} aria-label="OpenUI chat controls">
       <div className={styles.headerRow}>
-        <Link className={styles.backLink} href="/" prefetch={false}>
-          <ArrowLeft aria-hidden="true" size={17} />
-          <span>Back to docs</span>
+        <Link className={styles.backLink} href="/" prefetch={false} aria-label="Back to docs">
+          <ArrowLeft aria-hidden="true" size={15} strokeWidth={2} />
         </Link>
-
-        <StartLocallyButton />
 
         <div className={styles.modeControl}>
           <ToggleGroup
@@ -93,6 +148,8 @@ export function ChatPageHeader({ mode, onModeChange }: ChatPageHeaderProps) {
             </ToggleItem>
           </ToggleGroup>
         </div>
+
+        <BuildForFreeMenu />
       </div>
     </header>
   );

--- a/docs/app/chat/chat-page.module.css
+++ b/docs/app/chat/chat-page.module.css
@@ -10,9 +10,6 @@
 }
 
 .header {
-  --home-surface-ink: #0a0a0a;
-  --home-bevel-on-dark:
-    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
   position: relative;
   z-index: 5;
   flex: none;

--- a/docs/app/chat/chat-page.module.css
+++ b/docs/app/chat/chat-page.module.css
@@ -10,130 +10,54 @@
 }
 
 .header {
+  --home-surface-ink: #0a0a0a;
+  --home-bevel-on-dark:
+    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
   position: relative;
   z-index: 5;
   flex: none;
   border-bottom: 1px solid var(--openui-border-default);
   background: var(--openui-foreground);
-  padding: 12px 20px 10px;
+  padding: 8px;
 }
 
 .headerRow {
-  display: flex;
+  display: grid;
+  min-height: 2.25rem;
   min-width: 0;
   align-items: center;
-  gap: 16px;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 8px;
 }
 
 .backLink {
   display: inline-flex;
-  min-height: 44px;
+  box-sizing: border-box;
+  width: 2.25rem;
+  height: 2.25rem;
   flex: none;
   align-items: center;
-  gap: 7px;
-  border-radius: var(--openui-radius-m);
-  color: var(--openui-text-neutral-secondary);
-  font: var(--openui-text-body-sm);
+  justify-content: center;
+  justify-self: start;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--openui-text-neutral-primary);
   text-decoration: none;
-  transition:
-    color 120ms ease,
-    background-color 120ms ease;
+  transition: background-color 120ms ease;
 }
 
 .backLink:hover {
-  color: var(--openui-text-neutral-primary);
+  background: var(--openui-highlight);
 }
 
 .backLink:focus-visible {
   outline: 2px solid var(--openui-border-accent-emphasis);
-  outline-offset: 3px;
-}
-
-.startLocallyButton {
-  display: inline-flex;
-  box-sizing: border-box;
-  inline-size: 18.75rem;
-  height: 2.5rem;
-  min-inline-size: 18.75rem;
-  flex: 0 0 18.75rem;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  padding-inline: 0.875rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
-  background: #0a0a0a;
-  color: #fff;
-  box-shadow:
-    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16),
-    inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
-  font-family: var(--font-geist-mono), monospace;
-  font-size: 0.75rem;
-  font-weight: 500;
-  line-height: 1;
-  white-space: nowrap;
-  cursor: pointer;
-  transition:
-    border-color 160ms ease,
-    background-color 160ms ease,
-    color 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.startLocallyButton:is(:hover, :focus-visible) {
-  border-color: rgba(10, 10, 10, 0.18);
-  background: #fff;
-  color: #0a0a0a;
-  box-shadow:
-    0 5px 14px rgba(0, 0, 0, 0.14),
-    inset 0 -3px 6px rgba(0, 0, 0, 0.06);
-}
-
-.startLocallyButton:focus-visible {
-  outline: 2px solid var(--openui-text-neutral-primary);
   outline-offset: 2px;
-}
-
-.startLocallyButton svg {
-  flex-shrink: 0;
-}
-
-.startLocallyLabelGroup {
-  display: grid;
-  min-width: 0;
-  place-items: center;
-}
-
-.startLocallyLabel {
-  grid-area: 1 / 1;
-  transition: opacity 140ms ease;
-}
-
-.startLocallyCommand,
-.startLocallyCopied {
-  opacity: 0;
-}
-
-.startLocallyButton:not([data-copied="true"]):is(:hover, :focus-visible) .startLocallyDefault {
-  opacity: 0;
-}
-
-.startLocallyButton:not([data-copied="true"]):is(:hover, :focus-visible) .startLocallyCommand {
-  opacity: 1;
-}
-
-.startLocallyButton[data-copied="true"] .startLocallyDefault,
-.startLocallyButton[data-copied="true"] .startLocallyCommand {
-  opacity: 0;
-}
-
-.startLocallyButton[data-copied="true"] .startLocallyCopied {
-  opacity: 1;
 }
 
 .modeControl {
   min-width: 0;
-  margin-left: auto;
+  justify-self: center;
 }
 
 .modeGroup {
@@ -141,22 +65,25 @@
   width: auto !important;
   min-width: 0;
   flex-wrap: nowrap !important;
-  gap: 0 !important;
-  border: 1px solid var(--openui-border-default);
-  border-radius: var(--openui-radius-m);
-  background: var(--openui-sunk);
-  padding: 3px;
+  gap: 4px !important;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
 }
 
 .modeItem {
-  min-height: 38px !important;
+  min-height: 2.25rem !important;
   border: 0 !important;
-  border-radius: calc(var(--openui-radius-m) - 3px) !important;
+  border-radius: 10px !important;
   background: transparent !important;
-  padding: 7px 13px !important;
+  padding: 7px 14px !important;
   color: var(--openui-text-neutral-secondary) !important;
   font: var(--openui-text-label-sm) !important;
   white-space: nowrap;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
 }
 
 .modeItem:hover:not(:disabled) {
@@ -165,9 +92,9 @@
 }
 
 .modeItem[data-state="on"] {
-  color: var(--openui-text-white) !important;
-  background: var(--openui-text-black) !important;
-  box-shadow: var(--openui-shadow-s);
+  color: var(--openui-text-neutral-primary) !important;
+  background: var(--openui-sunk) !important;
+  box-shadow: none;
 }
 
 .modeItem:focus-visible {
@@ -175,6 +102,135 @@
   z-index: 1;
   outline: 2px solid var(--openui-border-accent-emphasis);
   outline-offset: 1px;
+}
+
+.ctaWrap {
+  position: relative;
+  min-width: 0;
+  justify-self: end;
+}
+
+.ctaButton {
+  display: flex;
+  box-sizing: border-box;
+  height: 2.25rem;
+  align-items: center;
+  gap: 0.375rem;
+  padding-inline: 0.625rem;
+  border: 0;
+  border-radius: 10px;
+  background: var(--home-surface-ink);
+  box-shadow: var(--home-bevel-on-dark);
+  color: #fff;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: opacity 120ms ease;
+}
+
+.ctaButton:hover {
+  opacity: 0.88;
+}
+
+.ctaButton:focus-visible,
+.ctaMenuItem:focus-visible {
+  outline: 2px solid var(--openui-text-neutral-primary);
+  outline-offset: 2px;
+}
+
+.ctaArrow {
+  transition: transform 160ms ease;
+}
+
+.ctaArrow[data-open="true"] {
+  transform: rotate(90deg);
+}
+
+.ctaMenu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 60;
+  width: 22.5rem;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    opacity 0.18s ease,
+    visibility 0s linear 0.18s;
+}
+
+.ctaMenuOpen {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    opacity 0.18s ease,
+    visibility 0s;
+}
+
+.ctaMenuCard {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--openui-border-default);
+  border-radius: 12px;
+  background: var(--openui-foreground);
+  padding: 0.375rem;
+  box-shadow: var(--openui-shadow-l);
+}
+
+.ctaMenuItem {
+  display: flex;
+  width: 100%;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 8px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--openui-text-neutral-primary);
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.ctaMenuItem:hover {
+  background: var(--openui-highlight) !important;
+}
+
+.ctaMenuItemLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ctaMenuItemRunner {
+  color: var(--openui-text-neutral-primary);
+  font-weight: 600;
+}
+
+.ctaMenuItemIcon {
+  display: inline-flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: var(--openui-text-neutral-secondary);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.ctaMenuItem:hover .ctaMenuItemIcon,
+.ctaMenuItem:focus-visible .ctaMenuItemIcon {
+  opacity: 1;
 }
 
 .agentViewport {
@@ -371,42 +427,34 @@
   border: 0;
 }
 
-@media (max-width: 820px) {
-  .startLocallyButton {
-    display: none;
-  }
-}
-
 @media (max-width: 760px) {
   .header {
     padding: 8px 12px;
   }
 
   .headerRow {
-    flex-wrap: wrap;
-    gap: 6px 12px;
-  }
-
-  .backLink {
-    min-height: 36px;
+    grid-template-columns: 2.25rem minmax(0, 1fr) 2.25rem;
+    gap: 6px;
   }
 
   .modeControl {
-    width: 100%;
-    margin-left: 0;
+    width: min(100%, 15rem) !important;
   }
 
   .modeGroup {
-    display: flex !important;
     width: 100% !important;
   }
 
   .modeItem {
     min-width: 0;
-    min-height: 44px !important;
     flex: 1;
     justify-content: center;
-    padding-inline: 8px !important;
+    padding-inline: 4px !important;
+    font-size: 0.6875rem !important;
+  }
+
+  .ctaWrap {
+    display: none;
   }
 }
 
@@ -417,11 +465,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .startLocallyButton {
-    transition: none;
-  }
-
-  .startLocallyLabel {
+  .ctaArrow,
+  .ctaMenu,
+  .modeItem {
     transition: none;
   }
 

--- a/docs/app/chat/chat-page.module.css
+++ b/docs/app/chat/chat-page.module.css
@@ -104,133 +104,10 @@
   outline-offset: 1px;
 }
 
-.ctaWrap {
+.buildForFreeMenu {
   position: relative;
   min-width: 0;
   justify-self: end;
-}
-
-.ctaButton {
-  display: flex;
-  box-sizing: border-box;
-  height: 2.25rem;
-  align-items: center;
-  gap: 0.375rem;
-  padding-inline: 0.625rem;
-  border: 0;
-  border-radius: 10px;
-  background: var(--home-surface-ink);
-  box-shadow: var(--home-bevel-on-dark);
-  color: #fff;
-  font-family: "Inter", "Segoe UI", sans-serif;
-  font-size: 0.9375rem;
-  font-weight: 500;
-  line-height: 1;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: opacity 120ms ease;
-}
-
-.ctaButton:hover {
-  opacity: 0.88;
-}
-
-.ctaButton:focus-visible,
-.ctaMenuItem:focus-visible {
-  outline: 2px solid var(--openui-text-neutral-primary);
-  outline-offset: 2px;
-}
-
-.ctaArrow {
-  transition: transform 160ms ease;
-}
-
-.ctaArrow[data-open="true"] {
-  transform: rotate(90deg);
-}
-
-.ctaMenu {
-  position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  z-index: 60;
-  width: 22.5rem;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transition:
-    opacity 0.18s ease,
-    visibility 0s linear 0.18s;
-}
-
-.ctaMenuOpen {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-  transition:
-    opacity 0.18s ease,
-    visibility 0s;
-}
-
-.ctaMenuCard {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  border: 1px solid var(--openui-border-default);
-  border-radius: 12px;
-  background: var(--openui-foreground);
-  padding: 0.375rem;
-  box-shadow: var(--openui-shadow-l);
-}
-
-.ctaMenuItem {
-  display: flex;
-  width: 100%;
-  min-height: 40px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 8px 12px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--openui-text-neutral-primary);
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: background-color 120ms ease;
-}
-
-.ctaMenuItem:hover {
-  background: var(--openui-highlight) !important;
-}
-
-.ctaMenuItemLabel {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.ctaMenuItemRunner {
-  color: var(--openui-text-neutral-primary);
-  font-weight: 600;
-}
-
-.ctaMenuItemIcon {
-  display: inline-flex;
-  width: 1.5rem;
-  height: 1.5rem;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  color: var(--openui-text-neutral-secondary);
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.ctaMenuItem:hover .ctaMenuItemIcon,
-.ctaMenuItem:focus-visible .ctaMenuItemIcon {
-  opacity: 1;
 }
 
 .agentViewport {
@@ -453,7 +330,7 @@
     font-size: 0.6875rem !important;
   }
 
-  .ctaWrap {
+  .buildForFreeMenu {
     display: none;
   }
 }
@@ -465,8 +342,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ctaArrow,
-  .ctaMenu,
   .modeItem {
     transition: none;
   }

--- a/docs/app/compare/_components/agent-surfaces/cloud-agent-surface.tsx
+++ b/docs/app/compare/_components/agent-surfaces/cloud-agent-surface.tsx
@@ -11,9 +11,10 @@ import { ComparisonSurfaceWelcome } from "./comparison-surface-welcome";
 
 interface CloudAgentSurfaceProps {
   registry: ComparisonControllerRegistry;
+  themeMode: "light" | "dark";
 }
 
-export function CloudAgentSurface({ registry }: CloudAgentSurfaceProps) {
+export function CloudAgentSurface({ registry, themeMode }: CloudAgentSurfaceProps) {
   const [userId] = useState(getOrCreateCloudUserId);
   const [llm] = useState(createCloudChatLLM);
   const cloudFetch = useMemo<typeof fetch>(() => {
@@ -40,6 +41,7 @@ export function CloudAgentSurface({ registry }: CloudAgentSurfaceProps) {
         componentLibrary={chatLibrary}
         artifactRenderers={artifactRenderers}
         scrollVariant="always"
+        theme={{ mode: themeMode }}
       >
         <AgentInterface.Sidebar />
         <AgentInterface.Welcome>

--- a/docs/app/compare/_components/agent-surfaces/cloud-agent-surface.tsx
+++ b/docs/app/compare/_components/agent-surfaces/cloud-agent-surface.tsx
@@ -11,10 +11,9 @@ import { ComparisonSurfaceWelcome } from "./comparison-surface-welcome";
 
 interface CloudAgentSurfaceProps {
   registry: ComparisonControllerRegistry;
-  themeMode: "light" | "dark";
 }
 
-export function CloudAgentSurface({ registry, themeMode }: CloudAgentSurfaceProps) {
+export function CloudAgentSurface({ registry }: CloudAgentSurfaceProps) {
   const [userId] = useState(getOrCreateCloudUserId);
   const [llm] = useState(createCloudChatLLM);
   const cloudFetch = useMemo<typeof fetch>(() => {
@@ -41,7 +40,6 @@ export function CloudAgentSurface({ registry, themeMode }: CloudAgentSurfaceProp
         componentLibrary={chatLibrary}
         artifactRenderers={artifactRenderers}
         scrollVariant="always"
-        theme={{ mode: themeMode }}
       >
         <AgentInterface.Sidebar />
         <AgentInterface.Welcome>

--- a/docs/app/compare/_components/agent-surfaces/markdown-agent-surface.tsx
+++ b/docs/app/compare/_components/agent-surfaces/markdown-agent-surface.tsx
@@ -7,26 +7,16 @@ import { ComparisonSurfaceWelcome } from "./comparison-surface-welcome";
 import { useComparisonChatLLM } from "./use-comparison-chat-llm";
 
 interface MarkdownAgentSurfaceProps {
-  themeMode: "light" | "dark";
   onCreditsExhausted: () => void;
   registry: ComparisonControllerRegistry;
 }
 
-export function MarkdownAgentSurface({
-  themeMode,
-  onCreditsExhausted,
-  registry,
-}: MarkdownAgentSurfaceProps) {
+export function MarkdownAgentSurface({ onCreditsExhausted, registry }: MarkdownAgentSurfaceProps) {
   const llm = useComparisonChatLLM("markdown", onCreditsExhausted);
 
   return (
     <div className="chat-agent-surface" data-chat-mode="markdown">
-      <AgentInterface
-        llm={llm}
-        agentName="Markdown"
-        scrollVariant="always"
-        theme={{ mode: themeMode }}
-      >
+      <AgentInterface llm={llm} agentName="Markdown" scrollVariant="always">
         <AgentInterface.Sidebar />
         <AgentInterface.Welcome>
           <ComparisonSurfaceWelcome mode="markdown" />

--- a/docs/app/compare/_components/agent-surfaces/oss-agent-surface.tsx
+++ b/docs/app/compare/_components/agent-surfaces/oss-agent-surface.tsx
@@ -8,12 +8,11 @@ import { ComparisonSurfaceWelcome } from "./comparison-surface-welcome";
 import { useComparisonChatLLM } from "./use-comparison-chat-llm";
 
 interface OssAgentSurfaceProps {
-  themeMode: "light" | "dark";
   onCreditsExhausted: () => void;
   registry: ComparisonControllerRegistry;
 }
 
-export function OssAgentSurface({ themeMode, onCreditsExhausted, registry }: OssAgentSurfaceProps) {
+export function OssAgentSurface({ onCreditsExhausted, registry }: OssAgentSurfaceProps) {
   const llm = useComparisonChatLLM("openui", onCreditsExhausted);
 
   return (
@@ -23,7 +22,6 @@ export function OssAgentSurface({ themeMode, onCreditsExhausted, registry }: Oss
         componentLibrary={openuiChatLibrary}
         agentName="OpenUI OSS"
         scrollVariant="always"
-        theme={{ mode: themeMode }}
       >
         <AgentInterface.Sidebar />
         <AgentInterface.Welcome>

--- a/docs/app/compare/_components/chat-page-header.tsx
+++ b/docs/app/compare/_components/chat-page-header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ClipboardCommandButton } from "@/app/(home)/components/Button/Button";
 import { GitHubButton } from "@/app/(home)/components/GitHubButton/GitHubButton";
+import { BuildForFreeMenu } from "@/app/_components/build-for-free-menu";
+import { useHeaderDropdown } from "@/app/_components/use-header-dropdown";
 import trayStyles from "@/components/site-marketing-header.module.css";
 import {
   ArrowLeft,
@@ -17,19 +18,11 @@ import {
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import Link from "next/link";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import styles from "../chat-page.module.css";
 import { getComparisonPair, type ComparisonPair } from "./chat-types";
 import type { ComparisonMode } from "./comparison-mode-controller";
 import { useHasMounted } from "./use-has-mounted";
-
-// Same runner set and order as the homepage hero's command dropdown.
-const CLI_COMMANDS = [
-  { id: "pnpm", runner: "pnpx", command: "pnpx @openuidev/cli@latest create" },
-  { id: "bun", runner: "bunx", command: "bunx @openuidev/cli@latest create" },
-  { id: "yarn", runner: "yarn dlx", command: "yarn dlx @openuidev/cli@latest create" },
-  { id: "npm", runner: "npx", command: "npx @openuidev/cli@latest create" },
-] as const;
 
 // Display titles for the pair options, mirroring the panel headings: mode name
 // plus a chip for the OpenUI flavor. aria-labels keep the canonical names.
@@ -138,62 +131,6 @@ function PairTitle({ pair }: { pair: ComparisonPair }) {
   );
 }
 
-// Shared open/close behavior for the header dropdowns: hover opens (mouse only,
-// with a grace delay so the pointer can cross into the menu), click toggles,
-// outside pointer-down and Escape close.
-function useHeaderDropdown() {
-  const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
-    };
-  }, []);
-
-  const cancelScheduledClose = () => {
-    if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
-    closeTimeoutRef.current = null;
-  };
-
-  const handleHoverOpen = (event: React.PointerEvent) => {
-    if (event.pointerType !== "mouse") return;
-    cancelScheduledClose();
-    setOpen(true);
-  };
-
-  const handleHoverClose = (event: React.PointerEvent) => {
-    if (event.pointerType !== "mouse") return;
-    cancelScheduledClose();
-    closeTimeoutRef.current = setTimeout(() => setOpen(false), 160);
-  };
-
-  useEffect(() => {
-    if (!open) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!wrapRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-        triggerRef.current?.focus();
-      }
-    };
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  return { open, setOpen, wrapRef, triggerRef, handleHoverOpen, handleHoverClose };
-}
-
 // Menu display order, independent of the default comparison pair.
 const PAIR_MENU_ORDER: readonly ComparisonPair[] = ["markdown-oss", "markdown-cloud", "oss-cloud"];
 const PAIR_MENU_OPTIONS = PAIR_MENU_ORDER.map((pair) => getComparisonPair(pair));
@@ -257,61 +194,6 @@ function PairSwitcher({
                 </span>
               </span>
             </button>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function BuildForFreeMenu() {
-  const { open, setOpen, wrapRef, triggerRef, handleHoverOpen, handleHoverClose } =
-    useHeaderDropdown();
-
-  return (
-    <div
-      className={styles.ctaWrap}
-      ref={wrapRef}
-      onPointerEnter={handleHoverOpen}
-      onPointerLeave={handleHoverClose}
-    >
-      <button
-        type="button"
-        ref={triggerRef}
-        className={styles.ctaButton}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span>Build for free</span>
-        <ArrowRight
-          size={15}
-          strokeWidth={2}
-          aria-hidden="true"
-          className={styles.ctaChevron}
-          data-open={open}
-        />
-      </button>
-
-      <div className={`${styles.ctaMenu} ${open ? styles.ctaMenuOpen : ""}`.trim()}>
-        <div
-          className={styles.ctaMenuCard}
-          role="menu"
-          aria-label="Copy the setup command for a package manager"
-        >
-          {CLI_COMMANDS.map((item) => (
-            <ClipboardCommandButton
-              key={item.id}
-              command={item.command}
-              className={styles.ctaMenuItem}
-              iconContainerClassName={styles.ctaMenuItemIcon}
-              copyIconColor="currentColor"
-            >
-              <span className={styles.ctaMenuItemLabel}>
-                <span className={styles.ctaMenuItemRunner}>{item.runner}</span>
-                {item.command.slice(item.runner.length)}
-              </span>
-            </ClipboardCommandButton>
           ))}
         </div>
       </div>
@@ -541,7 +423,7 @@ export function ChatPageHeader({
 
         {rightHeading}
 
-        <BuildForFreeMenu />
+        <BuildForFreeMenu className={styles.buildForFreeMenu} />
 
         <MobileMenu pair={pair} onPairChange={onPairChange} onReset={onReset} />
       </div>

--- a/docs/app/compare/_components/chat-page-header.tsx
+++ b/docs/app/compare/_components/chat-page-header.tsx
@@ -423,7 +423,7 @@ export function ChatPageHeader({
 
         {rightHeading}
 
-        <BuildForFreeMenu className={styles.buildForFreeMenu} />
+        <BuildForFreeMenu analyticsSource="compare_navbar" className={styles.buildForFreeMenu} />
 
         <MobileMenu pair={pair} onPairChange={onPairChange} onReset={onReset} />
       </div>

--- a/docs/app/compare/_components/compare-page-client.tsx
+++ b/docs/app/compare/_components/compare-page-client.tsx
@@ -298,7 +298,9 @@ export function ComparePageClient({
                         registry={registry}
                       />
                     )}
-                    {mode === "cloud" && <CloudAgentSurface registry={registry} />}
+                    {mode === "cloud" && (
+                      <CloudAgentSurface registry={registry} themeMode={themeMode} />
+                    )}
                   </SurfaceErrorBoundary>
                   {!snapshot.isReady && !snapshot.threadError && !unavailableModes.has(mode) ? (
                     <div className={styles.panelLoadingOverlay}>

--- a/docs/app/compare/_components/compare-page-client.tsx
+++ b/docs/app/compare/_components/compare-page-client.tsx
@@ -2,7 +2,6 @@
 
 import { DemoCreditsDialog } from "@/components/DemoCreditsDialog";
 import { OPENUI_CLOUD_UNAVAILABLE_MESSAGE } from "@/lib/openui-cloud/errors";
-import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
 import {
   Component,
@@ -77,7 +76,6 @@ interface ComparePageClientProps {
 export function ComparePageClient({
   initialPair = DEFAULT_COMPARISON_PAIR,
 }: ComparePageClientProps) {
-  const { resolvedTheme } = useTheme();
   const [pair, setPair] = useState<ComparisonPair>(initialPair);
   const selectedPair = getComparisonPair(pair);
   const [mobileMode, setMobileMode] = useState<(typeof ALL_MODES)[number]>(selectedPair.modes[0]);
@@ -86,7 +84,6 @@ export function ComparePageClient({
   const [creditsDialogOpen, setCreditsDialogOpen] = useState(false);
   const [unavailableModes, setUnavailableModes] = useState<Set<ComparisonMode>>(() => new Set());
   const [registry] = useState(createComparisonControllerRegistry);
-  const themeMode = resolvedTheme === "dark" ? "dark" : "light";
 
   const markdown = useComparisonModeSnapshot(registry, "markdown");
   const oss = useComparisonModeSnapshot(registry, "oss");
@@ -286,21 +283,17 @@ export function ComparePageClient({
                   >
                     {mode === "markdown" && (
                       <MarkdownAgentSurface
-                        themeMode={themeMode}
                         onCreditsExhausted={handleCreditsExhausted}
                         registry={registry}
                       />
                     )}
                     {mode === "oss" && (
                       <OssAgentSurface
-                        themeMode={themeMode}
                         onCreditsExhausted={handleCreditsExhausted}
                         registry={registry}
                       />
                     )}
-                    {mode === "cloud" && (
-                      <CloudAgentSurface registry={registry} themeMode={themeMode} />
-                    )}
+                    {mode === "cloud" && <CloudAgentSurface registry={registry} />}
                   </SurfaceErrorBoundary>
                   {!snapshot.isReady && !snapshot.threadError && !unavailableModes.has(mode) ? (
                     <div className={styles.panelLoadingOverlay}>

--- a/docs/app/compare/chat-page.module.css
+++ b/docs/app/compare/chat-page.module.css
@@ -9,13 +9,7 @@
   background: var(--openui-background);
 }
 
-/* The shared CTA inherits these homepage surface tokens because this page
-   renders outside .homeTheme (same trick as GitHubButton.module.css
-   .glowBtnCompact). */
 .header {
-  --home-surface-ink: #0a0a0a;
-  --home-bevel-on-dark:
-    inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
   position: relative;
   z-index: 5;
   flex: none;

--- a/docs/app/compare/chat-page.module.css
+++ b/docs/app/compare/chat-page.module.css
@@ -9,15 +9,11 @@
   background: var(--openui-background);
 }
 
-/* The --home-* surface tokens are re-declared locally because the chat page
+/* The shared CTA inherits these homepage surface tokens because this page
    renders outside .homeTheme (same trick as GitHubButton.module.css
-   .glowBtnCompact). Declared on the header so the back button, pair switcher,
-   and CTA dropdown all share them. */
+   .glowBtnCompact). */
 .header {
   --home-surface-ink: #0a0a0a;
-  --home-surface-raised: #f7f7f8;
-  --home-bevel:
-    inset 0 2px 1px -0.5px rgba(255, 255, 255, 1), inset 0 -3px 6px -1px rgba(0, 0, 0, 0.1);
   --home-bevel-on-dark:
     inset 0 7px 12px -6px rgba(255, 255, 255, 0.16), inset 0 -5px 8px -2px rgba(0, 0, 0, 0.6);
   position: relative;
@@ -81,8 +77,7 @@
   background: color-mix(in srgb, var(--openui-foreground) 96%, #fff);
 }
 
-.trayChevron,
-.ctaChevron {
+.trayChevron {
   transition: transform 160ms ease;
 }
 
@@ -90,8 +85,7 @@
   transform: rotate(180deg);
 }
 
-.viewComparisonChip:focus-visible,
-.ctaMenuItem:focus-visible {
+.viewComparisonChip:focus-visible {
   outline: 2px solid var(--openui-border-accent-emphasis);
   outline-offset: -2px;
 }
@@ -207,8 +201,7 @@
   transition: opacity 120ms ease;
 }
 
-.comparisonCta:hover,
-.ctaButton:hover {
+.comparisonCta:hover {
   opacity: 0.88;
 }
 
@@ -273,7 +266,7 @@
   justify-self: start;
 }
 
-.headerRow > .ctaWrap {
+.headerRow > .buildForFreeMenu {
   position: absolute;
   right: 8px;
   justify-self: end;
@@ -299,7 +292,6 @@
 .backLink:hover,
 .mobileMenuButton:hover,
 .mobileMenuButton[aria-expanded="true"],
-.ctaMenuItem:hover,
 .resetButton:hover,
 .themeToggle:hover {
   background: var(--openui-highlight);
@@ -317,47 +309,6 @@
 .themeToggle:focus-visible {
   outline: 2px solid var(--openui-border-accent-emphasis);
   outline-offset: 2px;
-}
-
-/* "Build for free" dropdown — same component recipe as the homepage hero's
-   command dropdown (HeroSection.module.css .command*). The --home-* surface
-   tokens are re-declared locally because the chat page renders outside
-   .homeTheme (same trick as GitHubButton.module.css .glowBtnCompact). */
-.ctaWrap {
-  position: relative;
-  flex: none;
-}
-
-/* Text button. */
-.ctaButton {
-  display: flex;
-  box-sizing: border-box;
-  height: 2.25rem;
-  align-items: center;
-  gap: 0.375rem;
-  padding-inline: 0.625rem;
-  border: 0;
-  border-radius: 10px;
-  background: var(--home-surface-ink);
-  box-shadow: var(--home-bevel-on-dark);
-  color: #fff;
-  font-family: "Inter", "Segoe UI", sans-serif;
-  font-size: 0.9375rem;
-  font-weight: 500;
-  line-height: 1;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: opacity 120ms ease;
-}
-
-.ctaButton:focus-visible {
-  outline: 2px solid var(--openui-text-neutral-primary);
-  outline-offset: 2px;
-}
-
-/* Right arrow tips down while the menu is open. */
-.ctaChevron[data-open="true"] {
-  transform: rotate(90deg);
 }
 
 /* Blurs the page beneath the header while a menu is open. Negative z-index
@@ -486,7 +437,6 @@
 }
 
 /* Fade-only reveal, as on the hero. */
-.ctaMenu,
 .pairMenu {
   position: absolute;
   top: calc(100% + 8px);
@@ -499,13 +449,7 @@
     visibility 0s linear 0.18s;
 }
 
-.ctaMenu {
-  right: 0;
-  width: 22.5rem;
-}
-
 /* Shared dropdown card recipe. */
-.ctaMenuCard,
 .pairMenuCard {
   display: flex;
   flex-direction: column;
@@ -513,58 +457,6 @@
   border-radius: 12px;
   background: var(--openui-foreground);
   box-shadow: var(--openui-shadow-l);
-}
-
-.ctaMenuCard {
-  gap: 2px;
-  padding: 0.375rem;
-}
-
-.ctaMenuItem {
-  display: flex;
-  width: 100%;
-  min-height: 40px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 8px 12px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--openui-text-neutral-primary);
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: background-color 120ms ease;
-}
-
-.ctaMenuItemLabel {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.ctaMenuItemRunner {
-  font-weight: 600;
-  color: var(--openui-text-neutral-primary);
-}
-
-/* Copy icon: space reserved, revealed on row hover. */
-.ctaMenuItemIcon {
-  display: inline-flex;
-  width: 1.5rem;
-  height: 1.5rem;
-  flex-shrink: 0;
-  align-items: center;
-  justify-content: center;
-  color: var(--openui-text-neutral-secondary);
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-
-.ctaMenuItem:hover .ctaMenuItemIcon,
-.ctaMenuItem:focus-visible .ctaMenuItemIcon {
-  opacity: 1;
 }
 
 /* Pair switcher dropdown: absolutely centered on the screen, out of the grid,
@@ -612,7 +504,6 @@
   transform: translateX(-50%);
 }
 
-.ctaMenuOpen,
 .pairMenuOpen {
   opacity: 1;
   visibility: visible;
@@ -1150,7 +1041,7 @@
 }
 
 @media (max-width: 1180px) {
-  .ctaWrap {
+  .buildForFreeMenu {
     display: none;
   }
 }
@@ -1373,10 +1264,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .ctaButton,
-  .ctaChevron,
-  .ctaMenu,
-  .ctaMenuItem,
   .menuOverlay,
   .comparisonTray,
   .comparisonTrayCard,

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -87,7 +87,9 @@ export default function Layout({ children }: LayoutProps<"/">) {
     <html lang="en" className={`${inter.className} ${geistMono.variable}`} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
         <PHProvider>
-          <RootProvider theme={{ defaultTheme: "light" }}>{children}</RootProvider>
+          <RootProvider theme={{ defaultTheme: "system", enableSystem: true }}>
+            {children}
+          </RootProvider>
         </PHProvider>
         <Script
           src="https://www.googletagmanager.com/gtag/js?id=G-MZ0TZ82NM2"

--- a/docs/components/website-theme-provider.tsx
+++ b/docs/components/website-theme-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ThemeProvider } from "@openuidev/react-ui/ThemeProvider";
+import { ThemeProvider } from "@openuidev/react-ui";
 import { useTheme } from "next-themes";
 import { useEffect, type ReactNode } from "react";
 


### PR DESCRIPTION
## Summary

- align the Chat header structure and sizing with the Compare navbar
- share one **Build for free** command menu across Chat and Compare
- restyle the OpenUI OSS / OpenUI Cloud selector so only the active tab has a raised surface
- follow the system light/dark preference by default while preserving explicit user choices
- invert the shared CTA correctly: dark in light mode and light in dark mode
- keep the full mode labels while hiding the desktop CTA on mobile
- propagate the resolved theme into Compare's Cloud panel

## Why

The Chat navbar used a different layout and interaction pattern from Compare, duplicated the setup-command menu, and defaulted to a fixed light theme. Compare's Cloud surface also omitted its theme mode, allowing its default light tokens to override the page in dark mode.

## Impact

Chat and Compare now share the same setup CTA and theme behavior. The navbar, mode selector, command menu, sidebar, and agent surfaces resolve consistently in light and dark modes. The mobile Chat header remains compact without dropping the full mode names.

## Screenshots

### Chat

| Light | Dark |
| --- | --- |
| ![Chat in light mode](https://raw.githubusercontent.com/zahlekhan/openui/codex/pr-assets-chat-navbar-868/pr-assets/openui-pr868-chat-light.jpg) | ![Chat in dark mode](https://raw.githubusercontent.com/zahlekhan/openui/codex/pr-assets-chat-navbar-868/pr-assets/openui-pr868-chat-dark.jpg) |

### Compare

| Light | Dark |
| --- | --- |
| ![Compare in light mode](https://raw.githubusercontent.com/zahlekhan/openui/codex/pr-assets-chat-navbar-868/pr-assets/openui-pr868-compare-light.jpg) | ![Compare in dark mode](https://raw.githubusercontent.com/zahlekhan/openui/codex/pr-assets-chat-navbar-868/pr-assets/openui-pr868-compare-dark.jpg) |

## Validation

- `pnpm types:check`
- targeted ESLint for the shared header and Compare theme changes
- targeted Prettier checks
- `git diff --check`
- browser verification of Chat and Compare at 1440×900 in light and dark modes
