### PR TITLE
chore(deps): manage prettier via pnpm catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "eslint-plugin-react-refresh": "catalog:",
     "eslint-plugin-storybook": "catalog:",
     "eslint-plugin-unused-imports": "catalog:",
-    "prettier": "^3.2.5",
-    "prettier-plugin-organize-imports": "^3.2.4",
+    "prettier": "catalog:",
+    "prettier-plugin-organize-imports": "catalog:",
     "publint": "^0.3.18",
     "tsdown": "^0.21.7",
     "typescript": "catalog:"

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -180,7 +180,7 @@
     "postcss": "^8.5.1",
     "postcss-js": "^4.0.1",
     "postcss-remove-duplicate-values": "^1.0.0",
-    "prettier-plugin-organize-imports": "^3.2.4",
+    "prettier-plugin-organize-imports": "catalog:",
     "prop-types": "^15.8.1",
     "sass": "^1.83.4",
     "storybook": "^8.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,12 @@ catalogs:
     jsdom:
       specifier: ^26.1.0
       version: 26.1.0
+    prettier:
+      specifier: ^3.2.5
+      version: 3.9.6
+    prettier-plugin-organize-imports:
+      specifier: ^3.2.4
+      version: 3.2.4
     react:
       specifier: ^18.3.1 || ^19.0.0
       version: 19.2.4
@@ -107,10 +113,10 @@ importers:
         specifier: 'catalog:'
         version: 4.4.1(@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))
       prettier:
-        specifier: ^3.2.5
+        specifier: 'catalog:'
         version: 3.9.6
       prettier-plugin-organize-imports:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(prettier@3.9.6)(typescript@5.9.3)
       publint:
         specifier: ^0.3.18
@@ -2134,7 +2140,7 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(postcss@8.5.24)
       prettier-plugin-organize-imports:
-        specifier: ^3.2.4
+        specifier: 'catalog:'
         version: 3.2.4(prettier@3.9.6)(typescript@5.9.3)
       prop-types:
         specifier: ^15.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ catalog:
   eslint-plugin-storybook: "^10.2.14"
   eslint-plugin-unused-imports: "^4.4.1"
   jsdom: "^26.1.0"
+  prettier: "^3.2.5"
+  prettier-plugin-organize-imports: "^3.2.4"
   react: "^18.3.1 || ^19.0.0"
   react-dom: "^18.0.0 || ^19.0.0"
   typescript: "^5.9.3"


### PR DESCRIPTION
## What

`prettier` and `prettier-plugin-organize-imports` were the last shared dev-tooling dependencies still pinned per package.json, while eslint, typescript and friends already go through the workspace catalog. This moves them into the catalog too, so the versions live in one place.

## Changes

- `pnpm-workspace.yaml`: add `prettier: "^3.2.5"` and `prettier-plugin-organize-imports: "^3.2.4"` to the catalog
- `package.json` (root): `prettier` / `prettier-plugin-organize-imports` → `catalog:`
- `packages/react-ui/package.json`: `prettier-plugin-organize-imports` → `catalog:`
- `pnpm-lock.yaml`: catalog entries added, importer specifiers updated

Resolved versions are unchanged (prettier 3.9.6, prettier-plugin-organize-imports 3.2.4), so no formatting behaviour changes.

## Test Plan

- [x] Verified locally

`pnpm install --frozen-lockfile` (pnpm 10.34.5, same major as CI) passes against the updated lockfile and produces no further lockfile changes — i.e. the lockfile is in sync with the manifests.

## Checklist

- [ ] I linked a related issue, if applicable
- [x] I updated docs/README when needed (n/a)
- [x] I considered backwards compatibility (no published package manifests are affected; `catalog:` is resolved at publish time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)