### PR TITLE
Add social metadata to demo pages

### DIFF
--- a/docs/app/chat/page.tsx
+++ b/docs/app/chat/page.tsx
@@ -1,13 +1,12 @@
-import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/page-metadata";
 import { ChatPageClient } from "./_components/chat-page-client";
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
+  pathname: "/chat",
   title: "OpenUI Chat",
   description: "Try OpenUI OSS and OpenUI Cloud in a live generative UI chat.",
-  alternates: {
-    canonical: "/chat",
-  },
-};
+  imageAlt: "OpenUI Chat preview",
+});
 
 export default function ChatPage() {
   return <ChatPageClient />;

--- a/docs/app/compare/page.tsx
+++ b/docs/app/compare/page.tsx
@@ -1,14 +1,13 @@
-import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/page-metadata";
 import { parseComparisonPair } from "./_components/chat-types";
 import { ComparePageClient } from "./_components/compare-page-client";
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
+  pathname: "/compare",
   title: "Compare OpenUI",
   description: "Compare rendered Markdown, OpenUI OSS, and OpenUI Cloud side by side.",
-  alternates: {
-    canonical: "/compare",
-  },
-};
+  imageAlt: "OpenUI comparison preview",
+});
 
 export default async function ComparePage(props: PageProps<"/compare">) {
   const searchParams = await props.searchParams;

--- a/docs/app/demo/github/layout.tsx
+++ b/docs/app/demo/github/layout.tsx
@@ -1,6 +1,14 @@
 import { WebsiteThemeProvider } from "@/components/website-theme-provider";
+import { createPageMetadata } from "@/lib/page-metadata";
 import type { ReactNode } from "react";
 import "./layout.css";
+
+export const metadata = createPageMetadata({
+  pathname: "/demo/github",
+  title: "OpenUI GitHub Dashboard Demo",
+  description: "Generate interactive dashboards from live GitHub data with OpenUI.",
+  imageAlt: "OpenUI GitHub dashboard preview",
+});
 
 export default function DemoGitHubLayout({ children }: { children: ReactNode }) {
   return <WebsiteThemeProvider>{children}</WebsiteThemeProvider>;

--- a/docs/app/demos/layout.tsx
+++ b/docs/app/demos/layout.tsx
@@ -1,13 +1,14 @@
 import { WebsiteThemeProvider } from "@/components/website-theme-provider";
-import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/page-metadata";
 import type { ReactNode } from "react";
 import "./layout.css";
 
-export const metadata: Metadata = {
-  alternates: {
-    canonical: "/demos",
-  },
-};
+export const metadata = createPageMetadata({
+  pathname: "/demos",
+  title: "OpenUI vs JSON",
+  description: "See how OpenUI runs 3x faster with 67% fewer tokens than JSON.",
+  imageAlt: "OpenUI versus JSON preview",
+});
 
 export default function DemosLayout({ children }: { children: ReactNode }) {
   return <WebsiteThemeProvider>{children}</WebsiteThemeProvider>;

--- a/docs/lib/page-metadata.ts
+++ b/docs/lib/page-metadata.ts
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+
+const SOCIAL_IMAGE = "/meta-image.png?v=20260725-1708";
+
+type PageMetadataOptions = {
+  pathname: string;
+  title: string;
+  description: string;
+  imageAlt: string;
+};
+
+export function createPageMetadata({
+  pathname,
+  title,
+  description,
+  imageAlt,
+}: PageMetadataOptions): Metadata {
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: pathname,
+    },
+    openGraph: {
+      title,
+      description,
+      url: pathname,
+      type: "website",
+      images: [
+        {
+          url: SOCIAL_IMAGE,
+          width: 1800,
+          height: 942,
+          alt: imageAlt,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [SOCIAL_IMAGE],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a shared page-metadata helper using the refreshed 1800×942 OpenUI social image
- add route-specific canonical, Open Graph, and Twitter card metadata to `/compare`, `/chat`, `/demos`, and `/demo/github`
- preserve the existing titles and descriptions where present, and add matching metadata for the two demo routes that did not have it

## Why

The demo destinations had inconsistent metadata coverage: `/compare` and `/chat` only defined basic page metadata, `/demos` only defined its canonical URL, and `/demo/github` did not define route metadata. As a result, social previews could inherit generic site-level values instead of identifying the destination being shared.

## Impact

Links to each demo now resolve to the correct canonical URL and render a route-specific title and description with a consistent Open Graph/Twitter large-card preview.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- Prettier check for all five changed files
- rendered all four routes locally and verified title, canonical, Open Graph, image dimensions, and Twitter tags
