### PR TITLE
docs: mention BYOK in OpenUI Cloud

### DIFF
--- a/docs/content/docs/openui-cloud/get-started.mdx
+++ b/docs/content/docs/openui-cloud/get-started.mdx
@@ -34,6 +34,8 @@ yarn dlx @openuidev/cli@latest create --template openui-cloud
 npx @openuidev/cli@latest create --template openui-cloud
 ```
 
+To use your own model provider, add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok). BYOK is available on every plan, including the free tier.
+
 ## Run
 
 Start the dev server:

--- a/docs/content/docs/openui-cloud/get-started.mdx
+++ b/docs/content/docs/openui-cloud/get-started.mdx
@@ -38,6 +38,10 @@ npx @openuidev/cli@latest create --template openui-cloud
 
 To use your own model provider, add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok). BYOK is available on every plan, including the free tier.
 
+Only organization admins can add or update provider keys. Once a key is added, every member of the organization can use models from that provider through BYOK.
+
+BYOK applies only to the matching provider. For example, if your organization adds an OpenAI key, requests to OpenAI models use that key. Requests to Anthropic or Google Vertex AI models are billed against OpenUI Cloud credits instead. If the organization has no credits, those requests fail with an out-of-credits error; otherwise, its credits are used for the requests.
+
 Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.5`, not `gpt-5.5`.
 
 | Provider  | Model name             | Model identifier                |

--- a/docs/content/docs/openui-cloud/get-started.mdx
+++ b/docs/content/docs/openui-cloud/get-started.mdx
@@ -34,30 +34,7 @@ yarn dlx @openuidev/cli@latest create --template openui-cloud
 npx @openuidev/cli@latest create --template openui-cloud
 ```
 
-## Bring your own key
-
-To use your own model provider, add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok). BYOK is available on every plan, including the free tier.
-
-Only organization admins can add or update provider keys. Once a key is added, every member of the organization can use models from that provider through BYOK.
-
-BYOK applies only to the matching provider. For example, if your organization adds an OpenAI key, requests to OpenAI models use that key. Requests to Anthropic or Google Vertex AI models are billed against OpenUI Cloud credits instead. If the organization has no credits, those requests fail with an out-of-credits error; otherwise, its credits are used for the requests.
-
-Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.5`, not `gpt-5.5`.
-
-| Provider  | Model name             | Model identifier                |
-| --------- | ---------------------- | ------------------------------- |
-| Anthropic | Claude Sonnet 5        | `anthropic/claude-sonnet-5`     |
-| Anthropic | Claude Sonnet 4.6      | `anthropic/claude-sonnet-4.6`   |
-| Anthropic | Claude Opus 4.7        | `anthropic/claude-opus-4-7`     |
-| Google    | Gemini 3.6 Flash       | `google/gemini-3.6-flash`       |
-| Google    | Gemini 3.5 Flash       | `google/gemini-3.5-flash`       |
-| Google    | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
-| OpenAI    | GPT-5.5                | `openai/gpt-5.5`                |
-| OpenAI    | GPT-5.4                | `openai/gpt-5.4`                |
-| OpenAI    | GPT-5.4 mini           | `openai/gpt-5.4-mini`           |
-| OpenAI    | GPT-5.2                | `openai/gpt-5.2`                |
-| OpenAI    | GPT-5.1                | `openai/gpt-5.1`                |
-| OpenAI    | GPT-5                  | `openai/gpt-5`                  |
+To add a provider key, choose a supported model, or call OpenUI Cloud through the Responses API, see [Models and BYOK](/docs/openui-cloud/models-and-byok).
 
 ## Run
 

--- a/docs/content/docs/openui-cloud/get-started.mdx
+++ b/docs/content/docs/openui-cloud/get-started.mdx
@@ -34,7 +34,7 @@ yarn dlx @openuidev/cli@latest create --template openui-cloud
 npx @openuidev/cli@latest create --template openui-cloud
 ```
 
-To add a provider key, choose a supported model, or call OpenUI Cloud through the Responses API, see [Models and BYOK](/docs/openui-cloud/models-and-byok).
+To add a provider key or choose a supported model, see [Models and BYOK](/docs/openui-cloud/models-and-byok).
 
 ## Run
 

--- a/docs/content/docs/openui-cloud/get-started.mdx
+++ b/docs/content/docs/openui-cloud/get-started.mdx
@@ -34,7 +34,26 @@ yarn dlx @openuidev/cli@latest create --template openui-cloud
 npx @openuidev/cli@latest create --template openui-cloud
 ```
 
