### PR TITLE
feat(langchain): support custom graph input

### DIFF
--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -79,6 +79,21 @@ export async function POST(request: Request) {
 }
 ```
 
+Use `prepareInput` when the graph needs additional fields from the browser
+request, such as a provider-managed conversation id or model selection:
+
+```ts
+return createLangChainStreamResponse(request, {
+  apiUrl: process.env.LANGGRAPH_API_URL ?? "http://localhost:2024",
+  assistantId: "agent",
+  prepareInput: ({ messages, requestBody }) => ({
+    messages: messages.slice(-1),
+    conversationId: requestBody.threadId,
+    model: requestBody.model,
+  }),
+});
+```
+
 The route expects a non-empty `{ messages: Message[] }` body in AG-UI format and
 returns a JSON `400` response for malformed input. It converts text and
 multimodal user content to LangChain messages. Complete assistant tool-call and
@@ -142,8 +157,9 @@ upstream LangGraph requests.
   LangGraph response path for stateless chat routes.
 - `streamOpenUI(options)` — lower-level protocol-v2 runner and custom-channel
   relay.
-- `CreateLangChainStreamResponseOptions`, `StreamOpenUIOptions`, and
-  `LangChainInputMessage` — exported TypeScript types.
+- `CreateLangChainStreamResponseOptions`, `PrepareLangChainRunInputContext`,
+  `StreamOpenUIOptions`, and `LangChainInputMessage` — exported TypeScript
+  types.
 
 See the repository's
 [`examples/langchain-chat`](https://github.com/thesysdev/openui/tree/main/examples/langchain-chat)

--- a/packages/langchain/package.json
+++ b/packages/langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/langchain",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "LangChain and LangGraph integration primitives for streaming OpenUI generative interfaces",
   "license": "MIT",
   "engines": {

--- a/packages/langchain/src/__tests__/request-handler.test.ts
+++ b/packages/langchain/src/__tests__/request-handler.test.ts
@@ -178,6 +178,68 @@ describe("createLangChainStreamResponse", () => {
     });
   });
 
+  it("lets callers forward request fields into the graph input", async () => {
+    let commandInput: unknown;
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (String(input).endsWith("/stream/events")) {
+        return new Response(
+          `event: lifecycle\ndata: ${JSON.stringify({ type: "event", params: { namespace: [], data: { event: "completed" } } })}\n\n`,
+        );
+      }
+      commandInput = JSON.parse(String(init?.body)).params.input;
+      return Response.json({ type: "success", id: 1, result: { run_id: "run-3" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = new Request("https://app.example/api/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        threadId: "conversation-1",
+        model: "gpt-5.5",
+        messages: [{ id: "user-1", role: "user", content: "Hello" }],
+      }),
+    });
+
+    const response = await createLangChainStreamResponse(request, {
+      apiUrl: "https://langgraph.example",
+      assistantId: "agent",
+      cleanupThread: false,
+      prepareInput: ({ messages, requestBody }) => ({
+        messages: messages.slice(-1),
+        conversationId: requestBody.threadId,
+        model: requestBody.model,
+      }),
+    });
+    await response.text();
+
+    expect(commandInput).toEqual({
+      messages: [{ type: "human", content: "Hello" }],
+      conversationId: "conversation-1",
+      model: "gpt-5.5",
+    });
+  });
+
+  it("returns 400 when custom input validation fails", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await createLangChainStreamResponse(
+      chatRequest([{ id: "user-1", role: "user", content: "Hello" }]),
+      {
+        apiUrl: "https://langgraph.example",
+        assistantId: "agent",
+        prepareInput: () => {
+          throw new Error("threadId is required");
+        },
+      },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "threadId is required" });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["malformed JSON", "{"],
     ["a missing messages property", JSON.stringify({})],

--- a/packages/langchain/src/index.ts
+++ b/packages/langchain/src/index.ts
@@ -2,6 +2,7 @@ export { createLangChainStreamResponse } from "./request-handler";
 export type {
   CreateLangChainStreamResponseOptions,
   LangChainInputMessage,
+  PrepareLangChainRunInputContext,
 } from "./request-handler";
 export { streamOpenUI } from "./stream-relay";
 export type { StreamOpenUIOptions } from "./stream-relay";

--- a/packages/langchain/src/request-handler.ts
+++ b/packages/langchain/src/request-handler.ts
@@ -11,6 +11,14 @@ export interface LangChainInputMessage {
   [key: string]: unknown;
 }
 
+/** Values available when customizing the input sent to a LangGraph run. */
+export interface PrepareLangChainRunInputContext {
+  /** The validated, tool-history-safe messages converted from the AG-UI request. */
+  messages: LangChainInputMessage[];
+  /** The complete incoming JSON body, including fields such as `threadId`. */
+  requestBody: Record<string, unknown>;
+}
+
 /** Configuration for {@link createLangChainStreamResponse}. */
 export interface CreateLangChainStreamResponseOptions {
   /** LangGraph agent-protocol-v2 base URL, for example `http://localhost:2024`. */
