### PR TITLE
Soften default regular and medium font weights

### DIFF
--- a/packages/react-ui/src/components/ThemeProvider/defaultTheme.ts
+++ b/packages/react-ui/src/components/ThemeProvider/defaultTheme.ts
@@ -349,8 +349,8 @@ const typographyTheme: TypographyTheme = {
   fontSize4xl: "32px",
   fontSize5xl: "36px",
 
-  fontWeightRegular: "400",
-  fontWeightMedium: "500",
+  fontWeightRegular: "375",
+  fontWeightMedium: "475",
   fontWeightBold: "600",
   fontWeightHeavy: "700",
 


### PR DESCRIPTION
Use variable-font weights 375/475 so default body text renders lighter and closer to the intended visual density.
