### PR TITLE
feat(home): widen the stack diagram rails, drop the hero star button

### DIFF
--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -25,8 +25,6 @@ export default function HomePage() {
           align="left"
           subtitle="Open Standard for Generative UI"
           showPlaygroundButton={false}
-          githubRepoUrl="https://github.com/thesysdev/openui"
-          githubButtonLabel="Star us on GitHub"
           showTagline={false}
         />
         <LogoStrip />

--- a/docs/app/(home)/sections/StackDiagramSection/StackDiagramSection.module.css
+++ b/docs/app/(home)/sections/StackDiagramSection/StackDiagramSection.module.css
@@ -169,7 +169,7 @@
   z-index: 0;
   display: flex;
   align-items: stretch;
-  gap: 0.25rem;
+  gap: 0.3125rem;
   pointer-events: none;
 }
 
@@ -185,7 +185,7 @@
 .rail {
   position: relative;
   flex: 0 0 auto;
-  width: 0.625rem;
+  width: 0.875rem;
   align-self: stretch;
   min-height: 4rem;
   overflow: hidden;
@@ -214,6 +214,13 @@
   animation: railDown 3.2s linear infinite;
 }
 
+/* Offset the second lane of each pair so neighbours do not march in lockstep,
+   which would read as one wide lane rather than two. */
+.rails > :nth-child(2) .railTrack,
+.rails > :nth-child(4) .railTrack {
+  animation-delay: -1.6s;
+}
+
 @keyframes railUp {
   from {
     transform: translateY(0);
@@ -234,8 +241,8 @@
 
 .chevron {
   flex: 0 0 auto;
-  width: 0.625rem;
-  height: 0.3125rem;
+  width: 0.875rem;
+  height: 0.4375rem;
   opacity: 0.5;
 }
 
@@ -269,7 +276,6 @@
   flex: 0 1 auto;
 }
 
-/* Title on the left; everything after it rides to the right edge. */
 /* Title row: vertically centred, with the arrow pinned to the right edge. */
 .contentSplit {
   align-items: center;
@@ -590,13 +596,7 @@
   }
 
   .rail {
-    width: 0.75rem;
     min-height: 5.5rem;
-  }
-
-  .chevron {
-    width: 0.75rem;
-    height: 0.375rem;
   }
 
   /* The description becomes a sheet that rises from the bottom on tap. */

--- a/docs/app/(home)/sections/StackDiagramSection/StackDiagramSection.tsx
+++ b/docs/app/(home)/sections/StackDiagramSection/StackDiagramSection.tsx
@@ -252,7 +252,7 @@ export function StackDiagramSection() {
                   <span className={styles.itemIcon}>
                     <Browser size={ICON_SIZE} />
                   </span>
-                  <span className={styles.itemTitle}>App surface</span>
+                  <span className={styles.itemTitle}>Agent Interface</span>
                 </div>
                 <span className={styles.layerArrow}>
                   <ArrowRight size={12} weight="bold" />
@@ -276,8 +276,12 @@ export function StackDiagramSection() {
           </div>
 
           <div className={styles.connector}>
+            {/* Four lanes: the left pair streams UI up, the right pair carries
+                actions down. */}
             <span className={styles.rails}>
               <Rail direction="up" />
+              <Rail direction="up" />
+              <Rail direction="down" />
               <Rail direction="down" />
             </span>
             <div className={styles.langLayer}>


### PR DESCRIPTION
Follow-up to #878.

## Changes

**Flow rails: two lanes → four.** Two lanes stream UI up on the left, two carry actions down on the right, and each lane is wider (14px, up from 10px) with larger chevrons.

The second lane of each pair is offset by half the animation cycle (`-1.6s`). Without that, paired lanes march in lockstep and read as a single wide lane rather than two.

The mobile rail override is removed — it scaled the lanes up from a smaller base that now matches it, so only the taller `min-height` remains.

**First card renamed** to "Agent Interface".

**GitHub star button removed from the hero.** Done by dropping the `githubRepoUrl` / `githubButtonLabel` props on the homepage rather than editing the shared `HeroSection`, since the homepage is the only caller that passes them. That also restores `desktopCtaStackShadowRoom`, the class the CTA stack applies when it has no secondary CTA.

## Note

The **mobile** hero still shows its GitHub banner — that is a separate `GitHubBanner` component which falls back to a default repo URL, so it is unaffected. Happy to remove it too if that is wanted.

Verified in light and dark. Typecheck and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)