### PR TITLE
ci: trigger template version sync on openui-templates after publish

### DIFF
--- a/.github/workflows/update-template-versions.yml
+++ b/.github/workflows/update-template-versions.yml
@@ -1,0 +1,29 @@
+name: Update CLI Template Versions
+
+# After a package publish, ping openui-templates to sync its template
+# versions. The sync over there reads this repo's packages/*/package.json —
+# not the npm registry, whose metadata lags right after a publish — and the
+# bump PR is opened on openui-templates.
+on:
+  workflow_run:
+    workflows: ["Publish NPM packages"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-template-sync:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # head_sha pins the openui-templates checkout of this repo to exactly
+      # the commit that was published.
+      - name: Send package-published dispatch to openui-templates
+        env:
+          GH_TOKEN: ${{ secrets.TEMPLATES_REPO_TOKEN }}
+        run: |
+          gh api repos/thesysdev/openui-templates/dispatches \
+            -f event_type=package-published \
+            -F 'client_payload[sha]=${{ github.event.workflow_run.head_sha || github.sha }}'


### PR DESCRIPTION
Part 3 of 3, stacked on #953.

- After "Publish NPM packages" succeeds, sends a `repository_dispatch` (`package-published`) to openui-templates with the publish commit SHA
- The sync itself lives in openui-templates (thesysdev/openui-templates#6): it checks out this repo pinned to that SHA and reads versions from `packages/*/package.json` — the repo is the source of truth, not npm's laggy registry metadata
- Needs the `TEMPLATES_REPO_TOKEN` secret; scope shrinks to Contents: read/write on openui-templates (just enough to send the dispatch)