### PR TITLE
fix: auto-submit prompt template completions

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/ConversationStarter.tsx
+++ b/packages/react-ui/src/components/AgentInterface/ConversationStarter.tsx
@@ -89,7 +89,7 @@ export interface ConversationStarterContainerProps {
   /**
    * Optional click override. When provided, replaces the default
    * send-to-thread behavior (still guarded by `isRunning`). The prefill-chips
-   * welcome uses it to append contextual-starter prompts into the draft.
+   * welcome uses it to submit contextual starters with the prefilled draft.
    */
   onSelect?: (starter: ConversationStarterProps) => void;
 }

--- a/packages/react-ui/src/components/AgentInterface/WelcomeScreen.tsx
+++ b/packages/react-ui/src/components/AgentInterface/WelcomeScreen.tsx
@@ -5,7 +5,7 @@ import { ConversationStarterProps } from "../../types/ConversationStarter";
 import { PromptTemplate } from "../../types/PromptTemplate";
 import { useStartersFromContext } from "./_shared/startersContext";
 import { isChatEmpty } from "./_shared/utils";
-import { appendStarterPrompt } from "./_shared/utils/welcomePrefill";
+import { submitStarterPrompt } from "./_shared/utils/welcomePrefill";
 import { DesktopWelcomeComposer, WelcomePrefillChips } from "./components";
 import { ConversationStarter, ConversationStarterVariant } from "./ConversationStarter";
 import { WelcomeGlow, WelcomeGlowProvider } from "./WelcomeGlow";
