### PR TITLE
chore(docs): bump @openuidev/thesys-server to 0.1.3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -21,7 +21,7 @@
     "@openuidev/react-lang": "workspace:^",
     "@openuidev/react-ui": "workspace:^",
     "@openuidev/thesys": "0.3.0",
-    "@openuidev/thesys-server": "0.1.1",
+    "@openuidev/thesys-server": "0.1.3",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-tooltip": "1.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))
       '@openuidev/thesys-server':
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.1.3
+        version: 0.1.3
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## What

The docs site pins `@openuidev/thesys-server` at `0.1.1`, while npm `latest` has been `0.1.3` since 2026-07-24. This brings the pin up to date so the documentation builds against the same server SDK consumers install.

`@openuidev/thesys` is already level at `0.3.0` and is untouched here.

## Changes

- `docs/package.json` — `@openuidev/thesys-server` `0.1.1` → `0.1.3`
- `pnpm-lock.yaml` — the `docs` importer entry now resolves `0.1.3`

`0.1.3` is additive over `0.1.1`. It adds `generateSystemPrompt` and `validateChatLibrary` to the public surface, together with the `SystemPromptSpec`, `ToolSpec`, `ChatLibrary`, `ChatLibraryIssue`, `ComponentGroup`, `LibraryJSONSchema` and `PromptOptions` types. `createResponsesInstructions` is now marked deprecated in favour of `generateSystemPrompt`, but remains exported with an unchanged signature.

Note that `0.1.2` was never published to npm — `0.1.1` → `0.1.3` is the real sequence.

The lockfile diff is deliberately two lines: `@openuidev/thesys-server@0.1.3` was already resolved in the lockfile by another workspace package, so only the `docs` importer needed to point at it. No other workspace package's resolutions change.

## Test Plan

- [x] Verified locally

- `pnpm install --frozen-lockfile` exits 0 under both pnpm `9.15.4` and `10.33.0` — the versions this repository's workflows pin — so the frozen install CI step is satisfied.
- The published type surfaces of `0.1.1` and `0.1.3` were compared directly from the npm tarballs. Every `0.1.1` export is still present in `0.1.3`, and the two symbols the docs site actually imports are byte-identical:
  - `artifactTool(options?: ArtifactToolOptions): ResponsesArtifactToolEntry`
  - `createResponsesInstructions(options?: ResponsesConfigOptions): string`
- `docs/app/api/openui-cloud/chat/route.ts` is the only consumer of the package in the repository; both of its call sites typecheck unchanged against `0.1.3`.

**Not verified in this PR:** no docs build or `types:check` run was performed locally. Nothing in `docs/` source changed — this is a version pin plus the matching lockfile resolution — so the build result rests on CI rather than a local run.

## Follow-up, deliberately not in this PR

`createResponsesInstructions` is deprecated as of `0.1.3`. Migrating the Cloud chat route to `generateSystemPrompt` is a behavioural change and belongs in its own PR; keeping this one to the pin makes it trivially revertible.

## Checklist

- [ ] I linked a related issue, if applicable — no public issue for this; it is tracked on our side
- [x] I updated docs/README when needed — not applicable, no documentation content changed
- [x] I considered backwards compatibility — the release is additive and no exported signature changed
