### PR TITLE
Make compare artifacts fullscreen

### DIFF
--- a/docs/app/compare/chat-page.module.css
+++ b/docs/app/compare/chat-page.module.css
@@ -817,6 +817,32 @@
   overflow: hidden !important;
 }
 
+/* Artifacts are the primary output in this comparison, so promote an open
+   detailed view above the page chrome instead of confining it to the Cloud
+   half of the comparison grid. AgentInterface uses a desktop split panel and
+   a mobile overlay; both must be fixed to the viewport for consistent
+   behavior at every container width. */
+.panelBody :global(.openui-agent-thread-detailed-view-panel),
+.panelBody :global(.openui-detailed-view-overlay) {
+  position: fixed !important;
+  inset: 0 !important;
+  z-index: 100;
+  width: 100dvw !important;
+  height: 100dvh !important;
+  min-width: 0 !important;
+  max-width: none !important;
+  flex: none !important;
+  overflow: auto;
+  overscroll-behavior: contain;
+  background: var(--openui-foreground);
+}
+
+/* The desktop splitter only controls the now-covered chat pane and should not
+   remain focusable behind the fullscreen artifact. */
+.panelBody :global(.openui-agent-resizable-separator) {
+  display: none;
+}
+
 /* Comparison owns all navigation and input chrome. Both internal desktop and
    mobile branches are suppressed because each pane measures its own width. */
 .panelBody :global(.openui-agent-sidebar-container),


### PR DESCRIPTION
## What changed

- Promote an open comparison artifact above the full page instead of confining it to the Cloud half of the comparison grid.
- Apply the same viewport-level treatment to the desktop detailed-view panel and mobile overlay.
- Hide the desktop resize separator while the fullscreen artifact is open.

## Why

The comparison page constrains each response surface to half of the viewport. AgentInterface then splits the Cloud half between a 420px chat column and the artifact, leaving reports and presentations with too little room to review.

The viewer now uses the complete application viewport while it is open, and the existing close action returns users to the comparison.

## Validation

- `pnpm --filter docs build`
- `pnpm exec prettier --check docs/app/compare/chat-page.module.css`
- Desktop browser check: the artifact panel matched the 1600×900 viewport at `(0, 0)` and the resize separator was hidden.
- Mobile production-browser check: the artifact overlay matched the 500×700 viewport at `(0, 0)`.
- Verified closing the artifact restores the comparison surface.
- `pnpm --filter docs lint` still reports the existing repository baseline: 17 unrelated `react-hooks/set-state-in-effect` errors and 46 warnings.

## Screenshots

### Desktop

![Fullscreen EV report artifact](https://raw.githubusercontent.com/zahlekhan/openui/7afa3f8be951b929034a9e7e7edb57d9ccdb410c/pr-assets/874/fullscreen-compare-artifact.jpg)

### Mobile

![Fullscreen EV report artifact on mobile](https://raw.githubusercontent.com/zahlekhan/openui/7afa3f8be951b929034a9e7e7edb57d9ccdb410c/pr-assets/874/fullscreen-compare-artifact-mobile.jpg)