+## Bring your own key
+
 To use your own model provider, add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok). BYOK is available on every plan, including the free tier.
+
+Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.5`, not `gpt-5.5`.
+
+| Provider  | Model name             | Model identifier                |
+| --------- | ---------------------- | ------------------------------- |
+| Anthropic | Claude Sonnet 5        | `anthropic/claude-sonnet-5`     |
+| Anthropic | Claude Sonnet 4.6      | `anthropic/claude-sonnet-4.6`   |
+| Anthropic | Claude Opus 4.7        | `anthropic/claude-opus-4-7`     |
+| Google    | Gemini 3.6 Flash       | `google/gemini-3.6-flash`       |
+| Google    | Gemini 3.5 Flash       | `google/gemini-3.5-flash`       |
+| Google    | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
+| OpenAI    | GPT-5.5                | `openai/gpt-5.5`                |
+| OpenAI    | GPT-5.4                | `openai/gpt-5.4`                |
+| OpenAI    | GPT-5.4 mini           | `openai/gpt-5.4-mini`           |
+| OpenAI    | GPT-5.2                | `openai/gpt-5.2`                |
+| OpenAI    | GPT-5.1                | `openai/gpt-5.1`                |
+| OpenAI    | GPT-5                  | `openai/gpt-5`                  |
 
 ## Run
 

--- a/docs/content/docs/openui-cloud/index.mdx
+++ b/docs/content/docs/openui-cloud/index.mdx
@@ -19,11 +19,12 @@ It combines OpenUI's generative UI capabilities with reliable model access, auto
 ## What you get
 
 1. **Production hardening:** Run generative UI reliably in production with managed model access, automatic fallbacks, and output validation. Requests are rerouted when a model or provider is unavailable, and generated output is validated before it reaches the interface.
-2. **Generative UI for agents:** Let agents respond with rich, interactive interfaces instead of walls of text. Each response can assemble the components best suited to the task.
+2. **Bring your own model key (BYOK):** Use your own OpenAI, Anthropic, or Google API key with OpenUI Cloud on any plan, including the free tier.
+3. **Generative UI for agents:** Let agents respond with rich, interactive interfaces instead of walls of text. Each response can assemble the components best suited to the task.
    - **Built-in component library:** Use a pre-tested, responsive, and accessible set of components: forms, inputs, interactive charts, accordions, tabs, and other layout components.
    - **Bring your own component library:** Generate interfaces using your own components and design system while OpenUI Cloud provides model reliability, output validation, and observability.
-3. **Slides:** Generate presentations from conversations using well-designed templates for charts, images, and structured content. Review decks in an interactive viewer, edit slides manually, and export them to PowerPoint.
-4. **Reports:** Generate long-form documents from conversations using rich components for metrics, charts, tables, images, and structured content. Review reports in a dedicated viewer and export them to PDF.
+4. **Slides:** Generate presentations from conversations using well-designed templates for charts, images, and structured content. Review decks in an interactive viewer, edit slides manually, and export them to PowerPoint.
+5. **Reports:** Generate long-form documents from conversations using rich components for metrics, charts, tables, images, and structured content. Review reports in a dedicated viewer and export them to PDF.
 
 ## OpenUI vs. OpenUI Cloud
 

--- a/docs/content/docs/openui-cloud/index.mdx
+++ b/docs/content/docs/openui-cloud/index.mdx
@@ -19,7 +19,7 @@ It combines OpenUI's generative UI capabilities with reliable model access, auto
 ## What you get
 
 1. **Production hardening:** Run generative UI reliably in production with managed model access, automatic fallbacks, and output validation. Requests are rerouted when a model or provider is unavailable, and generated output is validated before it reaches the interface.
-2. **Bring your own model key (BYOK):** Use your own OpenAI, Anthropic, or Google API key with OpenUI Cloud on any plan, including the free tier.
+2. **Bring your own model key (BYOK):** Use your own OpenAI, Anthropic, or Google API key with OpenUI Cloud on any plan, including the free tier. See [Models and BYOK](/docs/openui-cloud/models-and-byok).
 3. **Generative UI for agents:** Let agents respond with rich, interactive interfaces instead of walls of text. Each response can assemble the components best suited to the task.
    - **Built-in component library:** Use a pre-tested, responsive, and accessible set of components: forms, inputs, interactive charts, accordions, tabs, and other layout components.
    - **Bring your own component library:** Generate interfaces using your own components and design system while OpenUI Cloud provides model reliability, output validation, and observability.

--- a/docs/content/docs/openui-cloud/meta.json
+++ b/docs/content/docs/openui-cloud/meta.json
@@ -4,8 +4,8 @@
   "pages": [
     "index",
     "get-started",
-    "models-and-byok",
     "how-it-works",
+    "models-and-byok",
     "---Features---",
     "build/chat",
     "build/slides",

--- a/docs/content/docs/openui-cloud/meta.json
+++ b/docs/content/docs/openui-cloud/meta.json
@@ -4,6 +4,7 @@
   "pages": [
     "index",
     "get-started",
+    "models-and-byok",
     "how-it-works",
     "---Features---",
     "build/chat",

--- a/docs/content/docs/openui-cloud/models-and-byok.mdx
+++ b/docs/content/docs/openui-cloud/models-and-byok.mdx
@@ -1,6 +1,6 @@
 ---
 title: Models and BYOK
-description: "Configure provider keys and choose supported models in OpenUI Cloud."
+description: "Configure provider keys, choose supported models, and call OpenUI Cloud with the Responses API."
 ---
 
 OpenUI Cloud supports both managed model access and bring your own key (BYOK). Both use the same `provider/model` identifiers.

--- a/docs/content/docs/openui-cloud/models-and-byok.mdx
+++ b/docs/content/docs/openui-cloud/models-and-byok.mdx
@@ -1,9 +1,9 @@
 ---
 title: Models and BYOK
-description: "Configure provider keys, choose supported models, and call OpenUI Cloud with the Responses API."
+description: "Configure provider keys and choose supported models in OpenUI Cloud."
 ---
 
-OpenUI Cloud supports both managed model access and bring your own key (BYOK). Both use the same `provider/model` identifiers and OpenAI-compatible Responses API.
+OpenUI Cloud supports both managed model access and bring your own key (BYOK). Both use the same `provider/model` identifiers.
 
 ## Bring your own key
 
@@ -33,28 +33,3 @@ Model identifiers follow the `provider/model` convention. For example, use `open
 | OpenAI    | GPT-5.2                | `openai/gpt-5.2`                |
 | OpenAI    | GPT-5.1                | `openai/gpt-5.1`                |
 | OpenAI    | GPT-5                  | `openai/gpt-5`                  |
