### PR TITLE
fix: allow lang-core postinstall in template pnpm allowlists

### DIFF
--- a/packages/openui-cli/src/templates/openui-cloud/package.json
+++ b/packages/openui-cli/src/templates/openui-cloud/package.json
@@ -35,7 +35,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "sharp",
-      "unrs-resolver"
+      "unrs-resolver",
+      "@openuidev/lang-core"
     ]
   }
 }

--- a/packages/openui-cli/src/templates/openui-cloud/pnpm-workspace.yaml
+++ b/packages/openui-cli/src/templates/openui-cloud/pnpm-workspace.yaml
@@ -5,9 +5,11 @@
 onlyBuiltDependencies:
   - sharp
   - unrs-resolver
+  - "@openuidev/lang-core"
 allowBuilds:
   sharp: true
   unrs-resolver: true
+  "@openuidev/lang-core": true
 packages: ["."]
 minimumReleaseAgeExclude:
   - "@openuidev/*"

--- a/packages/openui-cli/src/templates/openui-self-hosted/package.json
+++ b/packages/openui-cli/src/templates/openui-self-hosted/package.json
@@ -5,7 +5,8 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "sharp",
-      "unrs-resolver"
+      "unrs-resolver",
+      "@openuidev/lang-core"
     ]
   },
   "scripts": {

--- a/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
+++ b/packages/openui-cli/src/templates/openui-self-hosted/pnpm-workspace.yaml
@@ -8,8 +8,10 @@ packages:
 onlyBuiltDependencies:
   - sharp
   - unrs-resolver
+  - "@openuidev/lang-core"
 allowBuilds:
   sharp: true
   unrs-resolver: true
+  "@openuidev/lang-core": true
 minimumReleaseAgeExclude:
   - "@openuidev/*"


### PR DESCRIPTION
pnpm@11 template CI jobs are failing repo-wide with:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @openuidev/lang-core@0.2.11
Error: dependency install failed
```

**Cause:** `@openuidev/lang-core@0.2.11` (published Aug 5) added an install-telemetry `postinstall` script — 0.2.10 had none. pnpm 11 hard-fails installs whose dependency build scripts are not allowlisted, and the template allowlists only covered `sharp` and `unrs-resolver`.

**Fix:** add `@openuidev/lang-core` to the allowlist in both templates, in all three per-pnpm-version locations the existing comment documents (package.json `pnpm` field for <=10.13, `onlyBuiltDependencies` in pnpm-workspace.yaml for 10.14-10.x, `allowBuilds` for >=11). The postinstall is first-party and intentionally added, so allowing it (rather than ignoring) preserves the telemetry.

Unblocks #942 and any other PR currently red on the `openui-cloud (pnpm@11, *)` / `openui-self-hosted (pnpm@11, *)` matrix jobs.