### PR TITLE
Test CLI compatibility across runtimes

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -5,18 +5,12 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/cli-e2e.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
       - "packages/openui-cli/**"
       - "tsconfig.json"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/cli-e2e.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
       - "packages/openui-cli/**"
       - "tsconfig.json"
 
@@ -36,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
@@ -68,45 +62,33 @@ jobs:
           - openui-cloud
           - openui-self-hosted
         configuration:
-          # Exercise every supported Node/package-manager major on Linux.
+          # Keep one npm and pnpm canary for the legacy Node.js line.
           - ubuntu-node20-npm10
-          - ubuntu-node20-npm11
           - ubuntu-node20-pnpm9
-          - ubuntu-node20-pnpm10
+          # Exercise established and current package-manager majors on Linux.
           - ubuntu-node22-npm10
           - ubuntu-node22-npm11
-          - ubuntu-node22-pnpm9
           - ubuntu-node22-pnpm10
-          - ubuntu-node24-npm10
+          - ubuntu-node22-pnpm11
           - ubuntu-node24-npm11
-          - ubuntu-node24-pnpm9
           - ubuntu-node24-pnpm10
+          - ubuntu-node24-pnpm11
           # Keep the non-Linux jobs focused on the current package-manager majors.
-          - macos-node22-npm11
-          - macos-node22-pnpm10
-          - windows-node22-npm11
-          - windows-node22-pnpm10
+          - macos-node24-npm11
+          - macos-node24-pnpm11
+          - windows-node24-npm11
+          - windows-node24-pnpm11
         include:
           - configuration: ubuntu-node20-npm10
             os: ubuntu-latest
             node-version: 20
             package-manager: npm
             package-manager-version: "10"
-          - configuration: ubuntu-node20-npm11
-            os: ubuntu-latest
-            node-version: 20
-            package-manager: npm
-            package-manager-version: "11"
           - configuration: ubuntu-node20-pnpm9
             os: ubuntu-latest
             node-version: 20
             package-manager: pnpm
             package-manager-version: "9"
-          - configuration: ubuntu-node20-pnpm10
-            os: ubuntu-latest
-            node-version: 20
-            package-manager: pnpm
-            package-manager-version: "10"
           - configuration: ubuntu-node22-npm10
             os: ubuntu-latest
             node-version: 22
@@ -117,56 +99,51 @@ jobs:
             node-version: 22
             package-manager: npm
             package-manager-version: "11"
-          - configuration: ubuntu-node22-pnpm9
-            os: ubuntu-latest
-            node-version: 22
-            package-manager: pnpm
-            package-manager-version: "9"
           - configuration: ubuntu-node22-pnpm10
             os: ubuntu-latest
             node-version: 22
             package-manager: pnpm
             package-manager-version: "10"
-          - configuration: ubuntu-node24-npm10
+          - configuration: ubuntu-node22-pnpm11
             os: ubuntu-latest
-            node-version: 24
-            package-manager: npm
-            package-manager-version: "10"
+            node-version: 22
+            package-manager: pnpm
+            package-manager-version: "11"
           - configuration: ubuntu-node24-npm11
             os: ubuntu-latest
             node-version: 24
             package-manager: npm
             package-manager-version: "11"
-          - configuration: ubuntu-node24-pnpm9
-            os: ubuntu-latest
-            node-version: 24
-            package-manager: pnpm
-            package-manager-version: "9"
           - configuration: ubuntu-node24-pnpm10
             os: ubuntu-latest
             node-version: 24
             package-manager: pnpm
             package-manager-version: "10"
-          - configuration: macos-node22-npm11
+          - configuration: ubuntu-node24-pnpm11
+            os: ubuntu-latest
+            node-version: 24
+            package-manager: pnpm
+            package-manager-version: "11"
+          - configuration: macos-node24-npm11
             os: macos-latest
-            node-version: 22
+            node-version: 24
             package-manager: npm
             package-manager-version: "11"
-          - configuration: macos-node22-pnpm10
+          - configuration: macos-node24-pnpm11
             os: macos-latest
-            node-version: 22
+            node-version: 24
             package-manager: pnpm
-            package-manager-version: "10"
-          - configuration: windows-node22-npm11
+            package-manager-version: "11"
+          - configuration: windows-node24-npm11
             os: windows-latest
-            node-version: 22
+            node-version: 24
             package-manager: npm
             package-manager-version: "11"
