### PR TITLE
Disable Reo copy tracking

### DIFF
--- a/docs/app/providers.tsx
+++ b/docs/app/providers.tsx
@@ -17,7 +17,9 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
         // @ts-expect-error reodotdev does not publish TypeScript declarations.
         import("reodotdev")
           .then(({ loadReoScript }) => loadReoScript({ clientID }))
-          .then((reo: { init(config: { clientID: string }): void }) => reo.init({ clientID }))
+          .then((reo: { init(config: { clientID: string; dnt: string[] }): void }) =>
+            reo.init({ clientID, dnt: ["copy"] }),
+          )
           .catch(() => {});
     }
 


### PR DESCRIPTION
## What changed

- pass `dnt: ["copy"]` when initializing the Reo docs beacon
- keep the remaining Reo analytics integration unchanged

## Why

Reo copy tracking can transmit copied command contents, including API keys embedded in commands. The SDK's copy-specific do-not-track option prevents those copy events from being collected while preserving other analytics.

## Validation

- `pnpm exec prettier --check docs/app/providers.tsx`
- `pnpm --filter @openuidev/docs exec eslint app/providers.tsx`
- `git diff --check`

The repository-wide docs format check still reports 54 pre-existing formatting failures. The docs type check reaches TypeScript but cannot resolve unbuilt internal workspace packages in a fresh checkout.
