### PR TITLE
fix(template): anchor a new message to the top instead of chasing the bottom

### DIFF
--- a/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
+++ b/packages/openui-cli/src/templates/openui-cloud/src/components/cloud-chat.tsx
@@ -92,8 +92,6 @@ export function CloudChat() {
         componentLibrary={chatLibrary}
         artifactRenderers={artifactRenderers}
         artifactCategories={artifactCategories}
-        scrollVariant="always"
-        scrollOnLoad={false}
         logoUrl={mode === "dark" ? DARK_LOGO_URL : LIGHT_LOGO_URL}
         theme={{ mode }}
         starters={starters}


### PR DESCRIPTION


The cloud template pinned scrollVariant="always", which follows the stream to the bottom of the viewport, and scrollOnLoad={false}, which left an opened conversation sitting at the top of its history. Dropping both falls through to the defaults — user-message-anchor, which scrolls the new user message to the top so the answer fills the space beneath it, and scroll-on-load.

## What

Describe the change and why it is needed.

## Changes

- 

## Test Plan

Describe how you validated this change.

- [ ] Not applicable (explain why)
- [ ] Verified locally

## Checklist

- [ ] I linked a related issue, if applicable
- [ ] I updated docs/README when needed
- [ ] I considered backwards compatibility