-
-## Use with the Responses API
-
-OpenUI Cloud exposes an OpenAI-compatible Responses endpoint at `POST https://api.thesys.dev/v1/embed/responses`. Use the OpenAI SDK with the Cloud base URL and authenticate with your server-side `THESYS_API_KEY`.
-
-Provider keys stay in the Thesys console and are never sent by your application. The provider prefix in `model` selects the matching BYOK key when one is configured.
-
-```ts
-import { generateSystemPrompt } from "@openuidev/thesys-server";
-import OpenAI from "openai";
-
-const cloud = new OpenAI({
-  apiKey: process.env.THESYS_API_KEY,
-  baseURL: "https://api.thesys.dev/v1/embed",
-});
-
-const stream = await cloud.responses.create({
-  model: "openai/gpt-5.5",
-  input: "Create a quarterly sales dashboard.",
-  instructions: generateSystemPrompt(),
-  stream: true,
-});
-```
-
-The generated Cloud app adds conversation persistence, artifacts, built-in tools, and stream handling around this request. See [How it works](/docs/openui-cloud/how-it-works) for the complete request lifecycle.

--- a/docs/content/docs/openui-cloud/models-and-byok.mdx
+++ b/docs/content/docs/openui-cloud/models-and-byok.mdx
@@ -1,0 +1,60 @@
+---
+title: Models and BYOK
+description: "Configure provider keys, choose supported models, and call OpenUI Cloud with the Responses API."
+---
+
+OpenUI Cloud supports both managed model access and bring your own key (BYOK). Both use the same `provider/model` identifiers and OpenAI-compatible Responses API.
+
+## Bring your own key
+
+Add an OpenAI, Anthropic, or Google API key from the [BYOK page in the Thesys console](https://console.thesys.dev/byok). BYOK is available on every plan, including the free tier.
+
+Only organization admins can add or update provider keys. Once a key is added, every member of the organization can use models from that provider through BYOK.
+
+### Provider-specific billing
+
+BYOK applies only to the matching provider. For example, if your organization adds an OpenAI key, requests to OpenAI models use that key. Requests to Anthropic or Google Vertex AI models are billed against OpenUI Cloud credits instead. If the organization has no credits, those requests fail with an out-of-credits error; otherwise, its credits are used for the requests.
+
+## Supported BYOK models
+
+Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.5`, not `gpt-5.5`.
+
+| Provider  | Model name             | Model identifier                |
+| --------- | ---------------------- | ------------------------------- |
+| Anthropic | Claude Sonnet 5        | `anthropic/claude-sonnet-5`     |
+| Anthropic | Claude Sonnet 4.6      | `anthropic/claude-sonnet-4.6`   |
+| Anthropic | Claude Opus 4.7        | `anthropic/claude-opus-4-7`     |
+| Google    | Gemini 3.6 Flash       | `google/gemini-3.6-flash`       |
+| Google    | Gemini 3.5 Flash       | `google/gemini-3.5-flash`       |
+| Google    | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
+| OpenAI    | GPT-5.5                | `openai/gpt-5.5`                |
+| OpenAI    | GPT-5.4                | `openai/gpt-5.4`                |
+| OpenAI    | GPT-5.4 mini           | `openai/gpt-5.4-mini`           |
+| OpenAI    | GPT-5.2                | `openai/gpt-5.2`                |
+| OpenAI    | GPT-5.1                | `openai/gpt-5.1`                |
+| OpenAI    | GPT-5                  | `openai/gpt-5`                  |
+
+## Use with the Responses API
+
+OpenUI Cloud exposes an OpenAI-compatible Responses endpoint at `POST https://api.thesys.dev/v1/embed/responses`. Use the OpenAI SDK with the Cloud base URL and authenticate with your server-side `THESYS_API_KEY`.
+
+Provider keys stay in the Thesys console and are never sent by your application. The provider prefix in `model` selects the matching BYOK key when one is configured.
+
+```ts
+import { generateSystemPrompt } from "@openuidev/thesys-server";
+import OpenAI from "openai";
+
+const cloud = new OpenAI({
+  apiKey: process.env.THESYS_API_KEY,
+  baseURL: "https://api.thesys.dev/v1/embed",
+});
+
+const stream = await cloud.responses.create({
+  model: "openai/gpt-5.5",
+  input: "Create a quarterly sales dashboard.",
+  instructions: generateSystemPrompt(),
+  stream: true,
+});
+```
+
+The generated Cloud app adds conversation persistence, artifacts, built-in tools, and stream handling around this request. See [How it works](/docs/openui-cloud/how-it-works) for the complete request lifecycle.


### PR DESCRIPTION
## Summary

- add BYOK to the OpenUI Cloud overview
- add a **Models and BYOK** page after **How it works** in the Cloud navigation
- document organization-admin key management and organization-wide access
- explain provider-specific BYOK billing and Cloud-credit behavior for unmatched providers
- list supported BYOK model names and `provider/model` identifiers
- link the new page from Get Started and the Cloud overview

## Why

OpenUI Cloud supports bringing an OpenAI, Anthropic, or Google API key on any plan, including the free tier. The dedicated page keeps the Get Started flow concise while making BYOK access, billing behavior, and supported models discoverable.

Related: #942

## Validation

- `pnpm --filter @openuidev/docs types:check`
- verified the documented identifiers against the Cloud starter model allowlist
- `git diff --check`
