### PR TITLE
Restore PostHog session recording

### DIFF
--- a/docs/lib/analytics.ts
+++ b/docs/lib/analytics.ts
@@ -1,15 +1,17 @@
-type PostHog = (typeof import("posthog-js/dist/module.slim"))["default"];
+type PostHog = (typeof import("posthog-js"))["default"];
 
 let posthogPromise: Promise<PostHog> | undefined;
 
 export function loadPostHog(): Promise<PostHog> {
-  posthogPromise ??= import("posthog-js/dist/module.slim").then(({ default: posthog }) => {
+  posthogPromise ??= import("posthog-js").then(({ default: posthog }) => {
     posthog.init("phc_3OLW53x09ZTVZSV6BEpj5uycj3ooqR6KOemOjx04e3D", {
       api_host: "https://dgoeivjus9jfp.cloudfront.net",
       capture_pageview: "history_change",
       advanced_disable_flags: true,
-      disable_external_dependency_loading: true,
-      disable_session_recording: true,
+      disable_session_recording: false,
+      session_recording: {
+        sampleRate: 0.1,
+      },
       disable_surveys: true,
     });
 


### PR DESCRIPTION
## Summary

- load the full `posthog-js` browser package instead of the slim module
- re-enable PostHog session recording with a 10% sample rate
- allow the recorder extension to load by removing `disable_external_dependency_loading`

## Root cause

The deferred analytics refactor switched the site to `posthog-js/dist/module.slim` and explicitly disabled both external dependency loading and session recording. That configuration continued to capture pageviews but prevented the session recorder from loading.

## Impact

OpenUI site sessions can be recorded again at the previous 10% sampling rate while retaining deferred PostHog initialization.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @openuidev/docs exec prettier --check lib/analytics.ts`
- `pnpm --filter @openuidev/docs exec eslint lib/analytics.ts`
- `pnpm --filter @openuidev/docs types:check`
- `git diff --check`

The production docs build was also attempted, but Next.js/Turbopack remained at `Creating an optimized production build ...` without further output for several minutes, so it was stopped and is reported as inconclusive rather than passing.
