### PR TITLE
docs: refresh BYOK model examples

### DIFF
--- a/docs/components/copyable-model-id.tsx
+++ b/docs/components/copyable-model-id.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { cn } from "@/lib/cn";
+import { buttonVariants } from "fumadocs-ui/components/ui/button";
+import { useCopyButton } from "fumadocs-ui/utils/use-copy-button";
+import { Check, Copy } from "lucide-react";
+
+export function CopyableModelId({ value }: { value: string }) {
+  const [copied, onCopy] = useCopyButton(() => navigator.clipboard.writeText(value));
+
+  return (
+    <span className="not-prose inline-flex items-center gap-1 rounded-md border bg-fd-secondary py-0.5 pl-2 pr-1 font-mono text-xs text-fd-secondary-foreground">
+      <code>{value}</code>
+      <button
+        type="button"
+        className={cn(buttonVariants({ color: "ghost", size: "icon-xs" }), "shrink-0")}
+        aria-label={copied ? `Copied ${value}` : `Copy ${value}`}
+        title={copied ? "Copied" : "Copy model identifier"}
+        onClick={onCopy}
+      >
+        {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+      </button>
+    </span>
+  );
+}

--- a/docs/content/docs/openui-cloud/models-and-byok.mdx
+++ b/docs/content/docs/openui-cloud/models-and-byok.mdx
@@ -3,6 +3,8 @@ title: Models and BYOK
 description: "Configure provider keys, choose supported models, and call OpenUI Cloud with the Responses API."
 ---
 
+import { CopyableModelId } from "@/components/copyable-model-id";
+
 OpenUI Cloud supports both managed model access and bring your own key (BYOK). Both use the same `provider/model` identifiers.
 
 ## Bring your own key
@@ -17,19 +19,18 @@ BYOK applies only to the matching provider. For example, if your organization ad
 
 ## Supported BYOK models
 
-Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.5`, not `gpt-5.5`.
+Model identifiers follow the `provider/model` convention. For example, use `openai/gpt-5.6-sol`, not `gpt-5.6-sol`.
 
-| Provider  | Model name             | Model identifier                |
-| --------- | ---------------------- | ------------------------------- |
-| Anthropic | Claude Sonnet 5        | `anthropic/claude-sonnet-5`     |
-| Anthropic | Claude Sonnet 4.6      | `anthropic/claude-sonnet-4.6`   |
-| Anthropic | Claude Opus 4.7        | `anthropic/claude-opus-4-7`     |
-| Google    | Gemini 3.6 Flash       | `google/gemini-3.6-flash`       |
-| Google    | Gemini 3.5 Flash       | `google/gemini-3.5-flash`       |
-| Google    | Gemini 3.1 Pro Preview | `google/gemini-3.1-pro-preview` |
-| OpenAI    | GPT-5.5                | `openai/gpt-5.5`                |
-| OpenAI    | GPT-5.4                | `openai/gpt-5.4`                |
-| OpenAI    | GPT-5.4 mini           | `openai/gpt-5.4-mini`           |
-| OpenAI    | GPT-5.2                | `openai/gpt-5.2`                |
-| OpenAI    | GPT-5.1                | `openai/gpt-5.1`                |
-| OpenAI    | GPT-5                  | `openai/gpt-5`                  |
+| Provider  | Model name             | Model identifier                                          |
+| --------- | ---------------------- | --------------------------------------------------------- |
+| Anthropic | Claude Opus 5          | <CopyableModelId value="anthropic/claude-opus-5" />       |
+| Anthropic | Claude Sonnet 5        | <CopyableModelId value="anthropic/claude-sonnet-5" />     |
+| Anthropic | Claude Opus 4.7        | <CopyableModelId value="anthropic/claude-opus-4-7" />     |
+| Google    | Gemini 3.6 Flash       | <CopyableModelId value="google/gemini-3.6-flash" />       |
+| Google    | Gemini 3.5 Flash       | <CopyableModelId value="google/gemini-3.5-flash" />       |
+| Google    | Gemini 3.1 Pro Preview | <CopyableModelId value="google/gemini-3.1-pro-preview" /> |
+| OpenAI    | GPT-5.6 Sol            | <CopyableModelId value="openai/gpt-5.6-sol" />            |
+| OpenAI    | GPT-5.5                | <CopyableModelId value="openai/gpt-5.5" />                |
+| OpenAI    | GPT-5.4                | <CopyableModelId value="openai/gpt-5.4" />                |
+
+_This is an example list; all models available from these providers are supported with BYOK._


### PR DESCRIPTION
## What changed

- reduce the BYOK model table to three current examples per provider
- add GPT-5.6 Sol and Claude Opus 5
- add a copy button to every model identifier
- clarify that the table is an example list and all models from the listed providers are supported with BYOK

## Why

The existing table overrepresented older OpenAI models and could be mistaken for an exhaustive support list. This keeps the page concise, highlights current models, and makes identifiers easier to copy into Responses API requests.

## Validation

- `pnpm exec prettier --check docs/components/copyable-model-id.tsx docs/content/docs/openui-cloud/models-and-byok.mdx`
- `pnpm --filter @openuidev/docs types:check`
- `git diff --check`
