### PR TITLE
Bump CLI version to 0.2.6

### DIFF
--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/cli",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CLI for OpenUI — scaffold generative UI chat apps and generate LLM system prompts from component libraries",
   "bin": {
     "openui": "dist/index.js"


### PR DESCRIPTION
## What changed

- Bumped `@openuidev/cli` from `0.2.5` to `0.2.6`.

## Why

This prepares the next patch release of the OpenUI CLI.

## Impact

The published CLI will report version `0.2.6`; there are no runtime behavior changes in this PR.

## Validation

- `pnpm --filter @openuidev/cli build`
- `git diff --check`
- Verified the manifest resolves as `@openuidev/cli@0.2.6`
