### PR TITLE
fix(react-ui): remount artifact list on category switch

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/AgentInterface.tsx
+++ b/packages/react-ui/src/components/AgentInterface/AgentInterface.tsx
@@ -417,7 +417,13 @@ const AgentInterfaceBody = ({
               <MobileHeader />
             ))}
           {artifactPath.kind === "list" ? (
-            <ArtifactBrowserPage categoryName={artifactPath.categoryName} />
+            // Keyed on category so switching categories remounts with fresh
+            // state instead of rendering the previous category's list while the
+            // new one loads.
+            <ArtifactBrowserPage
+              key={artifactPath.categoryName ?? "__all__"}
+              categoryName={artifactPath.categoryName}
+            />
           ) : (
             <ArtifactViewPage
               artifactId={artifactPath.artifactId}

--- a/packages/react-ui/src/components/AgentInterface/ArtifactBrowserPage.tsx
+++ b/packages/react-ui/src/components/AgentInterface/ArtifactBrowserPage.tsx
@@ -114,7 +114,10 @@ export const ArtifactBrowserPage = ({ categoryName }: { categoryName?: string })
   const [debouncedSearch, setDebouncedSearch] = useState("");
   const [artifacts, setArtifacts] = useState<ArtifactSummary[]>([]);
   const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(false);
+  // Starts true so a fresh mount (see the `key` on this component at its render
+  // site — the category name) shows the loader immediately rather than flashing
+  // the empty state before the fetch effect runs.
+  const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const requestIdRef = useRef(0);
 


### PR DESCRIPTION
ArtifactBrowserPage reset its fetched list inside a useEffect, which runs after paint. On switching category, React first committed a frame with the new category but the previous list, flashing the old category's cards (with the loader below) before the new results arrived.

Key the component on the category name at its render site so a switch remounts it with fresh state — the old list can never render under the new category. isLoading now initializes to true so the fresh mount shows the loader instead of flashing the empty state before the fetch runs.