### PR TITLE
feat: mention BYOK in CLI create flow and credits error card

### DIFF
--- a/packages/devtools/src/QuotaErrorRow.tsx
+++ b/packages/devtools/src/QuotaErrorRow.tsx
@@ -120,7 +120,6 @@ const styles = {
     marginTop: 2,
   },
   action: {
-    alignSelf: "flex-start",
     display: "inline-flex",
     alignItems: "center",
     gap: 6,
@@ -133,11 +132,10 @@ const styles = {
     fontSize: 12,
     fontWeight: 500,
     cursor: "pointer",
-    marginTop: 2,
   },
   actionSecondary: {
     background: "#ffffff",
     color: "#18181b",
-    border: "1px solid #d4d4d8",
+    border: "1px solid #e4e4e7",
   },
 } satisfies Record<string, CSSProperties>;

--- a/packages/devtools/src/QuotaErrorRow.tsx
+++ b/packages/devtools/src/QuotaErrorRow.tsx
@@ -1,25 +1,28 @@
 import { type ObservabilityEvent } from "@openuidev/observability";
-import { CreditCard } from "lucide-react";
+import { CreditCard, KeyRound } from "lucide-react";
 import type { CSSProperties } from "react";
 
 export interface QuotaErrorInfo {
   title: string;
   message: string;
   showPurchaseCta: boolean;
+  showByokCta: boolean;
 }
 
 const QUOTA_ERROR_MESSAGES: Record<string, QuotaErrorInfo> = {
   ERR_BILLING_THRESHOLD_EXCEEDED: {
     title: "Add credits to keep going",
     message:
-      "Looks like this workspace is out of OpenUI Cloud credits. Purchase credits to keep testing, then try your request again. This notice is only shown in development.",
+      "Looks like this workspace is out of OpenUI Cloud credits. Purchase credits, or bring your own OpenAI, Anthropic, or Google key (BYOK) at no extra cost, then try your request again. This notice is only shown in development.",
     showPurchaseCta: true,
+    showByokCta: true,
   },
   ERR_QUOTA_EXCEEDED: {
     title: "Rate limit reached",
     message:
       "This workspace has hit a rate limit, usually from sending requests too quickly, or exceeding the per-model token/request limit for the current plan. Wait a moment and try again. This notice is only shown in development.",
     showPurchaseCta: false,
+    showByokCta: false,
   },
 };
 
@@ -37,17 +40,33 @@ export function QuotaErrorRow({ info }: { info: QuotaErrorInfo }) {
       <div style={styles.creditsNote}>
         <div style={styles.creditsTitle}>{info.title}</div>
         <p style={styles.creditsMessage}>{info.message}</p>
-        {info.showPurchaseCta ? (
-          <button
-            type="button"
-            style={styles.action}
-            onClick={() =>
-              window.open("https://console.thesys.dev/billing", "_blank", "noopener,noreferrer")
-            }
-          >
-            <CreditCard size={13} />
-            Purchase Credits
-          </button>
+        {info.showPurchaseCta || info.showByokCta ? (
+          <div style={styles.actions}>
+            {info.showPurchaseCta ? (
+              <button
+                type="button"
+                style={styles.action}
+                onClick={() =>
+                  window.open("https://console.thesys.dev/billing", "_blank", "noopener,noreferrer")
+                }
+              >
+                <CreditCard size={13} />
+                Purchase Credits
+              </button>
+            ) : null}
+            {info.showByokCta ? (
+              <button
+                type="button"
+                style={{ ...styles.action, ...styles.actionSecondary }}
+                onClick={() =>
+                  window.open("https://console.thesys.dev/byok", "_blank", "noopener,noreferrer")
+                }
+              >
+                <KeyRound size={13} />
+                Add your own key
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
     </div>
@@ -95,6 +114,11 @@ const styles = {
     lineHeight: 1.55,
     color: "#52525b",
   },
+  actions: {
+    display: "flex",
+    gap: 8,
+    marginTop: 2,
+  },
   action: {
     alignSelf: "flex-start",
     display: "inline-flex",
@@ -110,5 +134,10 @@ const styles = {
     fontWeight: 500,
     cursor: "pointer",
     marginTop: 2,
+  },
+  actionSecondary: {
+    background: "#ffffff",
+    color: "#18181b",
+    border: "1px solid #d4d4d8",
   },
 } satisfies Record<string, CSSProperties>;

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -138,7 +138,7 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
               choices: [
                 {
                   value: "openui-cloud",
-                  name: "OpenUI Cloud — free hosted models, managed history, tools & artifacts; fastest setup (recommended)",
+                  name: "OpenUI Cloud — free hosted models or bring your own key, managed history, tools & artifacts; fastest setup (recommended)",
                 },
                 {
                   value: "openui-self-hosted",

--- a/packages/openui-cli/src/index.ts
+++ b/packages/openui-cli/src/index.ts
@@ -70,7 +70,9 @@ Templates:
   openui-cloud        Recommended default for prototypes and evaluations.
                       Hosted models, managed conversation history, built-in tools,
                       and ready-to-use reports and presentations. No model, storage,
-                      or artifact infrastructure to operate.
+                      or artifact infrastructure to operate. Bring your own
+                      OpenAI/Anthropic/Google key (BYOK) on any plan,
+                      including the free tier.
   openui-self-hosted  Choose when owning the OpenAI-compatible provider, AI route,
                       and persistence is a requirement.
 `,


### PR DESCRIPTION
Part of the BYOK free-tier launch: surface BYOK in the two places a new CLI user decides how models get paid for.

## Changes

**CLI (`@openuidev/cli`)**
- The `openui-cloud` choice in the interactive template picker now reads: *"OpenUI Cloud — free hosted models or bring your own key, managed history, tools & artifacts; fastest setup (recommended)"*
- `create --help` templates blurb adds: *"Bring your own OpenAI/Anthropic/Google key (BYOK) on any plan, including the free tier."*

**Devtools (`@openuidev/devtools`)**
- The out-of-credits card (`ERR_BILLING_THRESHOLD_EXCEEDED`) now offers BYOK as the alternative to purchasing credits, with a secondary **Add your own key** button linking to https://console.thesys.dev/byok
- `QuotaErrorInfo` gains a `showByokCta` flag; the rate-limit card (`ERR_QUOTA_EXCEEDED`) keeps it off for now (follow-up)

## Screenshot

<img width="800" height="362" alt="BYOK option on the out-of-credits devtools card" src="https://github.com/user-attachments/assets/6426ad17-735f-4ae7-946c-8521b7ebdbd1" />

## Verification

- `tsc --noEmit` clean in both packages; prettier clean
- Verified live in a freshly scaffolded `openui-cloud` app: triggered a real 429 billing-threshold error and confirmed the card renders the new copy + button
- Note: the card only matches when `@openuidev/react-headless` >= 0.9.6 is installed (0.9.5 emits the 429 event without `error.type`, so no card renders on any devtools version). Fresh scaffolds resolve `^0.9.3` to 0.9.6, so they're fine.

## Shipping note

Reaches users via the next `@openuidev/devtools` npm publish (template pins `^0.0.3`) and the next CLI publish.