-          - configuration: windows-node22-pnpm10
+          - configuration: windows-node24-pnpm11
             os: windows-latest
-            node-version: 22
+            node-version: 24
             package-manager: pnpm
-            package-manager-version: "10"
+            package-manager-version: "11"
 
     steps:
       - uses: actions/setup-node@v6

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -5,12 +5,18 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/cli-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "packages/openui-cli/**"
       - "tsconfig.json"
   pull_request:
     branches: [main]
     paths:
       - ".github/workflows/cli-e2e.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "packages/openui-cli/**"
       - "tsconfig.json"
 
@@ -52,7 +58,7 @@ jobs:
           retention-days: 1
 
   cli-e2e:
-    name: ${{ matrix.template }} (${{ matrix.package-manager }}, ${{ matrix.os }}, Node ${{ matrix.node-version }})
+    name: ${{ matrix.template }} (${{ matrix.package-manager }}@${{ matrix.package-manager-version }}, ${{ matrix.os }}, Node ${{ matrix.node-version }})
     needs: package-cli
     runs-on: ${{ matrix.os }}
     strategy:
@@ -61,41 +67,132 @@ jobs:
         template:
           - openui-cloud
           - openui-self-hosted
-        package-manager:
-          - npm
-          - pnpm
-        environment:
-          - ubuntu-node20
-          - ubuntu-node22
-          - ubuntu-node24
-          - macos-node22
-          - windows-node22
+        configuration:
+          # Exercise every supported Node/package-manager major on Linux.
+          - ubuntu-node20-npm10
+          - ubuntu-node20-npm11
+          - ubuntu-node20-pnpm9
+          - ubuntu-node20-pnpm10
+          - ubuntu-node22-npm10
+          - ubuntu-node22-npm11
+          - ubuntu-node22-pnpm9
+          - ubuntu-node22-pnpm10
+          - ubuntu-node24-npm10
+          - ubuntu-node24-npm11
+          - ubuntu-node24-pnpm9
+          - ubuntu-node24-pnpm10
+          # Keep the non-Linux jobs focused on the current package-manager majors.
+          - macos-node22-npm11
+          - macos-node22-pnpm10
+          - windows-node22-npm11
+          - windows-node22-pnpm10
         include:
-          - environment: ubuntu-node20
+          - configuration: ubuntu-node20-npm10
             os: ubuntu-latest
             node-version: 20
-          - environment: ubuntu-node22
+            package-manager: npm
+            package-manager-version: "10"
+          - configuration: ubuntu-node20-npm11
+            os: ubuntu-latest
+            node-version: 20
+            package-manager: npm
+            package-manager-version: "11"
+          - configuration: ubuntu-node20-pnpm9
+            os: ubuntu-latest
+            node-version: 20
+            package-manager: pnpm
+            package-manager-version: "9"
+          - configuration: ubuntu-node20-pnpm10
+            os: ubuntu-latest
+            node-version: 20
+            package-manager: pnpm
+            package-manager-version: "10"
+          - configuration: ubuntu-node22-npm10
             os: ubuntu-latest
             node-version: 22
-          - environment: ubuntu-node24
+            package-manager: npm
+            package-manager-version: "10"
+          - configuration: ubuntu-node22-npm11
+            os: ubuntu-latest
+            node-version: 22
+            package-manager: npm
+            package-manager-version: "11"
+          - configuration: ubuntu-node22-pnpm9
+            os: ubuntu-latest
+            node-version: 22
+            package-manager: pnpm
+            package-manager-version: "9"
+          - configuration: ubuntu-node22-pnpm10
+            os: ubuntu-latest
+            node-version: 22
+            package-manager: pnpm
+            package-manager-version: "10"
+          - configuration: ubuntu-node24-npm10
             os: ubuntu-latest
             node-version: 24
-          - environment: macos-node22
+            package-manager: npm
+            package-manager-version: "10"
+          - configuration: ubuntu-node24-npm11
+            os: ubuntu-latest
+            node-version: 24
+            package-manager: npm
+            package-manager-version: "11"
+          - configuration: ubuntu-node24-pnpm9
+            os: ubuntu-latest
+            node-version: 24
+            package-manager: pnpm
+            package-manager-version: "9"
+          - configuration: ubuntu-node24-pnpm10
+            os: ubuntu-latest
+            node-version: 24
+            package-manager: pnpm
+            package-manager-version: "10"
+          - configuration: macos-node22-npm11
             os: macos-latest
             node-version: 22
-          - environment: windows-node22
+            package-manager: npm
+            package-manager-version: "11"
+          - configuration: macos-node22-pnpm10
+            os: macos-latest
+            node-version: 22
+            package-manager: pnpm
+            package-manager-version: "10"
+          - configuration: windows-node22-npm11
             os: windows-latest
             node-version: 22
+            package-manager: npm
+            package-manager-version: "11"
+          - configuration: windows-node22-pnpm10
+            os: windows-latest
+            node-version: 22
+            package-manager: pnpm
+            package-manager-version: "10"
 
     steps:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Set up npm ${{ matrix.package-manager-version }}
+        if: matrix.package-manager == 'npm'
+        run: npm install --global npm@${{ matrix.package-manager-version }}
+
       - uses: pnpm/action-setup@v6
         if: matrix.package-manager == 'pnpm'
         with:
-          version: 10.33.0
+          version: ${{ matrix.package-manager-version }}
+
+      - name: Verify package manager version
+        shell: bash
+        env:
+          PACKAGE_MANAGER: ${{ matrix.package-manager }}
+          EXPECTED_MAJOR: ${{ matrix.package-manager-version }}
+        run: |
+          actual_version="$("${PACKAGE_MANAGER}" --version)"
+          if [[ "${actual_version}" != "${EXPECTED_MAJOR}".* ]]; then
+            echo "Expected ${PACKAGE_MANAGER} ${EXPECTED_MAJOR}.x, got ${actual_version}" >&2
+            exit 1
+          fi
 
       - uses: actions/download-artifact@v8
         with:

--- a/packages/openui-cli/src/templates/openui-self-hosted/package.json
+++ b/packages/openui-cli/src/templates/openui-self-hosted/package.json
@@ -2,6 +2,12 @@
   "name": "openui-self-hosted",
   "version": "0.1.1",
   "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp",
+      "unrs-resolver"
+    ]
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
+++ b/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
@@ -1,6 +1,13 @@
 packages:
   - "."
 
+# Allow native build scripts so `pnpm install` never stops at (or nags about)
+# approve-builds. pnpm reads this from a different place per major version, so
+# the same list appears three times: package.json "pnpm" field (<=10.13),
+# onlyBuiltDependencies here (10.14-10.x), allowBuilds here (>=11).
+onlyBuiltDependencies:
+  - sharp
+  - unrs-resolver
 allowBuilds:
-  sharp@0.34.5: true
-  unrs-resolver@1.12.2: true
+  sharp: true
+  unrs-resolver: true

--- a/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
+++ b/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+packages:
+  - "."
+
+allowBuilds:
+  sharp@0.34.5: true
+  unrs-resolver@1.12.2: true


### PR DESCRIPTION
## Summary

- expand CLI end-to-end coverage to Node.js 20, 22, and 24
- test npm 10/11 and pnpm 10/11 across Ubuntu, macOS, and Windows
- retain one pnpm 9 canary for legacy Node.js 20 compatibility
- verify the selected package-manager major before scaffolding and building both CLI templates
- build the shared CLI artifact on Node.js 24
- keep workflow triggers focused on CLI and workflow changes
- allow the `sharp` and `unrs-resolver` native build scripts across pnpm's legacy and current configuration locations

## Why

The existing workflow covered both package managers and all three operating systems, but it pinned a single pnpm release and relied on the npm version bundled with Node.js. This matrix makes package-manager compatibility explicit, prioritizes established and current majors, and limits legacy and non-Linux combinations to control CI cost.

The self-hosted template requires the native install scripts from sharp and unrs-resolver. Their build approval is declared in `package.json#pnpm.onlyBuiltDependencies`, `pnpm-workspace.yaml#onlyBuiltDependencies`, and `pnpm-workspace.yaml#allowBuilds` so the template works across pnpm majors.

## Validation

- `pnpm exec prettier --check .github/workflows/cli-e2e.yml`
- YAML/matrix validation: 26 jobs across two templates and 13 configurations
- `git diff --check`
- `pnpm --filter @openuidev/cli build`
- isolated self-hosted template install with pnpm 9.15.9
- isolated self-hosted template install with pnpm 10.34.5
- isolated self-hosted template install and production build with pnpm 11.17.0
- packed CLI tarball contains the self-hosted `pnpm-workspace.yaml`
