### PR TITLE
Use navbar previews for demo metadata

### DIFF
--- a/docs/app/chat/page.tsx
+++ b/docs/app/chat/page.tsx
@@ -5,6 +5,7 @@ export const metadata = createPageMetadata({
   pathname: "/chat",
   title: "OpenUI Chat",
   description: "Try OpenUI OSS and OpenUI Cloud in a live generative UI chat.",
+  image: "/nav/chat-light.webp",
   imageAlt: "OpenUI Chat preview",
 });
 

--- a/docs/app/compare/page.tsx
+++ b/docs/app/compare/page.tsx
@@ -6,6 +6,7 @@ export const metadata = createPageMetadata({
   pathname: "/compare",
   title: "Compare OpenUI",
   description: "Compare rendered Markdown, OpenUI OSS, and OpenUI Cloud side by side.",
+  image: "/nav/compare-light.webp",
   imageAlt: "OpenUI comparison preview",
 });
 

--- a/docs/app/demo/github/layout.tsx
+++ b/docs/app/demo/github/layout.tsx
@@ -7,6 +7,7 @@ export const metadata = createPageMetadata({
   pathname: "/demo/github",
   title: "OpenUI GitHub Dashboard Demo",
   description: "Generate interactive dashboards from live GitHub data with OpenUI.",
+  image: "/nav/dashboard-light.webp",
   imageAlt: "OpenUI GitHub dashboard preview",
 });
 

--- a/docs/app/demos/layout.tsx
+++ b/docs/app/demos/layout.tsx
@@ -7,6 +7,7 @@ export const metadata = createPageMetadata({
   pathname: "/demos",
   title: "OpenUI vs JSON",
   description: "See how OpenUI runs 3x faster with 67% fewer tokens than JSON.",
+  image: "/nav/vsjson-light.webp",
   imageAlt: "OpenUI versus JSON preview",
 });
 

--- a/docs/lib/page-metadata.ts
+++ b/docs/lib/page-metadata.ts
@@ -1,11 +1,10 @@
 import type { Metadata } from "next";
 
-const SOCIAL_IMAGE = "/meta-image.png?v=20260725-1708";
-
 type PageMetadataOptions = {
   pathname: string;
   title: string;
   description: string;
+  image: string;
   imageAlt: string;
 };
 
@@ -13,6 +12,7 @@ export function createPageMetadata({
   pathname,
   title,
   description,
+  image,
   imageAlt,
 }: PageMetadataOptions): Metadata {
   return {
@@ -28,9 +28,9 @@ export function createPageMetadata({
       type: "website",
       images: [
         {
-          url: SOCIAL_IMAGE,
-          width: 1800,
-          height: 942,
+          url: image,
+          width: 560,
+          height: 320,
           alt: imageAlt,
         },
       ],
@@ -39,7 +39,7 @@ export function createPageMetadata({
       card: "summary_large_image",
       title,
       description,
-      images: [SOCIAL_IMAGE],
+      images: [image],
     },
   };
 }


### PR DESCRIPTION
## Summary

- use each demo's existing navbar preview as its Open Graph and Twitter image
- declare the navbar assets' native 560×320 dimensions in the shared metadata helper
- keep the site-wide metadata image as the fallback for routes without page-specific metadata

## Metadata image previews

These are the exact assets referenced by the generated `og:image` and `twitter:image` tags.

| `/compare` | `/chat` |
| --- | --- |
| ![Compare metadata preview](https://raw.githubusercontent.com/thesysdev/openui/main/docs/public/nav/compare-light.webp) | ![OpenUI Chat metadata preview](https://raw.githubusercontent.com/thesysdev/openui/main/docs/public/nav/chat-light.webp) |

| `/demos` | `/demo/github` |
| --- | --- |
| ![OpenUI versus JSON metadata preview](https://raw.githubusercontent.com/thesysdev/openui/main/docs/public/nav/vsjson-light.webp) | ![GitHub dashboard metadata preview](https://raw.githubusercontent.com/thesysdev/openui/main/docs/public/nav/dashboard-light.webp) |

## Verification

- `pnpm --filter @openuidev/docs types:check`
- Prettier check for all five changed files
- rendered all four routes locally with HTTP 200 responses
- verified each route emits its matching absolute Open Graph and Twitter image URL
