### PR TITLE
refactor(docs): drop -free Google models from the model switcher

### DIFF
--- a/docs/lib/openui-cloud/models.ts
+++ b/docs/lib/openui-cloud/models.ts
@@ -1,4 +1,4 @@
-export const DEFAULT_MODEL = "google/gemini-3.6-flash-free";
+export const DEFAULT_MODEL = "google/gemini-3.6-flash";
 
 export interface ModelOption {
   id: string;
@@ -7,19 +7,7 @@ export interface ModelOption {
 }
 
 export const MODEL_OPTIONS: readonly ModelOption[] = [
-  { provider: "Google", id: "google/gemini-3.6-flash-free", name: "Gemini 3.6 Flash" },
-  { provider: "Google", id: "google/gemini-3.6-flash", name: "Gemini 3.6 Flash (Paid)" },
-  { provider: "Google", id: "google/gemini-3.1-pro-free", name: "Gemini 3.1 Pro" },
-  {
-    provider: "Google",
-    id: "google/gemini-3.1-flash-lite-free",
-    name: "Gemini 3.1 Flash Lite",
-  },
-  {
-    provider: "Google",
-    id: "google/gemini-3.5-flash-free",
-    name: "Gemini 3.5 Flash",
-  },
+  { provider: "Google", id: "google/gemini-3.6-flash", name: "Gemini 3.6 Flash" },
   { provider: "Google", id: "google/gemini-3.1-pro-preview", name: "Gemini 3.1 Pro Preview" },
   { provider: "OpenAI", id: "openai/gpt-5.5", name: "GPT-5.5" },
   { provider: "OpenAI", id: "openai/gpt-5.4", name: "GPT-5.4" },


### PR DESCRIPTION
## What

Remove every `-free` Google model from the docs model switcher and make the paid **Gemini 3.6 Flash** the default.

`docs/lib/openui-cloud/models.ts`:
- `DEFAULT_MODEL`: `google/gemini-3.6-flash-free` → **`google/gemini-3.6-flash`**
- Dropped from the dropdown: `gemini-3.6-flash-free`, `gemini-3.1-pro-free`, `gemini-3.1-flash-lite-free`, `gemini-3.5-flash-free`
- Dropped the now-redundant "(Paid)" suffix — the entry reads simply **Gemini 3.6 Flash**

Applies to both `/chat` and `/compare?pair=markdown-cloud` (both read this file).

## Why

openui.com runs on the org's **single shared** Cloud quota. Exposing free-tier models in the public switcher let visitors exhaust it, surfacing `429 ERR_FREE_MODEL_LIMIT` mid-demo. Paid models bill against the org account instead of hitting the shared free cap.

## Not touched

The `openui-cloud` **template** keeps `-free` as its default. Scaffolded apps run on **each user's own key/quota**, so the free tier is the right zero-cost starting point there.