@@ -25,6 +33,11 @@ export interface CreateLangChainStreamResponseOptions {
   cleanupThread?: boolean;
   /** Register thread cleanup with a serverless execution context such as `waitUntil`. */
   waitUntil?: (task: Promise<void>) => void;
+  /**
+   * Customize the graph input. Use this to forward application fields such as
+   * a provider conversation id or selected model alongside `messages`.
+   */
+  prepareInput?: (context: PrepareLangChainRunInputContext) => unknown | Promise<unknown>;
 }
 
 type AssistantMessage = Extract<Message, { role: "assistant" }>;
@@ -51,19 +64,28 @@ export async function createLangChainStreamResponse(
     return badRequest("Expected a JSON request body containing a non-empty messages array");
   }
 
-  const messages = parseChatRequestBody(body);
+  const requestBody = asRecord(body);
+  const messages = parseChatRequestBody(requestBody);
   if (!messages) {
     return badRequest("Expected a JSON request body containing a non-empty messages array");
   }
 
   const langChainMessages = toLangChainMessages(messages);
   const visibleMessages = sanitizeToolHistory(langChainMessages);
+  let input: unknown;
+  try {
+    input = options.prepareInput
+      ? await options.prepareInput({ messages: visibleMessages, requestBody })
+      : { messages: visibleMessages };
+  } catch (error) {
+    return badRequest(error instanceof Error ? error.message : "Unable to prepare LangGraph input");
+  }
 
   const readable = streamOpenUI({
     apiUrl: options.apiUrl,
     assistantId: options.assistantId,
     apiKey: options.apiKey,
-    input: { messages: visibleMessages },
+    input,
     signal: request.signal,
     debug: options.debug,
     cleanupThread: options.cleanupThread,
@@ -236,4 +258,8 @@ function parseChatRequestBody(value: unknown): Message[] | undefined {
   if (typeof value !== "object" || value === null || !("messages" in value)) return undefined;
   const parsed = MessageSchema.array().safeParse(value.messages);
   return parsed.success && parsed.data.length > 0 ? parsed.data : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : {};
 }


### PR DESCRIPTION
## Summary

- bump `@openuidev/langchain` to `0.0.2`
- add an optional `prepareInput` hook to `createLangChainStreamResponse`
- expose the validated, tool-history-safe messages and complete request body to the hook
- preserve the existing `{ messages }` input when the hook is omitted
- return a `400` response when caller-owned input preparation or validation fails
- export the new context type and document the API

## Why

LangGraph applications sometimes need graph-state fields that are carried alongside the browser messages, such as a provider-managed conversation ID or a selected model. The current helper always constructs `{ messages }`, forcing those applications to bypass its request validation, message conversion, and tool-history sanitization.

This keeps the helper framework-agnostic while allowing callers to construct the graph input expected by their deployed agent.

## Dependency

The Cloud + LangGraph scaffold in #785 uses this hook to forward its OpenUI Cloud conversation ID and selected model into the LangGraph run.

## Issue

[TH-2051 — Ask for backend framework in CLI](https://linear.app/thesys/issue/TH-2051/ask-for-backend-framework-in-cli)

## Validation

- `pnpm --filter @openuidev/langchain run ci`
- `pnpm --filter @openuidev/langchain run build`
- 28 package tests passing