@@ -48,8 +48,8 @@ interface WelcomeScreenWithContentProps extends WelcomeScreenBaseProps {
   /**
    * Fill-in-the-blank prompt templates, rendered as chips between the composer
    * and the starters. Clicking one drops its prompt stem into the composer
-   * (instead of sending) and shows the template's completions, which append to
-   * the draft.
+   * (instead of sending) and shows the template's completions. Selecting a
+   * completion sends the completed prompt immediately.
    */
   promptTemplates?: PromptTemplate[];
   /**
@@ -95,6 +95,7 @@ export const WelcomeScreen = (props: WelcomeScreenProps) => {
   const messages = useThread((s) => s.messages);
   const isLoadingMessages = useThread((s) => s.isLoadingMessages);
   const isRunning = useThread((s) => s.isRunning);
+  const processMessage = useThread((s) => s.processMessage);
 
   // Prefill-chips draft state — owned here (not in the composer) so chips can
   // write into the draft. Hooks stay unconditional; unused without chips.
@@ -167,13 +168,7 @@ export const WelcomeScreen = (props: WelcomeScreenProps) => {
   };
 
   const handleContextualSelect = (starter: ConversationStarterProps) => {
-    const next = appendStarterPrompt(draft, starter.prompt);
-    setDraft(next);
-    setSelectedChip(null);
-    requestAnimationFrame(() => {
-      inputRef.current?.focus();
-      inputRef.current?.setSelectionRange(next.length, next.length);
-    });
+    submitStarterPrompt(processMessage, draft, starter.prompt);
   };
 
   return (

--- a/packages/react-ui/src/components/AgentInterface/WelcomeScreen.tsx
+++ b/packages/react-ui/src/components/AgentInterface/WelcomeScreen.tsx
@@ -169,6 +169,12 @@ export const WelcomeScreen = (props: WelcomeScreenProps) => {
 
   const handleContextualSelect = (starter: ConversationStarterProps) => {
     submitStarterPrompt(processMessage, draft, starter.prompt);
+    // Clear at submit time like the composer's own submit path — the
+    // thread-switch reset above won't fire when selectedThreadId doesn't
+    // change (e.g. thread creation fails on a fresh chat and it stays null),
+    // and the stale stem would resurface if the welcome shows again.
+    setDraft("");
+    setSelectedChip(null);
   };
 
   return (

--- a/packages/react-ui/src/components/AgentInterface/__tests__/welcomePrefill.test.ts
+++ b/packages/react-ui/src/components/AgentInterface/__tests__/welcomePrefill.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { appendStarterPrompt } from "../_shared/utils/welcomePrefill";
+import { describe, expect, it, vi } from "vitest";
+import { appendStarterPrompt, submitStarterPrompt } from "../_shared/utils/welcomePrefill";
 
 describe("appendStarterPrompt", () => {
   it("returns the prompt alone for an empty draft", () => {
@@ -16,5 +16,25 @@ describe("appendStarterPrompt", () => {
     expect(appendStarterPrompt("Create a presentation about ", "a product launch plan")).toBe(
       "Create a presentation about a product launch plan",
     );
+  });
+});
+
+describe("submitStarterPrompt", () => {
+  it("submits the composed draft + prompt as a user message", () => {
+    const processMessage = vi.fn();
+    submitStarterPrompt(processMessage, "Create a presentation about ", "our Q2 business review");
+    expect(processMessage).toHaveBeenCalledExactlyOnceWith({
+      role: "user",
+      content: "Create a presentation about our Q2 business review",
+    });
+  });
+
+  it("submits the prompt alone when the draft is empty", () => {
+    const processMessage = vi.fn();
+    submitStarterPrompt(processMessage, "", "our Q2 business review");
+    expect(processMessage).toHaveBeenCalledExactlyOnceWith({
+      role: "user",
+      content: "our Q2 business review",
+    });
   });
 });

--- a/packages/react-ui/src/components/AgentInterface/_shared/utils/welcomePrefill.ts
+++ b/packages/react-ui/src/components/AgentInterface/_shared/utils/welcomePrefill.ts
@@ -7,3 +7,16 @@ export const appendStarterPrompt = (draft: string, prompt: string): string => {
   const separator = draft.length > 0 && !draft.endsWith(" ") ? " " : "";
   return `${draft}${separator}${prompt}`;
 };
+
+type ProcessStarterMessage = (message: { role: "user"; content: string }) => void;
+
+/** Composes a contextual starter with the current draft and submits it. */
+export const submitStarterPrompt = (
+  processMessage: ProcessStarterMessage,
+  draft: string,
+  prompt: string,
+): void =>
+  processMessage({
+    role: "user",
+    content: appendStarterPrompt(draft, prompt),
+  });

--- a/packages/react-ui/src/components/AgentInterface/components/WelcomePrefillChips.tsx
+++ b/packages/react-ui/src/components/AgentInterface/components/WelcomePrefillChips.tsx
@@ -34,7 +34,7 @@ export interface WelcomePrefillChipsProps {
  * Chip row + grid-stacked starters layers for the prefill-chips welcome.
  * Layer 1 (chips + default starters) hides via `visibility` while drafting so
  * the layout doesn't jump; layer 2 shows the selected chip's contextual
- * starters, which append to the draft (see WelcomeScreen).
+ * starters, which submit the completed prompt (see WelcomeScreen).
  */
 export const WelcomePrefillChips = ({
   chips,

--- a/packages/react-ui/src/components/AgentInterface/stories/AgentInterface.stories.tsx
+++ b/packages/react-ui/src/components/AgentInterface/stories/AgentInterface.stories.tsx
@@ -253,7 +253,7 @@ export const WithWelcome = {
   ),
 };
 
-/** Welcome with prefill chips — chip click prefills the composer; contextual starters append. */
+/** Welcome with prompt templates — a chip prefills the composer; a completion submits it. */
 export const WelcomeWithPrefillChips = {
   render: () => (
     <AgentInterface

--- a/packages/react-ui/src/types/PromptTemplate.ts
+++ b/packages/react-ui/src/types/PromptTemplate.ts
@@ -4,8 +4,8 @@ import { ConversationStarterProps } from "./ConversationStarter";
 /**
  * A fill-in-the-blank prompt for the welcome screen, rendered as a chip:
  * clicking drops the incomplete `prompt` stem into the welcome composer
- * (instead of sending), then shows the template's `completions`, which append
- * to the draft on click.
+ * (instead of sending), then shows the template's `completions`, which submit
+ * the completed prompt on click.
  */
 export interface PromptTemplate {
   displayText: string;
@@ -13,6 +13,6 @@ export interface PromptTemplate {
   prompt: string;
   /** Optional icon; omit for none (chips render no default icon). */
   icon?: ReactNode;
-  /** Suggested completions shown once this template is in the composer. */
+  /** Suggested completions that submit with the prompt stem when selected. */
   completions: ConversationStarterProps[];
 }


### PR DESCRIPTION
## Summary

- submit a prompt-template completion immediately after composing it with the prefilled prompt stem
- preserve the initial template-chip prefill behavior so users can still edit or submit the stem manually
- update the related API and Storybook descriptions to match the new interaction

## Root cause

The contextual starter handler appended the selected completion to the controlled composer draft and returned focus to the textarea. It never called the thread's message processor, so users had to press Send manually before generation started.

## Impact

Choosing a contextual completion now sends the complete prompt and starts generation in the same click.

## Validation

- `pnpm --filter @openuidev/react-ui test` (27 tests passed)
- `pnpm --filter @openuidev/react-ui typecheck`
- Prettier check on changed files
- `pnpm --filter @openuidev/react-ui lint:check` (0 errors; existing warnings only)
- Storybook interaction verified: template selection followed by completion selection immediately produced the combined user message and loading state
