### PR TITLE
fix(docs): use accurate sitemap dates

### DIFF
--- a/docs/app/sitemap.ts
+++ b/docs/app/sitemap.ts
@@ -1,24 +1,20 @@
 import { BASE_URL, blog, source } from "@/lib/source";
+import type { MetadataRoute } from "next";
 
 const STATIC_PATHS = ["/", "/cloud", "/demos", "/compare", "/lab", "/chat", "/blog"];
 
-export default async function sitemap() {
+export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes = STATIC_PATHS.map((path) => ({
     url: `${BASE_URL}${path}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
   }));
 
   const docsRoutes = source.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: page.data.lastModified,
-    changeFrequency: "weekly" as const,
   }));
 
   const blogRoutes = blog.getPages().map((page) => ({
     url: `${BASE_URL}${page.url}`,
-    lastModified: new Date(),
-    changeFrequency: "weekly" as const,
+    lastModified: page.data.date,
   }));
 
   return [...staticRoutes, ...docsRoutes, ...blogRoutes];

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,6 +1,5 @@
 import { metaSchema, pageSchema } from "fumadocs-core/source/schema";
 import { defineCollections, defineConfig, defineDocs } from "fumadocs-mdx/config";
-import lastModified from "fumadocs-mdx/plugins/last-modified";
 import { z } from "zod";
 
 // You can customise Zod schemas for frontmatter and `meta.json` here
@@ -28,6 +27,4 @@ export const blogPosts = defineCollections({
   }),
 });
 
-export default defineConfig({
-  plugins: [lastModified()],
-});
+export default defineConfig();


### PR DESCRIPTION
## Summary

- stop emitting deploy-time `lastmod` values for unchanged static and documentation URLs
- use each blog post's frontmatter publication date for its sitemap `lastmod`
- remove the Git-history-based Fumadocs last-modified plugin
- remove `changefreq`, which Google ignores

## Why

A Search Console indexing audit showed that the affected URLs were last crawled before the July 22 self-canonical fix, or had not yet been crawled. Live pages now return `200`, `index, follow`, and their own canonical URL.

The remaining sitemap signal was inaccurate: unchanged static and blog URLs received a new build timestamp on every deployment, while generated documentation timestamps collapsed to the checkout/build date. Fumadocs' resolver requires complete Git history, which cannot be assumed in the production build environment. Google only uses `lastmod` when it consistently reflects a significant page update.

This PR keeps sitemap dates truthful and stable. It does not change the already-deployed canonical fix.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- `pnpm --filter @openuidev/docs exec prettier --check app/sitemap.ts source.config.ts`
- `git diff --check`
- sampled affected live pages: `200`, self-canonical, and `index, follow`

A full Next production build was attempted on the original checkout but remained silent in optimized compilation for more than six minutes and was stopped, so that check is inconclusive rather than failed.
