### PR TITLE
chore(docs): bump @openuidev/thesys to 0.3.2

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
     "@openuidev/react-headless": "workspace:^",
     "@openuidev/react-lang": "workspace:^",
     "@openuidev/react-ui": "workspace:^",
-    "@openuidev/thesys": "0.3.1",
+    "@openuidev/thesys": "0.3.2",
     "@openuidev/thesys-server": "0.1.3",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-dialog": "1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
         specifier: workspace:^
         version: link:../packages/react-ui
       '@openuidev/thesys':
-        specifier: 0.3.1
-        version: 0.3.1(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))
+        specifier: 0.3.2
+        version: 0.3.2(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))
       '@openuidev/thesys-server':
         specifier: 0.1.3
         version: 0.1.3
@@ -5649,6 +5649,20 @@ packages:
       '@openuidev/react-headless': ^0.9.3
       '@openuidev/react-lang': ^0.2.8
       '@openuidev/react-ui': ^0.13.1
+      '@radix-ui/react-tooltip': ^1.0.0
+      react: ^18.3.1 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      zod: ^3.25.0 || ^4.0.0
+      zustand: ^4.5.5
+
+  '@openuidev/thesys@0.3.2':
+    resolution: {integrity: sha512-bVnVy2OcGawikt+R5QR4EBKtRvd0Y2PD9+Z94EClD5fSVtfi9VT9yztBp9a+r104SdB1GZuRuO3J/U+UALZgyg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@openuidev/lang-core': ^0.2.11
+      '@openuidev/react-headless': ^0.9.7
+      '@openuidev/react-lang': ^0.2.11
+      '@openuidev/react-ui': ^0.13.6
       '@radix-ui/react-tooltip': ^1.0.0
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -23591,7 +23605,7 @@ snapshots:
       - '@types/react-dom'
       - supports-color
 
-  '@openuidev/thesys@0.3.1(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))':
+  '@openuidev/thesys@0.3.2(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))':
     dependencies:
       '@floating-ui/react-dom': 2.1.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@openuidev/lang-core': link:packages/lang-core


### PR DESCRIPTION
Points the docs site at `@openuidev/thesys` 0.3.2 (was 0.3.1).

What 0.3.2 brings for docs:

- Inline markdown now renders in `OptionCards` and `EntityList` text props.
- Composite-card markdown emphasis is sized to the small body scale.
- Artifact preview styling updates.
- Peer ranges realigned to the current openui releases — `react-ui` ^0.13.6, `react-headless` ^0.9.7, `lang-core` / `react-lang` ^0.2.11. That is exactly what the docs workspace already ships, so nothing else has to move.

`@openuidev/thesys-server` stays at 0.1.3, which is the current published latest.

`pnpm-lock.yaml` is regenerated because `docs/` is part of the pnpm workspace — bumping the pin without it fails the frozen install in CI. The lockfile change is confined to the `@openuidev/thesys` resolution.
