### PR TITLE
feat: add assistant-ui integration package

### DIFF
--- a/docs/content/docs/api-reference/assistant-ui.mdx
+++ b/docs/content/docs/api-reference/assistant-ui.mdx
@@ -1,0 +1,243 @@
+---
+title: "@openuidev/assistant-ui"
+description: API reference for rendering OpenUI Lang tool calls in assistant-ui applications.
+---
+
+Use this package when assistant-ui owns the conversation and tool lifecycle and OpenUI should render
+streaming, interactive interfaces inside assistant messages.
+
+## Install
+
+```bash tab="pnpm" tab-group="pkg"
+pnpm add @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openuidev/react-lang @openuidev/react-headless react react-dom zod zustand@^4.5.5
+```
+
+```bash tab="bun" tab-group="pkg"
+bun add @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openuidev/react-lang @openuidev/react-headless react react-dom zod zustand@^4.5.5
+```
+
+```bash tab="yarn" tab-group="pkg"
+yarn add @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openuidev/react-lang @openuidev/react-headless react react-dom zod zustand@^4.5.5
+```
+
+```bash tab="npm" tab-group="pkg"
+npm install @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openuidev/react-lang @openuidev/react-headless react react-dom zod zustand@^4.5.5
+```
+
+Import the OpenUI styles once in the application:
+
+```css
+@import "@openuidev/react-ui/layered/styles/index.css";
+```
+
+## `openuiIntegration`
+
+The default integration combines a toolkit and model instructions generated from the same
+`openuiChatLibrary` component vocabulary:
+
+```ts
+interface OpenUIIntegration {
+  toolkit: Toolkit;
+  instructions: string;
+  toolNames: {
+    present: string;
+    prompt: string;
+  };
+}
+
+const openuiIntegration: OpenUIIntegration;
+```
+
+Register both values inside the assistant runtime's model-context client:
+
+```tsx
+"use client";
+
+import {
+  AssistantRuntimeProvider,
+  AuiConfig,
+  AuiProvider,
+  Tools,
+  useAui,
+  useAssistantInstructions,
+} from "@assistant-ui/react";
+import { openuiIntegration } from "@openuidev/assistant-ui";
+
+function OpenUIModelInstructions() {
+  useAssistantInstructions(openuiIntegration.instructions);
+  return null;
+}
+
+function OpenUIConfigProvider({ children }: { children: React.ReactNode }) {
+  const aui = useAui();
+  const config = AuiConfig({
+    tools: Tools({ toolkit: openuiIntegration.toolkit }),
+  });
+
+  return (
+    <AuiProvider extends={aui} config={config}>
+      <OpenUIModelInstructions />
+      {children}
+    </AuiProvider>
+  );
+}
+
+export function OpenUIRuntimeProvider({ runtime, children }) {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <OpenUIConfigProvider>{children}</OpenUIConfigProvider>
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+The default toolkit registers two standalone tools:
+
+| Tool             | assistant-ui type | Behavior                                                                                 |
+| :--------------- | :---------------- | :--------------------------------------------------------------------------------------- |
+| `present_openui` | `frontend`        | Renders display-only OpenUI Lang and completes when the streamed `ui` argument is ready. |
+| `prompt_openui`  | `human`           | Waits for an OpenUI `@ToAssistant` action, then submits its message and form state.      |
+
+## `createOpenUIIntegration(options)`
+
+Creates an aligned toolkit and instruction string for a custom library, tool names, renderer, or
+prompt configuration.
+
+```ts
+interface CreateOpenUIIntegrationOptions extends OpenUIToolUIOptions {
+  promptOptions?: PromptOptions;
+  presentToolName?: string;
+  promptToolName?: string;
+  presentDescription?: string;
+  promptDescription?: string;
+  preamble?: string;
+  additionalRules?: string[];
+}
+
+function createOpenUIIntegration(options?: CreateOpenUIIntegrationOptions): OpenUIIntegration;
+```
+
+```ts
+import { createOpenUIIntegration } from "@openuidev/assistant-ui";
+import { library } from "./library";
+
+const openui = createOpenUIIntegration({
+  library,
+  presentToolName: "show_panel",
+  promptToolName: "ask_panel",
+});
+```
+
+## Toolkit APIs
+
+```ts
+function createOpenUIToolkit(options?: CreateOpenUIToolkitOptions): Toolkit;
+function createOpenUIToolParameters(root?: string): z.ZodObject;
+
+const openuiToolkit: Toolkit;
+const openuiToolParameters: z.ZodObject;
+const OPENUI_PRESENT_TOOL_NAME = "present_openui";
+const OPENUI_PROMPT_TOOL_NAME = "prompt_openui";
+```
+
+`CreateOpenUIToolkitOptions` accepts the library, tool names and descriptions, plus the renderer
+options described below. Display and prompt tools must use different, non-empty names.
+
+## Renderer APIs
+
+```ts
+function OpenUIContent(props: OpenUIContentProps): React.ReactNode;
+function OpenUIPresent(props: OpenUIPresentProps): React.ReactNode;
+function OpenUIPrompt(props: OpenUIPromptProps): React.ReactNode;
+
+function createOpenUIPresent(options?: OpenUIToolUIOptions): ToolCallMessagePartComponent;
+
+function createOpenUIPrompt(options?: OpenUIToolUIOptions): ToolCallMessagePartComponent;
+```
+
+Shared configuration:
+
+```ts
+interface OpenUIToolUIOptions {
+  library?: Library;
+  rendererProps?: OpenUIRendererProps;
+  ErrorFallback?: OpenUIErrorFallback | null;
+  onError?: (errors: OpenUIError[]) => void;
+}
+```
+
+`OpenUIContent` forwards supported props to the OpenUI `Renderer`. Parser errors may be transient
+while `ui` is streaming, so the default error fallback appears only after streaming finishes. Set
+`ErrorFallback: null` to suppress it.
+
+`OpenUIPrompt` calls assistant-ui's `addResult` once for a terminal `@ToAssistant` action. Its result
+contains the action type, message, parameters, optional form name, and form state. Replayed messages
+use the saved form state as the renderer's initial state.
+
+## Instruction APIs
+
+```ts
+function createOpenUIInstructions(options?: CreateOpenUIInstructionsOptions): string;
+function useOpenUIInstructions(options?: UseOpenUIInstructionsOptions): void;
+function OpenUIInstructions(options: UseOpenUIInstructionsOptions): null;
+
+const openuiInstructions: string;
+```
+
+The generated instructions tell the model when to use each tool, include the selected library's
+OpenUI Lang prompt, and keep the display and interactive tool contracts distinct.
+
+## Runtime support and continuation
+
+The core `@openuidev/assistant-ui` entrypoint is runtime-agnostic. Its toolkit, renderers, and
+instructions work with any assistant-ui runtime that forwards tool schemas and results.
+
+After `prompt_openui` receives a result, a runtime adapter should continue the conversation once all
+tools in the current step are complete. A completed `present_openui` call remains the final display
+response and should not automatically start another model step.
+
+### Vercel AI SDK
+
+The optional `/ai-sdk` subpath implements that continuation policy for Vercel AI SDK runtimes. The
+`ai` package is an optional peer dependency and is not required by the core entrypoint.
+
+```tsx
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { shouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk";
+
+const runtime = useChatRuntime({
+  sendAutomaticallyWhen: shouldContinueAfterOpenUIPrompt,
+});
+```
+
+For custom tool names:
+
+```ts
+import { createShouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk";
+
+const shouldContinue = createShouldContinueAfterOpenUIPrompt({
+  promptToolName: "ask_panel",
+});
+```
+
+Other runtimes can implement the same policy through their continuation API. Additional
+runtime-specific helpers can be published as separate subpath exports without coupling the core
+integration to one transport or model SDK.
+
+## Exports
+
+| Export                                  | Description                                                     |
+| :-------------------------------------- | :-------------------------------------------------------------- |
+| `openuiIntegration`                     | Default aligned toolkit and instructions                        |
+| `createOpenUIIntegration`               | Integration factory for custom libraries and tool names         |
+| `openuiToolkit` / `createOpenUIToolkit` | Default toolkit and toolkit factory                             |
+| `openuiInstructions`                    | Default generated model instructions                            |
+| `createOpenUIInstructions`              | Instruction factory                                             |
+| `OpenUIInstructions`                    | Component that registers generated instructions                 |
+| `useOpenUIInstructions`                 | Hook that registers generated instructions                      |
+| `OpenUIContent`                         | OpenUI renderer wrapper for streamed tool arguments             |
+| `OpenUIPresent` / `createOpenUIPresent` | Display-tool renderer and factory                               |
+| `OpenUIPrompt` / `createOpenUIPrompt`   | Human-tool renderer and factory                                 |
+| `DefaultOpenUIErrorFallback`            | Default post-stream renderer error message                      |
+| `shouldContinueAfterOpenUIPrompt`       | Vercel AI SDK continuation predicate from the `/ai-sdk` subpath |
+| `createShouldContinueAfterOpenUIPrompt` | Vercel AI SDK predicate factory from the `/ai-sdk` subpath      |

--- a/docs/content/docs/api-reference/index.mdx
+++ b/docs/content/docs/api-reference/index.mdx
@@ -13,6 +13,8 @@ The OpenUI SDK is split into packages that build on each other:
 
 - **`@openuidev/react-ui`** — `AgentInterface`, a ready-to-use artifact chat surface with thread history, plus two built-in component libraries (general-purpose and chat-optimized). Depends on both packages above. Use this for the fastest path to a working chat interface.
 
+- **`@openuidev/assistant-ui`** — OpenUI tool renderers, model instructions, and toolkit wiring for applications built with assistant-ui. The core integration supports any assistant-ui runtime; an optional `/ai-sdk` subpath adds Vercel AI SDK continuation behavior.
+
 - **`@openuidev/react-email`** — Pre-built email component library and prompt options for model-generated emails that can be rendered to HTML with React Email.
 
 - **`@openuidev/vue-lang`** — Vue 3 bindings for defining model-renderable components, generating prompts from those definitions, and rendering streamed OpenUI Lang in Vue apps.
@@ -33,6 +35,7 @@ The OpenUI SDK is split into packages that build on each other:
 | React rendering primitives for OpenUI Lang                         | [`@openuidev/react-lang`](/docs/api-reference/react-lang)                                            |
 | Chat state and streaming without prebuilt UI                       | [`@openuidev/react-headless`](/docs/api-reference/react-headless)                                    |
 | A ready-made React chat surface                                    | [`@openuidev/react-ui`](/docs/api-reference/react-ui)                                                |
+| OpenUI tool rendering in an assistant-ui application               | [`@openuidev/assistant-ui`](/docs/api-reference/assistant-ui)                                        |
 | Model-generated emails                                             | [`@openuidev/react-email`](/docs/api-reference/react-email)                                          |
 | Vue integration                                                    | [`@openuidev/vue-lang`](https://github.com/thesysdev/openui/tree/main/packages/vue-lang)             |
 | Svelte integration                                                 | [`@openuidev/svelte-lang`](https://github.com/thesysdev/openui/tree/main/packages/svelte-lang)       |
@@ -60,6 +63,10 @@ The OpenUI SDK is split into packages that build on each other:
   <Card title="@openuidev/react-ui" href="/docs/api-reference/react-ui">
     AgentInterface, a ready-to-use artifact chat surface with thread history, and two built-in
     component libraries (general-purpose and chat-optimized).
+  </Card>
+  <Card title="@openuidev/assistant-ui" href="/docs/api-reference/assistant-ui">
+    Tool renderers, toolkit and instruction factories, interactive form handling, and optional
+    runtime-specific continuation helpers for assistant-ui applications.
   </Card>
   <Card title="@openuidev/react-email" href="/docs/api-reference/react-email">
     API reference for the pre-built email templates library and prompt options.

--- a/docs/content/docs/api-reference/index.mdx
+++ b/docs/content/docs/api-reference/index.mdx
@@ -15,6 +15,8 @@ The OpenUI SDK is split into packages that build on each other:
 
 - **`@openuidev/assistant-ui`** — OpenUI tool renderers, model instructions, and toolkit wiring for applications built with assistant-ui. The core integration supports any assistant-ui runtime; an optional `/ai-sdk` subpath adds Vercel AI SDK continuation behavior.
 
+- **`@openuidev/langchain`** — LangChain and LangGraph integration primitives for transforming protocol-v2 agent streams into AG-UI events and relaying them to an OpenUI frontend over Web-standard Server-Sent Events.
+
 - **`@openuidev/react-email`** — Pre-built email component library and prompt options for model-generated emails that can be rendered to HTML with React Email.
 
 - **`@openuidev/vue-lang`** — Vue 3 bindings for defining model-renderable components, generating prompts from those definitions, and rendering streamed OpenUI Lang in Vue apps.
@@ -36,6 +38,7 @@ The OpenUI SDK is split into packages that build on each other:
 | Chat state and streaming without prebuilt UI                       | [`@openuidev/react-headless`](/docs/api-reference/react-headless)                                    |
 | A ready-made React chat surface                                    | [`@openuidev/react-ui`](/docs/api-reference/react-ui)                                                |
 | OpenUI tool rendering in an assistant-ui application               | [`@openuidev/assistant-ui`](/docs/api-reference/assistant-ui)                                        |
+| A LangChain or LangGraph agent connected to an OpenUI frontend     | [`@openuidev/langchain`](/docs/api-reference/langchain)                                              |
 | Model-generated emails                                             | [`@openuidev/react-email`](/docs/api-reference/react-email)                                          |
 | Vue integration                                                    | [`@openuidev/vue-lang`](https://github.com/thesysdev/openui/tree/main/packages/vue-lang)             |
 | Svelte integration                                                 | [`@openuidev/svelte-lang`](https://github.com/thesysdev/openui/tree/main/packages/svelte-lang)       |
@@ -67,6 +70,10 @@ The OpenUI SDK is split into packages that build on each other:
   <Card title="@openuidev/assistant-ui" href="/docs/api-reference/assistant-ui">
     Tool renderers, toolkit and instruction factories, interactive form handling, and optional
     runtime-specific continuation helpers for assistant-ui applications.
+  </Card>
+  <Card title="@openuidev/langchain" href="/docs/api-reference/langchain">
+    LangGraph stream transformation, stateless run helpers, and AG-UI SSE relay APIs for OpenUI
+    frontends.
   </Card>
   <Card title="@openuidev/react-email" href="/docs/api-reference/react-email">
     API reference for the pre-built email templates library and prompt options.

--- a/docs/content/docs/api-reference/langchain.mdx
+++ b/docs/content/docs/api-reference/langchain.mdx
@@ -1,0 +1,239 @@
+---
+title: "@openuidev/langchain"
+description: API reference for streaming LangChain and LangGraph agents to OpenUI over AG-UI.
+---
+
+Use this package to transform LangGraph protocol-v2 message and tool events into AG-UI and relay
+them to an OpenUI frontend over Server-Sent Events.
+
+The package is framework-independent at the HTTP boundary. Its server APIs use Web-standard
+`Request`, `Response`, `fetch`, and `ReadableStream` rather than depending on Next.js or
+DeepAgents.
+
+## Install
+
+Install the package for the Web-standard server helpers:
+
+```bash tab="pnpm" tab-group="pkg"
+pnpm add @openuidev/langchain
+```
+
+```bash tab="bun" tab-group="pkg"
+bun add @openuidev/langchain
+```
+
+```bash tab="yarn" tab-group="pkg"
+yarn add @openuidev/langchain
+```
+
+```bash tab="npm" tab-group="pkg"
+npm install @openuidev/langchain
+```
+
+Applications that run the agent-side transformer also install the optional LangGraph peer:
+
+```bash
+npm install @openuidev/langchain @langchain/langgraph
+```
+
+The integration requires an agent-protocol-v2 server with both the `custom:*` and root `lifecycle`
+event channels. The tested local-server baseline is `@langchain/langgraph-cli` 1.4.x.
+
+## Data flow
+
+1. `openUIStreamTransformer()` converts LangGraph `messages` and `tools` events to AG-UI events on
+   the remote `custom:openui` channel.
+2. `createLangChainStreamResponse()` starts a stateless LangGraph run, adds the AG-UI run lifecycle,
+   and relays that channel as SSE.
+3. OpenUI's `agUIAdapter()` consumes the response without LangChain-specific frontend code.
+
+## `openUIStreamTransformer()`
+
+Import the transformer from the `/transformer` subpath and register it with any agent that accepts
+LangGraph `streamTransformers`:
+
+```ts
+import { openUIStreamTransformer } from "@openuidev/langchain/transformer";
+import { createDeepAgent } from "deepagents";
+
+export const graph = createDeepAgent({
+  model: "openai:gpt-5.5",
+  tools: [getWeather, getStockPrice, searchWeb],
+  systemPrompt: SYSTEM_PROMPT,
+  streamTransformers: [openUIStreamTransformer],
+});
+```
+
+```ts
+function openUIStreamTransformer(): StreamTransformer<{
+  openui: StreamChannel<AGUIEvent>;
+}>;
+```
+
+The transformer handles assistant text, tool-call deltas, tool results, and run errors. LangGraph
+publishes the resulting events remotely under `custom:openui`. The transformer subpath is the only
+entrypoint that loads `@langchain/langgraph`; the root server helpers communicate with LangGraph
+over HTTP.
+
+## `createLangChainStreamResponse(request, options)`
+
+Creates the complete AG-UI-request-to-LangGraph-response path for a stateless chat route:
+
+```ts
+function createLangChainStreamResponse(
+  request: Request,
+  options: CreateLangChainStreamResponseOptions,
+): Promise<Response>;
+```
+
+```ts
+interface CreateLangChainStreamResponseOptions {
+  apiUrl: string;
+  assistantId: string;
+  apiKey?: string;
+  debug?: boolean;
+  cleanupThread?: boolean;
+  waitUntil?: (task: Promise<void>) => void;
+  prepareInput?: (context: PrepareLangChainRunInputContext) => unknown | Promise<unknown>;
+}
+```
+
+The request body must contain a non-empty `{ messages: Message[] }` value in AG-UI format. Invalid
+JSON or messages return a JSON `400` response without starting a LangGraph run.
+
+The helper:
+
+- Converts text and multimodal user content to LangChain input messages.
+- Preserves complete assistant tool-call and tool-result pairs.
+- Removes incomplete calls and orphaned tool results before starting the run.
+- Returns AG-UI SSE with `RUN_STARTED` and `RUN_FINISHED` or `RUN_ERROR` lifecycle events.
+- Creates a temporary LangGraph thread and attempts bounded cleanup after the response completes.
+- Redacts upstream response details and registered graph ids unless trusted development code enables
+  `debug`.
+
+It can be returned directly from a Next.js route or any other Web-standard route handler:
+
+```ts
+import { createLangChainStreamResponse } from "@openuidev/langchain";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  return createLangChainStreamResponse(request, {
+    apiUrl: process.env.LANGGRAPH_API_URL ?? "http://localhost:2024",
+    assistantId: process.env.LANGGRAPH_ASSISTANT_ID ?? "agent",
+    apiKey: process.env.LANGSMITH_API_KEY,
+    debug: process.env.NODE_ENV !== "production",
+  });
+}
+```
+
+### `prepareInput(context)`
+
+Use `prepareInput` when the graph needs fields from the browser request in addition to converted
+messages:
+
+```ts
+interface PrepareLangChainRunInputContext {
+  messages: LangChainInputMessage[];
+  requestBody: Record<string, unknown>;
+}
+```
+
+```ts
+return createLangChainStreamResponse(request, {
+  apiUrl: process.env.LANGGRAPH_API_URL ?? "http://localhost:2024",
+  assistantId: "agent",
+  prepareInput: ({ messages, requestBody }) => ({
+    messages: messages.slice(-1),
+    conversationId: requestBody.threadId,
+    model: requestBody.model,
+  }),
+});
+```
+
+If `prepareInput` throws, the helper returns its error message in a `400` response and does not
+start a run.
+
+### Cleanup on serverless platforms
+
+Temporary-thread cleanup defaults to enabled. Pass the platform's `waitUntil`-style registration
+function when cleanup should survive a client disconnect:
+
+```ts
+return createLangChainStreamResponse(request, {
+  apiUrl,
+  assistantId,
+  waitUntil: (task) => executionContext.waitUntil(task),
+});
+```
+
+Set `cleanupThread: false` only when the temporary thread must remain available for local debugging.
+
+## `streamOpenUI(options)`
+
+Use the lower-level relay when the route builds the LangGraph input itself:
+
+```ts
+interface StreamOpenUIOptions {
+  apiUrl: string;
+  assistantId: string;
+  apiKey?: string;
+  input: unknown;
+  signal?: AbortSignal;
+  debug?: boolean;
+  cleanupThread?: boolean;
+  waitUntil?: (task: Promise<void>) => void;
+}
+
+function streamOpenUI(options: StreamOpenUIOptions): ReadableStream<Uint8Array>;
+```
+
+```ts
+import { streamOpenUI } from "@openuidev/langchain";
+
+const body = streamOpenUI({
+  apiUrl: "http://localhost:2024",
+  assistantId: "agent",
+  input: { messages: [{ type: "human", content: "Hello" }] },
+  signal: request.signal,
+});
+
+return new Response(body, {
+  headers: { "Content-Type": "text/event-stream" },
+});
+```
+
+Cancelling the returned stream or aborting `signal` aborts both upstream LangGraph requests.
+
+## Connect the OpenUI frontend
+
+The route returns standard AG-UI SSE, so the browser uses OpenUI's normal adapter:
+
+```tsx
+import { AgentInterface, agUIAdapter, fetchLLM } from "@openuidev/react-ui";
+
+const llm = fetchLLM({
+  url: "/api/chat",
+  streamAdapter: agUIAdapter(),
+});
+
+export function Chat() {
+  return <AgentInterface llm={llm} />;
+}
+```
+
+## Exports
+
+| Entry point                        | Export                                 | Description                                    |
+| :--------------------------------- | :------------------------------------- | :--------------------------------------------- |
+| `@openuidev/langchain`             | `createLangChainStreamResponse`        | Complete Web-standard request/response helper  |
+| `@openuidev/langchain`             | `streamOpenUI`                         | Lower-level protocol-v2 runner and AG-UI relay |
+| `@openuidev/langchain`             | `CreateLangChainStreamResponseOptions` | Request helper configuration                   |
+| `@openuidev/langchain`             | `PrepareLangChainRunInputContext`      | Values passed to `prepareInput`                |
+| `@openuidev/langchain`             | `LangChainInputMessage`                | Converted graph input message shape            |
+| `@openuidev/langchain`             | `StreamOpenUIOptions`                  | Lower-level relay configuration                |
+| `@openuidev/langchain/transformer` | `openUIStreamTransformer`              | Agent-side protocol-v2 to AG-UI transformer    |
+
+See the complete [`langchain-chat`](https://github.com/thesysdev/openui/tree/main/examples/langchain-chat)
+example for local and LangGraph Platform setups.

--- a/docs/content/docs/api-reference/meta.json
+++ b/docs/content/docs/api-reference/meta.json
@@ -1,5 +1,14 @@
 {
   "title": "API Reference",
   "root": true,
-  "pages": ["index", "react-lang", "react-headless", "react-ui", "react-email", "devtools", "cli"]
+  "pages": [
+    "index",
+    "react-lang",
+    "react-headless",
+    "react-ui",
+    "assistant-ui",
+    "react-email",
+    "devtools",
+    "cli"
+  ]
 }

--- a/docs/content/docs/api-reference/meta.json
+++ b/docs/content/docs/api-reference/meta.json
@@ -7,6 +7,7 @@
     "react-headless",
     "react-ui",
     "assistant-ui",
+    "langchain",
     "react-email",
     "devtools",
     "cli"

--- a/packages/assistant-ui/README.md
+++ b/packages/assistant-ui/README.md
@@ -19,54 +19,109 @@ Import the OpenUI styles once in your app:
 ```tsx
 "use client";
 
-import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
-import { OpenUIInstructions, openuiToolkit } from "@openuidev/assistant-ui";
+import {
+  AssistantRuntimeProvider,
+  AuiConfig,
+  AuiProvider,
+  Tools,
+  useAui,
+  useAssistantInstructions,
+} from "@assistant-ui/react";
+import { openuiIntegration } from "@openuidev/assistant-ui";
 
-export function OpenUIRuntimeProvider({ runtime, children }) {
-  const aui = useAui({
-    tools: Tools({ toolkit: openuiToolkit }),
+function OpenUIModelInstructions() {
+  useAssistantInstructions(openuiIntegration.instructions);
+  return null;
+}
+
+function OpenUIConfigProvider({ children }) {
+  const aui = useAui();
+  const config = AuiConfig({
+    tools: Tools({ toolkit: openuiIntegration.toolkit }),
   });
 
   return (
-    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
-      <OpenUIInstructions />
+    <AuiProvider extends={aui} config={config}>
+      <OpenUIModelInstructions />
       {children}
+    </AuiProvider>
+  );
+}
+
+export function OpenUIRuntimeProvider({ runtime, children }) {
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <OpenUIConfigProvider>{children}</OpenUIConfigProvider>
     </AssistantRuntimeProvider>
   );
 }
 ```
+
+Mount the OpenUI config inside `AssistantRuntimeProvider`. This keeps the tool
+schemas, renderers, and instructions on the runtime's model-context client so
+`AssistantChatTransport` can forward both tools to the backend.
 
 The default toolkit registers two standalone tools:
 
 - `present_openui` is a frontend tool for display-only cards, tables, charts, and other interfaces. It completes as soon as the streamed `ui` argument is available.
 - `prompt_openui` is a human tool for forms and choices. It completes only when an OpenUI `@ToAssistant(...)` action submits a result.
 
-`OpenUIInstructions` generates model instructions from the same `openuiChatLibrary` used by both renderers, so the model and renderer share one component vocabulary.
+`openuiIntegration` contains a toolkit and instruction string created from the
+same `openuiChatLibrary`, so the model and renderer share one component
+vocabulary. `openuiToolkit`, `openuiInstructions`, and the
+`OpenUIInstructions` component remain available as default conveniences.
 
 ## Customize the component library
 
-Create the toolkit and instruction string from the same library:
+Use the integration factory to keep custom libraries and tool names aligned:
 
 ```tsx
-import { createOpenUIInstructions, createOpenUIToolkit } from "@openuidev/assistant-ui";
-import { useAssistantInstructions } from "@assistant-ui/react";
+import { createOpenUIIntegration } from "@openuidev/assistant-ui";
 import { library } from "./library";
 
-const toolkit = createOpenUIToolkit({ library });
-const instructions = createOpenUIInstructions({ library });
-
-function Instructions() {
-  useAssistantInstructions(instructions);
-  return null;
-}
+const openui = createOpenUIIntegration({
+  library,
+  presentToolName: "show_panel",
+  promptToolName: "ask_panel",
+});
 ```
 
-`createOpenUIToolkit` also accepts custom tool names, descriptions, renderer props, error handling, and an error fallback. Pass the same custom tool names to `createOpenUIInstructions`.
+The result exposes `toolkit`, `instructions`, and the resolved `toolNames`.
+`createOpenUIIntegration` also accepts custom descriptions, prompt options,
+renderer props, error handling, and an error fallback.
 
 ## Human-tool continuation
 
 OpenUI returns the submitted action, message, parameters, and form state through assistant-ui's `addResult`. Replayed messages hydrate the submitted form state automatically.
 
-If the runtime has an automatic tool-continuation predicate, continue only after a completed `prompt_openui` call. A completed `present_openui` call is already the final display response and should not start another model step.
+For a Vercel AI SDK runtime, install `ai` and use the optional helper subpath:
+
+```tsx
+import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
+import { shouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk";
+
+const runtime = useChatRuntime({
+  sendAutomaticallyWhen: shouldContinueAfterOpenUIPrompt,
+});
+```
+
+The predicate waits for every tool in the latest step to finish, then continues
+only when that step contains a completed `prompt_openui` call. A completed
+`present_openui` call is already the final display response and does not start
+another model step.
+
+Match a custom integration's prompt tool name with a custom predicate:
+
+```tsx
+import { createOpenUIIntegration } from "@openuidev/assistant-ui";
+import { createShouldContinueAfterOpenUIPrompt } from "@openuidev/assistant-ui/ai-sdk";
+
+const openui = createOpenUIIntegration({
+  promptToolName: "ask_panel",
+});
+const shouldContinue = createShouldContinueAfterOpenUIPrompt({
+  promptToolName: openui.toolNames.prompt,
+});
+```
 
 Parser errors can be transient while the `ui` argument is streaming. The default error fallback appears only after streaming finishes. Use `onError` to observe the structured OpenUI errors or set `ErrorFallback: null` to suppress the fallback.

--- a/packages/assistant-ui/README.md
+++ b/packages/assistant-ui/README.md
@@ -94,7 +94,15 @@ renderer props, error handling, and an error fallback.
 
 OpenUI returns the submitted action, message, parameters, and form state through assistant-ui's `addResult`. Replayed messages hydrate the submitted form state automatically.
 
-For a Vercel AI SDK runtime, install `ai` and use the optional helper subpath:
+The core integration is not tied to the Vercel AI SDK. Its toolkit, renderers,
+and instructions can be used with any assistant-ui runtime that forwards tool
+schemas and results. A runtime adapter only needs to continue the conversation
+after `prompt_openui` receives its result, while leaving a completed
+`present_openui` call as the final display response. Runtime-specific helpers
+can implement that policy using the runtime's continuation API.
+
+For a Vercel AI SDK runtime, the package provides that policy as an optional
+convenience helper. Install `ai` and import it from the `/ai-sdk` subpath:
 
 ```tsx
 import { useChatRuntime } from "@assistant-ui/react-ai-sdk";

--- a/packages/assistant-ui/README.md
+++ b/packages/assistant-ui/README.md
@@ -1,0 +1,72 @@
+# `@openuidev/assistant-ui`
+
+Render streaming OpenUI Lang programs as assistant-ui Tool UI. The package keeps assistant-ui in charge of the conversation and tool lifecycle while OpenUI handles parsing, rendering, interaction state, and replay.
+
+## Install
+
+```bash
+pnpm add @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openuidev/react-lang @openuidev/react-headless react react-dom zod zustand@^4.5.5
+```
+
+Import the OpenUI styles once in your app:
+
+```css
+@import "@openuidev/react-ui/layered/styles/index.css";
+```
+
+## Register the tools and instructions
+
+```tsx
+"use client";
+
+import { AssistantRuntimeProvider, Tools, useAui } from "@assistant-ui/react";
+import { OpenUIInstructions, openuiToolkit } from "@openuidev/assistant-ui";
+
+export function OpenUIRuntimeProvider({ runtime, children }) {
+  const aui = useAui({
+    tools: Tools({ toolkit: openuiToolkit }),
+  });
+
+  return (
+    <AssistantRuntimeProvider aui={aui} runtime={runtime}>
+      <OpenUIInstructions />
+      {children}
+    </AssistantRuntimeProvider>
+  );
+}
+```
+
+The default toolkit registers two standalone tools:
+
+- `present_openui` is a frontend tool for display-only cards, tables, charts, and other interfaces. It completes as soon as the streamed `ui` argument is available.
+- `prompt_openui` is a human tool for forms and choices. It completes only when an OpenUI `@ToAssistant(...)` action submits a result.
+
+`OpenUIInstructions` generates model instructions from the same `openuiChatLibrary` used by both renderers, so the model and renderer share one component vocabulary.
+
+## Customize the component library
+
+Create the toolkit and instruction string from the same library:
+
+```tsx
+import { createOpenUIInstructions, createOpenUIToolkit } from "@openuidev/assistant-ui";
+import { useAssistantInstructions } from "@assistant-ui/react";
+import { library } from "./library";
+
+const toolkit = createOpenUIToolkit({ library });
+const instructions = createOpenUIInstructions({ library });
+
+function Instructions() {
+  useAssistantInstructions(instructions);
+  return null;
+}
+```
+
+`createOpenUIToolkit` also accepts custom tool names, descriptions, renderer props, error handling, and an error fallback. Pass the same custom tool names to `createOpenUIInstructions`.
+
+## Human-tool continuation
+
+OpenUI returns the submitted action, message, parameters, and form state through assistant-ui's `addResult`. Replayed messages hydrate the submitted form state automatically.
+
+If the runtime has an automatic tool-continuation predicate, continue only after a completed `prompt_openui` call. A completed `present_openui` call is already the final display response and should not start another model step.
+
+Parser errors can be transient while the `ui` argument is streaming. The default error fallback appears only after streaming finishes. Use `onError` to observe the structured OpenUI errors or set `ErrorFallback: null` to suppress the fallback.

--- a/packages/assistant-ui/eslint.config.cjs
+++ b/packages/assistant-ui/eslint.config.cjs
@@ -6,8 +6,24 @@ const eslintPluginPrettier = require("eslint-plugin-prettier");
 
 module.exports = [
   {
+    files: ["**/__tests__/**/*.{ts,tsx}", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    languageOptions: {
+      parser: typescript,
+      parserOptions: {
+        project: "./tsconfig.test.json",
+        sourceType: "module",
+      },
+    },
+  },
+  {
     files: ["**/*.{ts,tsx}"],
-    ignores: ["*.config.ts"],
+    ignores: [
+      "**/*.stories.tsx",
+      "**/__tests__/**/*.{ts,tsx}",
+      "**/*.test.{ts,tsx}",
+      "**/*.spec.{ts,tsx}",
+      "*.config.ts",
+    ],
     languageOptions: {
       parser: typescript,
       parserOptions: {
@@ -29,13 +45,27 @@ module.exports = [
       "@typescript-eslint/no-unused-vars": [
         "error",
         {
-          "vars": "all",
-          "varsIgnorePattern": "^_",
-          "args": "after-used",
-          "argsIgnorePattern": "^_"
-        }
+          vars: "all",
+          varsIgnorePattern: "^_",
+          args: "after-used",
+          argsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-use-before-define": [
+        "error",
+        {
+          functions: false,
+          classes: false,
+          variables: false,
+        },
       ],
       "unused-imports/no-unused-imports": "error",
+      "no-console": [
+        "error",
+        {
+          allow: ["error", "warn", "info"],
+        },
+      ],
       ...eslintPluginPrettier.configs.recommended.rules,
     },
   },

--- a/packages/assistant-ui/eslint.config.cjs
+++ b/packages/assistant-ui/eslint.config.cjs
@@ -1,0 +1,43 @@
+const tseslint = require("@typescript-eslint/eslint-plugin");
+const typescript = require("@typescript-eslint/parser");
+const prettier = require("eslint-config-prettier");
+const unusedImports = require("eslint-plugin-unused-imports");
+const eslintPluginPrettier = require("eslint-plugin-prettier");
+
+module.exports = [
+  {
+    files: ["**/*.{ts,tsx}"],
+    ignores: ["*.config.ts"],
+    languageOptions: {
+      parser: typescript,
+      parserOptions: {
+        project: "./tsconfig.json",
+        sourceType: "module",
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tseslint,
+      "unused-imports": unusedImports,
+      prettier: eslintPluginPrettier,
+    },
+    rules: {
+      "@typescript-eslint/interface-name-prefix": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/no-explicit-any": "off",
+      "no-undefined": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "vars": "all",
+          "varsIgnorePattern": "^_",
+          "args": "after-used",
+          "argsIgnorePattern": "^_"
+        }
+      ],
+      "unused-imports/no-unused-imports": "error",
+      ...eslintPluginPrettier.configs.recommended.rules,
+    },
+  },
+  prettier,
+];

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -10,6 +10,13 @@
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "types": "dist/index.d.cts",
+  "typesVersions": {
+    "*": {
+      "ai-sdk": [
+        "dist/ai-sdk.d.cts"
+      ]
+    }
+  },
   "sideEffects": false,
   "files": [
     "dist",
@@ -24,6 +31,16 @@
       "require": {
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
+      }
+    },
+    "./ai-sdk": {
+      "import": {
+        "types": "./dist/ai-sdk.d.mts",
+        "default": "./dist/ai-sdk.mjs"
+      },
+      "require": {
+        "types": "./dist/ai-sdk.d.cts",
+        "default": "./dist/ai-sdk.cjs"
       }
     }
   },
@@ -65,15 +82,22 @@
     "@openuidev/react-headless": "workspace:^",
     "@openuidev/react-lang": "workspace:^",
     "@openuidev/react-ui": "workspace:^",
+    "ai": "^6.0.0 || ^7.0.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "zod": "catalog:",
     "zustand": "catalog:"
   },
+  "peerDependenciesMeta": {
+    "ai": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@assistant-ui/react": "^0.15.13",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
+    "ai": "^6.0.236",
     "jsdom": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "@openuidev/assistant-ui",
+  "version": "0.0.1",
+  "description": "OpenUI Lang tool renderers and instruction wiring for assistant-ui",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.cts",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown",
+    "watch": "tsdown --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint:check": "eslint ./src",
+    "lint:fix": "eslint ./src --fix",
+    "format:fix": "prettier --write ./src README.md",
+    "format:check": "prettier --check ./src README.md",
+    "check:publint": "publint",
+    "check:attw": "attw --pack .",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run check:publint && pnpm run check:attw",
+    "ci": "pnpm run typecheck && pnpm run test && pnpm run lint:check && pnpm run format:check"
+  },
+  "keywords": [
+    "openui",
+    "assistant-ui",
+    "generative-ui",
+    "tool-ui",
+    "react",
+    "streaming"
+  ],
+  "homepage": "https://openui.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thesysdev/openui.git",
+    "directory": "packages/assistant-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/thesysdev/openui/issues"
+  },
+  "author": "engineering@thesys.dev",
+  "peerDependencies": {
+    "@assistant-ui/react": "^0.15.0",
+    "@openuidev/react-headless": "workspace:^",
+    "@openuidev/react-lang": "workspace:^",
+    "@openuidev/react-ui": "workspace:^",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "zod": "catalog:",
+    "zustand": "catalog:"
+  },
+  "devDependencies": {
+    "@assistant-ui/react": "^0.15.13",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "jsdom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/assistant-ui/src/__tests__/ai-sdk.test.ts
+++ b/packages/assistant-ui/src/__tests__/ai-sdk.test.ts
@@ -1,0 +1,97 @@
+import type { UIMessage } from "ai";
+import { describe, expect, it } from "vitest";
+import { createShouldContinueAfterOpenUIPrompt, shouldContinueAfterOpenUIPrompt } from "../ai-sdk";
+
+const message = (parts: UIMessage["parts"]): UIMessage => ({
+  id: "assistant-message",
+  role: "assistant",
+  parts,
+});
+
+describe("shouldContinueAfterOpenUIPrompt", () => {
+  it("continues after the user completes prompt_openui", () => {
+    expect(
+      shouldContinueAfterOpenUIPrompt({
+        messages: [
+          message([
+            { type: "step-start" },
+            {
+              type: "tool-prompt_openui",
+              toolCallId: "prompt-1",
+              state: "output-available",
+              input: { ui: "root = Card([])" },
+              output: { message: "Submit" },
+            },
+          ]),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("does not continue after a display-only OpenUI tool", () => {
+    expect(
+      shouldContinueAfterOpenUIPrompt({
+        messages: [
+          message([
+            { type: "step-start" },
+            {
+              type: "tool-present_openui",
+              toolCallId: "present-1",
+              state: "output-available",
+              input: { ui: "root = Card([])" },
+              output: { displayed: true },
+            },
+          ]),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("waits for every tool in the latest step to finish", () => {
+    expect(
+      shouldContinueAfterOpenUIPrompt({
+        messages: [
+          message([
+            { type: "step-start" },
+            {
+              type: "tool-prompt_openui",
+              toolCallId: "prompt-1",
+              state: "output-available",
+              input: { ui: "root = Card([])" },
+              output: { message: "Submit" },
+            },
+            {
+              type: "tool-present_openui",
+              toolCallId: "present-1",
+              state: "input-streaming",
+              input: undefined,
+            },
+          ]),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("supports a custom prompt tool name", () => {
+    const shouldContinue = createShouldContinueAfterOpenUIPrompt({
+      promptToolName: "ask_panel",
+    });
+
+    expect(
+      shouldContinue({
+        messages: [
+          message([
+            { type: "step-start" },
+            {
+              type: "tool-ask_panel",
+              toolCallId: "prompt-1",
+              state: "output-available",
+              input: { ui: "root = Panel()" },
+              output: { message: "Submit" },
+            },
+          ]),
+        ],
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/assistant-ui/src/__tests__/integration.test.ts
+++ b/packages/assistant-ui/src/__tests__/integration.test.ts
@@ -1,0 +1,36 @@
+import { createLibrary, defineComponent } from "@openuidev/react-lang";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { createOpenUIIntegration, openuiIntegration } from "../integration";
+
+describe("assistant-ui OpenUI integration", () => {
+  it("creates a matched default toolkit and instruction string", () => {
+    expect(openuiIntegration.toolkit[openuiIntegration.toolNames.present]?.type).toBe("frontend");
+    expect(openuiIntegration.toolkit[openuiIntegration.toolNames.prompt]?.type).toBe("human");
+    expect(openuiIntegration.instructions).toContain(openuiIntegration.toolNames.present);
+    expect(openuiIntegration.instructions).toContain(openuiIntegration.toolNames.prompt);
+  });
+
+  it("keeps custom tool names and component vocabulary aligned", () => {
+    const Panel = defineComponent({
+      name: "Panel",
+      description: "A test panel.",
+      props: z.object({ title: z.string() }),
+      component: ({ props }) => props.title,
+    });
+    const library = createLibrary({ root: "Panel", components: [Panel] });
+    const integration = createOpenUIIntegration({
+      library,
+      promptOptions: {},
+      presentToolName: "show_panel",
+      promptToolName: "ask_panel",
+    });
+
+    expect(integration.toolNames).toEqual({ present: "show_panel", prompt: "ask_panel" });
+    expect(integration.toolkit.show_panel?.type).toBe("frontend");
+    expect(integration.toolkit.ask_panel?.type).toBe("human");
+    expect(integration.instructions).toContain("show_panel");
+    expect(integration.instructions).toContain("ask_panel");
+    expect(integration.instructions).toContain("Panel(title: string)");
+  });
+});

--- a/packages/assistant-ui/src/__tests__/renderers.test.tsx
+++ b/packages/assistant-ui/src/__tests__/renderers.test.tsx
@@ -4,7 +4,7 @@ import { ThemeProvider } from "@openuidev/react-ui";
 import { act, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { OpenUIPrompt } from "./renderers";
+import { OpenUIPrompt } from "../renderers";
 
 const FORM = `root = Card([title, form])
 title = TextContent("Contact Us", "large-heavy")

--- a/packages/assistant-ui/src/__tests__/toolkit.test.ts
+++ b/packages/assistant-ui/src/__tests__/toolkit.test.ts
@@ -1,8 +1,8 @@
 import { createLibrary, defineComponent } from "@openuidev/react-lang";
 import { describe, expect, it } from "vitest";
 import { z } from "zod/v4";
-import { createOpenUIInstructions } from "./instructions";
-import { createOpenUIToolkit, openuiToolkit, openuiToolParameters } from "./toolkit";
+import { createOpenUIInstructions } from "../instructions";
+import { createOpenUIToolkit, openuiToolkit, openuiToolParameters } from "../toolkit";
 
 describe("assistant-ui OpenUI toolkit", () => {
   it("registers separate display and human tools", async () => {

--- a/packages/assistant-ui/src/ai-sdk.ts
+++ b/packages/assistant-ui/src/ai-sdk.ts
@@ -10,7 +10,17 @@ export interface CreateShouldContinueAfterOpenUIPromptOptions {
   promptToolName?: string;
 }
 
-export type OpenUIContinuationPredicate = (options: { messages: UIMessage[] }) => boolean;
+export interface OpenUIContinuationMessage {
+  role: string;
+  parts: Array<{
+    type: string;
+    state?: string;
+  }>;
+}
+
+export type OpenUIContinuationPredicate = (options: {
+  messages: OpenUIContinuationMessage[];
+}) => boolean;
 
 export function createShouldContinueAfterOpenUIPrompt({
   promptToolName = OPENUI_PROMPT_TOOL_NAME,
@@ -20,11 +30,12 @@ export function createShouldContinueAfterOpenUIPrompt({
   }
 
   return ({ messages }) => {
-    if (!lastAssistantMessageIsCompleteWithToolCalls({ messages })) {
+    const aiMessages = messages as UIMessage[];
+    if (!lastAssistantMessageIsCompleteWithToolCalls({ messages: aiMessages })) {
       return false;
     }
 
-    const message = messages.at(-1);
+    const message = aiMessages.at(-1);
     if (!message || message.role !== "assistant") {
       return false;
     }

--- a/packages/assistant-ui/src/ai-sdk.ts
+++ b/packages/assistant-ui/src/ai-sdk.ts
@@ -1,0 +1,45 @@
+import {
+  getToolName,
+  isToolUIPart,
+  lastAssistantMessageIsCompleteWithToolCalls,
+  type UIMessage,
+} from "ai";
+import { OPENUI_PROMPT_TOOL_NAME } from "./constants";
+
+export interface CreateShouldContinueAfterOpenUIPromptOptions {
+  promptToolName?: string;
+}
+
+export type OpenUIContinuationPredicate = (options: { messages: UIMessage[] }) => boolean;
+
+export function createShouldContinueAfterOpenUIPrompt({
+  promptToolName = OPENUI_PROMPT_TOOL_NAME,
+}: CreateShouldContinueAfterOpenUIPromptOptions = {}): OpenUIContinuationPredicate {
+  if (promptToolName.length === 0) {
+    throw new Error("The OpenUI prompt tool name must not be empty.");
+  }
+
+  return ({ messages }) => {
+    if (!lastAssistantMessageIsCompleteWithToolCalls({ messages })) {
+      return false;
+    }
+
+    const message = messages.at(-1);
+    if (!message || message.role !== "assistant") {
+      return false;
+    }
+
+    const lastStepStartIndex = message.parts.reduce(
+      (lastIndex, part, index) => (part.type === "step-start" ? index : lastIndex),
+      -1,
+    );
+    const toolParts = message.parts.slice(lastStepStartIndex + 1).filter(isToolUIPart);
+
+    return (
+      toolParts.every((part) => part.state === "output-available") &&
+      toolParts.some((part) => getToolName(part) === promptToolName)
+    );
+  };
+}
+
+export const shouldContinueAfterOpenUIPrompt = createShouldContinueAfterOpenUIPrompt();

--- a/packages/assistant-ui/src/constants.ts
+++ b/packages/assistant-ui/src/constants.ts
@@ -1,0 +1,7 @@
+export const OPENUI_PRESENT_TOOL_NAME = "present_openui";
+export const OPENUI_PROMPT_TOOL_NAME = "prompt_openui";
+
+export const openuiToolDescriptions = {
+  present: "Render a display-only interface from an OpenUI Lang program.",
+  prompt: "Render an interactive OpenUI Lang form or choice and wait for the user to submit it.",
+} as const;

--- a/packages/assistant-ui/src/index.ts
+++ b/packages/assistant-ui/src/index.ts
@@ -8,6 +8,9 @@ export {
 } from "./instructions";
 export type { CreateOpenUIInstructionsOptions, UseOpenUIInstructionsOptions } from "./instructions";
 
+export { createOpenUIIntegration, openuiIntegration } from "./integration";
+export type { CreateOpenUIIntegrationOptions, OpenUIIntegration } from "./integration";
+
 export {
   DefaultOpenUIErrorFallback,
   OpenUIContent,

--- a/packages/assistant-ui/src/index.ts
+++ b/packages/assistant-ui/src/index.ts
@@ -1,0 +1,40 @@
+"use client";
+
+export {
+  OpenUIInstructions,
+  createOpenUIInstructions,
+  openuiInstructions,
+  useOpenUIInstructions,
+} from "./instructions";
+export type { CreateOpenUIInstructionsOptions, UseOpenUIInstructionsOptions } from "./instructions";
+
+export {
+  DefaultOpenUIErrorFallback,
+  OpenUIContent,
+  OpenUIPresent,
+  OpenUIPrompt,
+  createOpenUIPresent,
+  createOpenUIPrompt,
+} from "./renderers";
+export type {
+  OpenUIActionResult,
+  OpenUIContentProps,
+  OpenUIErrorFallback,
+  OpenUIPresentProps,
+  OpenUIPresentResult,
+  OpenUIPromptProps,
+  OpenUIRendererProps,
+  OpenUIToolArgs,
+  OpenUIToolUIOptions,
+} from "./renderers";
+
+export {
+  OPENUI_PRESENT_TOOL_NAME,
+  OPENUI_PROMPT_TOOL_NAME,
+  createOpenUIToolParameters,
+  createOpenUIToolkit,
+  openuiToolDescriptions,
+  openuiToolParameters,
+  openuiToolkit,
+} from "./toolkit";
+export type { CreateOpenUIToolkitOptions } from "./toolkit";

--- a/packages/assistant-ui/src/instructions.tsx
+++ b/packages/assistant-ui/src/instructions.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useAssistantInstructions } from "@assistant-ui/react";
+import type { Library, PromptOptions } from "@openuidev/react-lang";
+import { openuiChatLibrary, openuiChatPromptOptions } from "@openuidev/react-ui";
+import { OPENUI_PRESENT_TOOL_NAME, OPENUI_PROMPT_TOOL_NAME } from "./toolkit";
+
+export interface CreateOpenUIInstructionsOptions {
+  library?: Library;
+  promptOptions?: PromptOptions;
+  presentToolName?: string;
+  promptToolName?: string;
+  preamble?: string;
+  additionalRules?: string[];
+}
+
+export function createOpenUIInstructions({
+  library = openuiChatLibrary,
+  promptOptions = openuiChatPromptOptions,
+  presentToolName = OPENUI_PRESENT_TOOL_NAME,
+  promptToolName = OPENUI_PROMPT_TOOL_NAME,
+  preamble,
+  additionalRules = [],
+}: CreateOpenUIInstructionsOptions = {}): string {
+  const defaultPreamble = [
+    `Render requested interfaces by calling ${presentToolName} or ${promptToolName}.`,
+    `Use ${presentToolName} for display-only responses and ${promptToolName} when the user must submit a choice or form.`,
+    "Set the ui argument to valid OpenUI Lang without markdown fences.",
+    "Make the tool call the entire response and never return OpenUI Lang as assistant text.",
+  ].join(" ");
+
+  return library.prompt({
+    ...promptOptions,
+    preamble: preamble ?? defaultPreamble,
+    additionalRules: [
+      ...(promptOptions.additionalRules ?? []),
+      `When using ${presentToolName}, do not include actions that continue the conversation.`,
+      `When using ${promptToolName}, include exactly one terminal @ToAssistant action that submits the form or choice.`,
+      ...additionalRules,
+    ],
+  });
+}
+
+export const openuiInstructions = createOpenUIInstructions();
+
+export interface UseOpenUIInstructionsOptions extends CreateOpenUIInstructionsOptions {
+  disabled?: boolean;
+}
+
+export function useOpenUIInstructions({
+  disabled = false,
+  ...options
+}: UseOpenUIInstructionsOptions = {}) {
+  useAssistantInstructions({
+    instruction: createOpenUIInstructions(options),
+    disabled,
+  });
+}
+
+export function OpenUIInstructions(options: UseOpenUIInstructionsOptions) {
+  useOpenUIInstructions(options);
+  return null;
+}

--- a/packages/assistant-ui/src/integration.ts
+++ b/packages/assistant-ui/src/integration.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import type { Toolkit } from "@assistant-ui/react";
+import type { PromptOptions } from "@openuidev/react-lang";
+import { openuiChatLibrary } from "@openuidev/react-ui";
+import { createOpenUIInstructions } from "./instructions";
+import type { OpenUIToolUIOptions } from "./renderers";
+import { OPENUI_PRESENT_TOOL_NAME, OPENUI_PROMPT_TOOL_NAME, createOpenUIToolkit } from "./toolkit";
+
+export interface CreateOpenUIIntegrationOptions extends OpenUIToolUIOptions {
+  promptOptions?: PromptOptions;
+  presentToolName?: string;
+  promptToolName?: string;
+  presentDescription?: string;
+  promptDescription?: string;
+  preamble?: string;
+  additionalRules?: string[];
+}
+
+export interface OpenUIIntegration {
+  toolkit: Toolkit;
+  instructions: string;
+  toolNames: {
+    present: string;
+    prompt: string;
+  };
+}
+
+export function createOpenUIIntegration(
+  options: CreateOpenUIIntegrationOptions = {},
+): OpenUIIntegration {
+  const library = options.library ?? openuiChatLibrary;
+  const presentToolName = options.presentToolName ?? OPENUI_PRESENT_TOOL_NAME;
+  const promptToolName = options.promptToolName ?? OPENUI_PROMPT_TOOL_NAME;
+
+  const toolkit = createOpenUIToolkit({
+    library,
+    presentToolName,
+    promptToolName,
+    ...(options.presentDescription !== undefined && {
+      presentDescription: options.presentDescription,
+    }),
+    ...(options.promptDescription !== undefined && {
+      promptDescription: options.promptDescription,
+    }),
+    ...(options.rendererProps !== undefined && { rendererProps: options.rendererProps }),
+    ...(options.ErrorFallback !== undefined && { ErrorFallback: options.ErrorFallback }),
+    ...(options.onError !== undefined && { onError: options.onError }),
+  });
+  const instructions = createOpenUIInstructions({
+    library,
+    presentToolName,
+    promptToolName,
+    ...(options.promptOptions !== undefined && { promptOptions: options.promptOptions }),
+    ...(options.preamble !== undefined && { preamble: options.preamble }),
+    ...(options.additionalRules !== undefined && {
+      additionalRules: options.additionalRules,
+    }),
+  });
+
+  return {
+    toolkit,
+    instructions,
+    toolNames: {
+      present: presentToolName,
+      prompt: promptToolName,
+    },
+  };
+}
+
+export const openuiIntegration = createOpenUIIntegration();

--- a/packages/assistant-ui/src/renderers.test.tsx
+++ b/packages/assistant-ui/src/renderers.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { ThemeProvider } from "@openuidev/react-ui";
+import { act, type ComponentProps } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenUIPrompt } from "./renderers";
+
+const FORM = `root = Card([title, form])
+title = TextContent("Contact Us", "large-heavy")
+form = Form("contact", btns, [nameField, emailField])
+nameField = FormControl("Name", Input("name", "Your name", "text", { required: true, minLength: 2 }))
+emailField = FormControl("Email", Input("email", "you@example.com", "email", { required: true, email: true }))
+btns = Buttons([Button("Submit", Action([@ToAssistant("Submit")]), "primary")])`;
+
+const MALFORMED = "root = MissingComponent([])";
+
+type PromptProps = ComponentProps<typeof OpenUIPrompt>;
+
+const makeProps = (overrides: Partial<PromptProps> = {}): PromptProps =>
+  ({
+    type: "tool-call",
+    toolCallId: "openui-call",
+    toolName: "prompt_openui",
+    args: { ui: FORM },
+    argsText: JSON.stringify({ ui: FORM }),
+    status: { type: "complete" },
+    addResult: vi.fn(),
+    resume: vi.fn(),
+    respondToApproval: vi.fn(),
+    ...overrides,
+  }) as PromptProps;
+
+const setInputValue = (input: HTMLInputElement, value: string) => {
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.dispatchEvent(new Event("change", { bubbles: true }));
+};
+
+describe("OpenUIPrompt", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+  });
+
+  const renderPrompt = async (props: PromptProps) => {
+    await act(async () => {
+      root.render(
+        <ThemeProvider mode="light">
+          <OpenUIPrompt {...props} />
+        </ThemeProvider>,
+      );
+    });
+  };
+
+  it("submits once and restores the completed form state", async () => {
+    const addResult = vi.fn();
+    await renderPrompt(makeProps({ addResult }));
+
+    const name = container.querySelector<HTMLInputElement>('input[name="name"]');
+    const email = container.querySelector<HTMLInputElement>('input[name="email"]');
+    const submit = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Submit",
+    );
+
+    expect(name).not.toBeNull();
+    expect(email).not.toBeNull();
+    expect(submit).toBeDefined();
+
+    await act(async () => {
+      setInputValue(name!, "Ada Lovelace");
+      setInputValue(email!, "ada@example.com");
+    });
+    await act(async () => {
+      submit!.click();
+      submit!.click();
+    });
+
+    expect(addResult).toHaveBeenCalledOnce();
+    const result = addResult.mock.calls[0]![0];
+    expect(result).toMatchObject({ message: "Submit", formName: "contact" });
+    expect(result.formState).toBeDefined();
+
+    await renderPrompt(makeProps({ result }));
+
+    expect(container.querySelector<HTMLInputElement>('input[name="name"]')?.value).toBe(
+      "Ada Lovelace",
+    );
+    expect(container.querySelector<HTMLInputElement>('input[name="email"]')?.value).toBe(
+      "ada@example.com",
+    );
+  });
+
+  it("waits until streaming ends before showing parser errors", async () => {
+    const malformedArgs = { ui: MALFORMED };
+    await renderPrompt(
+      makeProps({
+        args: malformedArgs,
+        argsText: JSON.stringify(malformedArgs),
+        status: { type: "running" },
+      }),
+    );
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+
+    await renderPrompt(
+      makeProps({
+        args: malformedArgs,
+        argsText: JSON.stringify(malformedArgs),
+      }),
+    );
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(
+      "OpenUI could not render this response.",
+    );
+
+    await renderPrompt(makeProps());
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/packages/assistant-ui/src/renderers.tsx
+++ b/packages/assistant-ui/src/renderers.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import type { ToolCallMessagePartComponent, ToolCallMessagePartProps } from "@assistant-ui/react";
+import {
+  BuiltinActionType,
+  Renderer,
+  type ActionEvent,
+  type Library,
+  type OpenUIError,
+  type RendererProps,
+} from "@openuidev/react-lang";
+import { openuiChatLibrary } from "@openuidev/react-ui";
+import { useCallback, useRef, useState, type ComponentType } from "react";
+
+export interface OpenUIToolArgs extends Record<string, unknown> {
+  ui: string;
+}
+
+export interface OpenUIPresentResult {
+  displayed: true;
+}
+
+export interface OpenUIActionResult {
+  type: BuiltinActionType.ContinueConversation;
+  message: string;
+  params: Record<string, unknown>;
+  formState?: Record<string, unknown>;
+  formName?: string;
+}
+
+export type OpenUIErrorFallback = ComponentType<{
+  errors: readonly OpenUIError[];
+}>;
+
+export type OpenUIRendererProps = Omit<
+  RendererProps,
+  "response" | "library" | "isStreaming" | "initialState" | "onAction" | "onError"
+>;
+
+export interface OpenUIToolUIOptions {
+  library?: Library;
+  rendererProps?: OpenUIRendererProps;
+  ErrorFallback?: OpenUIErrorFallback | null;
+  onError?: (errors: OpenUIError[]) => void;
+}
+
+export interface OpenUIContentProps extends OpenUIToolUIOptions {
+  response: string;
+  isStreaming: boolean;
+  initialState?: Record<string, unknown>;
+  onAction?: (event: ActionEvent) => void;
+}
+
+export const DefaultOpenUIErrorFallback: OpenUIErrorFallback = () => (
+  <div role="alert">OpenUI could not render this response.</div>
+);
+
+export function OpenUIContent({
+  response,
+  isStreaming,
+  initialState,
+  onAction,
+  library = openuiChatLibrary,
+  rendererProps,
+  ErrorFallback = DefaultOpenUIErrorFallback,
+  onError,
+}: OpenUIContentProps) {
+  const [errors, setErrors] = useState<OpenUIError[]>([]);
+  const handleError = useCallback(
+    (nextErrors: OpenUIError[]) => {
+      setErrors(nextErrors);
+      onError?.(nextErrors);
+    },
+    [onError],
+  );
+
+  return (
+    <>
+      <Renderer
+        {...rendererProps}
+        response={response}
+        library={library}
+        isStreaming={isStreaming}
+        onError={handleError}
+        {...(initialState !== undefined && { initialState })}
+        {...(onAction !== undefined && { onAction })}
+      />
+      {!isStreaming && errors.length > 0 && ErrorFallback !== null && (
+        <ErrorFallback errors={errors} />
+      )}
+    </>
+  );
+}
+
+export type OpenUIPresentProps = ToolCallMessagePartProps<OpenUIToolArgs, OpenUIPresentResult> &
+  OpenUIToolUIOptions;
+
+export function OpenUIPresent({ args, status, ...options }: OpenUIPresentProps) {
+  return (
+    <OpenUIContent {...options} response={args.ui ?? ""} isStreaming={status.type === "running"} />
+  );
+}
+
+export type OpenUIPromptProps = ToolCallMessagePartProps<OpenUIToolArgs, OpenUIActionResult> &
+  OpenUIToolUIOptions;
+
+export function OpenUIPrompt({ args, status, result, addResult, ...options }: OpenUIPromptProps) {
+  const completed = useRef(result !== undefined);
+  const onAction = (event: ActionEvent) => {
+    if (
+      result !== undefined ||
+      completed.current ||
+      event.type !== BuiltinActionType.ContinueConversation
+    ) {
+      return;
+    }
+
+    completed.current = true;
+    try {
+      addResult({
+        type: BuiltinActionType.ContinueConversation,
+        message: event.humanFriendlyMessage,
+        params: event.params,
+        ...(event.formState !== undefined && { formState: event.formState }),
+        ...(event.formName !== undefined && { formName: event.formName }),
+      });
+    } catch (error) {
+      completed.current = false;
+      throw error;
+    }
+  };
+
+  return (
+    <OpenUIContent
+      {...options}
+      response={args.ui ?? ""}
+      isStreaming={status.type === "running"}
+      onAction={onAction}
+      {...(result?.formState !== undefined && {
+        initialState: result.formState,
+      })}
+    />
+  );
+}
+
+export function createOpenUIPresent(
+  options: OpenUIToolUIOptions = {},
+): ToolCallMessagePartComponent<OpenUIToolArgs, OpenUIPresentResult> {
+  return function ConfiguredOpenUIPresent(props) {
+    return <OpenUIPresent {...props} {...options} />;
+  };
+}
+
+export function createOpenUIPrompt(
+  options: OpenUIToolUIOptions = {},
+): ToolCallMessagePartComponent<OpenUIToolArgs, OpenUIActionResult> {
+  return function ConfiguredOpenUIPrompt(props) {
+    return <OpenUIPrompt {...props} {...options} />;
+  };
+}

--- a/packages/assistant-ui/src/toolkit.test.ts
+++ b/packages/assistant-ui/src/toolkit.test.ts
@@ -1,0 +1,61 @@
+import { createLibrary, defineComponent } from "@openuidev/react-lang";
+import { describe, expect, it } from "vitest";
+import { z } from "zod/v4";
+import { createOpenUIInstructions } from "./instructions";
+import { createOpenUIToolkit, openuiToolkit, openuiToolParameters } from "./toolkit";
+
+describe("assistant-ui OpenUI toolkit", () => {
+  it("registers separate display and human tools", async () => {
+    expect(openuiToolkit["present_openui"]?.type).toBe("frontend");
+    expect(openuiToolkit["prompt_openui"]?.type).toBe("human");
+    expect(openuiToolkit["present_openui"]?.display).toBe("standalone");
+    expect(openuiToolkit["prompt_openui"]?.display).toBe("standalone");
+
+    const execute = openuiToolkit["present_openui"]?.execute;
+    expect(execute).toBeTypeOf("function");
+    await expect(execute?.({}, {} as never)).resolves.toEqual({ displayed: true });
+  });
+
+  it("validates the streamed OpenUI argument", () => {
+    expect(openuiToolParameters.parse({ ui: "root = Card([])" })).toEqual({
+      ui: "root = Card([])",
+    });
+    expect(() => openuiToolParameters.parse({})).toThrow();
+  });
+
+  it("keeps custom tool names and component vocabulary aligned", () => {
+    const Panel = defineComponent({
+      name: "Panel",
+      description: "A test panel.",
+      props: z.object({ title: z.string() }),
+      component: ({ props }) => props.title,
+    });
+    const library = createLibrary({ root: "Panel", components: [Panel] });
+    const toolkit = createOpenUIToolkit({
+      library,
+      presentToolName: "show_panel",
+      promptToolName: "ask_panel",
+    });
+    const instructions = createOpenUIInstructions({
+      library,
+      promptOptions: {},
+      presentToolName: "show_panel",
+      promptToolName: "ask_panel",
+    });
+
+    expect(toolkit["show_panel"]?.type).toBe("frontend");
+    expect(toolkit["ask_panel"]?.type).toBe("human");
+    expect(instructions).toContain("show_panel");
+    expect(instructions).toContain("ask_panel");
+    expect(instructions).toContain("Panel(title: string)");
+  });
+
+  it("rejects ambiguous tool names", () => {
+    expect(() =>
+      createOpenUIToolkit({
+        presentToolName: "openui",
+        promptToolName: "openui",
+      }),
+    ).toThrow("must use different names");
+  });
+});

--- a/packages/assistant-ui/src/toolkit.ts
+++ b/packages/assistant-ui/src/toolkit.ts
@@ -4,19 +4,22 @@ import { defineToolkit, type Toolkit } from "@assistant-ui/react";
 import { openuiChatLibrary } from "@openuidev/react-ui";
 import { z } from "zod/v4";
 import {
+  OPENUI_PRESENT_TOOL_NAME,
+  OPENUI_PROMPT_TOOL_NAME,
+  openuiToolDescriptions,
+} from "./constants";
+import {
   createOpenUIPresent,
   createOpenUIPrompt,
   type OpenUIPresentResult,
   type OpenUIToolUIOptions,
 } from "./renderers";
 
-export const OPENUI_PRESENT_TOOL_NAME = "present_openui";
-export const OPENUI_PROMPT_TOOL_NAME = "prompt_openui";
-
-export const openuiToolDescriptions = {
-  present: "Render a display-only interface from an OpenUI Lang program.",
-  prompt: "Render an interactive OpenUI Lang form or choice and wait for the user to submit it.",
-} as const;
+export {
+  OPENUI_PRESENT_TOOL_NAME,
+  OPENUI_PROMPT_TOOL_NAME,
+  openuiToolDescriptions,
+} from "./constants";
 
 export function createOpenUIToolParameters(root = "Card") {
   return z.object({

--- a/packages/assistant-ui/src/toolkit.ts
+++ b/packages/assistant-ui/src/toolkit.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { defineToolkit, type Toolkit } from "@assistant-ui/react";
+import { openuiChatLibrary } from "@openuidev/react-ui";
+import { z } from "zod/v4";
+import {
+  createOpenUIPresent,
+  createOpenUIPrompt,
+  type OpenUIPresentResult,
+  type OpenUIToolUIOptions,
+} from "./renderers";
+
+export const OPENUI_PRESENT_TOOL_NAME = "present_openui";
+export const OPENUI_PROMPT_TOOL_NAME = "prompt_openui";
+
+export const openuiToolDescriptions = {
+  present: "Render a display-only interface from an OpenUI Lang program.",
+  prompt: "Render an interactive OpenUI Lang form or choice and wait for the user to submit it.",
+} as const;
+
+export function createOpenUIToolParameters(root = "Card") {
+  return z.object({
+    ui: z.string().describe(`A complete OpenUI Lang program with ${root} as its root`),
+  });
+}
+
+export const openuiToolParameters = createOpenUIToolParameters();
+
+export interface CreateOpenUIToolkitOptions extends OpenUIToolUIOptions {
+  presentToolName?: string;
+  promptToolName?: string;
+  presentDescription?: string;
+  promptDescription?: string;
+}
+
+export function createOpenUIToolkit({
+  presentToolName = OPENUI_PRESENT_TOOL_NAME,
+  promptToolName = OPENUI_PROMPT_TOOL_NAME,
+  presentDescription = openuiToolDescriptions.present,
+  promptDescription = openuiToolDescriptions.prompt,
+  library = openuiChatLibrary,
+  ...rendererOptions
+}: CreateOpenUIToolkitOptions = {}): Toolkit {
+  if (presentToolName.length === 0 || promptToolName.length === 0) {
+    throw new Error("OpenUI tool names must not be empty.");
+  }
+  if (presentToolName === promptToolName) {
+    throw new Error("OpenUI display and prompt tools must use different names.");
+  }
+
+  const parameters = createOpenUIToolParameters(library.root ?? "the configured component");
+  const present = createOpenUIPresent({ library, ...rendererOptions });
+  const prompt = createOpenUIPrompt({ library, ...rendererOptions });
+
+  return defineToolkit({
+    [presentToolName]: {
+      type: "frontend",
+      display: "standalone",
+      description: presentDescription,
+      parameters,
+      execute: async (): Promise<OpenUIPresentResult> => ({ displayed: true }),
+      render: present,
+    },
+    [promptToolName]: {
+      type: "human",
+      display: "standalone",
+      description: promptDescription,
+      parameters,
+      render: prompt,
+    },
+  });
+}
+
+export const openuiToolkit = createOpenUIToolkit();

--- a/packages/assistant-ui/tsconfig.json
+++ b/packages/assistant-ui/tsconfig.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["dist", "node_modules"],
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
   "compilerOptions": {
     "moduleResolution": "bundler",
     "module": "ESNext",

--- a/packages/assistant-ui/tsconfig.json
+++ b/packages/assistant-ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "module": "ESNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  }
+}

--- a/packages/assistant-ui/tsconfig.test.json
+++ b/packages/assistant-ui/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/assistant-ui/tsdown.config.ts
+++ b/packages/assistant-ui/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/ai-sdk.ts"],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,

--- a/packages/assistant-ui/tsdown.config.ts
+++ b/packages/assistant-ui/tsdown.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  target: "es2022",
+  outDir: "dist",
+  clean: true,
+  deps: {
+    neverBundle: [/^(?![./]|[A-Za-z]:[/\\])/],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1711,6 +1711,49 @@ importers:
         specifier: ^4.5.0
         version: 4.6.4(vue@3.5.40(typescript@5.9.3))
 
+  packages/assistant-ui:
+    dependencies:
+      '@openuidev/react-headless':
+        specifier: workspace:^
+        version: link:../react-headless
+      '@openuidev/react-lang':
+        specifier: workspace:^
+        version: link:../react-lang
+      '@openuidev/react-ui':
+        specifier: workspace:^
+        version: link:../react-ui
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+      zustand:
+        specifier: 'catalog:'
+        version: 4.5.7(@types/react@19.2.17)(react@19.2.4)
+    devDependencies:
+      '@assistant-ui/react':
+        specifier: ^0.15.13
+        version: 0.15.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ioredis@5.11.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: 'catalog:'
+        version: 26.1.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.4
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.4(react@19.2.4)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@26.1.0)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(sass@1.102.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0))
+
   packages/browser-bundle:
     dependencies:
       '@openuidev/react-lang':
@@ -2549,6 +2592,61 @@ packages:
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
+  '@assistant-ui/core@0.3.13':
+    resolution: {integrity: sha512-oRAPC7DWiRB0HuindwpRGZq0SEPOpJeYY6eVmrpg5ymgQUCO0kWsmgl7ZSfTg5dw37bnCNqNzX8CQyA7wG31ZQ==}
+    peerDependencies:
+      '@assistant-ui/store': ^0.3.0
+      '@assistant-ui/tap': ^0.9.0
+      '@types/react': '*'
+      assistant-cloud: ^0.1.31
+      react: ^18 || ^19
+      zustand: ^5.0.11
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      assistant-cloud:
+        optional: true
+      react:
+        optional: true
+      zustand:
+        optional: true
+
+  '@assistant-ui/react@0.15.14':
+    resolution: {integrity: sha512-lBkW+RJTrZhC0TlgLTbM4KxMRIKoj17ALCfckfSXN6Uw/3arSZS36+Qz9NOHxD1cMHlpVxOttOVgFsI68pblzw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@assistant-ui/store@0.3.9':
+    resolution: {integrity: sha512-BXX1FNDBy47x3DItCiDULDAvFI6cFdNq2s48ch7pFZ6ZR2YHR8oxDshFRzdcoP6W/aYZTkGTI/zokOIugHUkuA==}
+    peerDependencies:
+      '@assistant-ui/tap': ^0.9.0
+      '@types/react': '*'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
+  '@assistant-ui/tap@0.9.12':
+    resolution: {integrity: sha512-VJrAPipWzhswHMUbO/8yTOyzGCJLYFFKtU22dlMx5ejmvktgErEgpAsHg7SARdB7Cd6skInSOHW0cMlGp155Hw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
 
@@ -2569,6 +2667,9 @@ packages:
   '@aws-sdk/core@3.977.1':
     resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
+    deprecated: |-
+      Deprecated due to Document number parsing bug in JSON, see
+        https://github.com/aws/aws-sdk-js-v3/issues/8246. Newer version available.
 
   '@aws-sdk/credential-provider-env@3.972.62':
     resolution: {integrity: sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==}
@@ -10269,6 +10370,20 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  assistant-cloud@0.1.40:
+    resolution: {integrity: sha512-O5sWg9SW494ZfW9pbOFzIm/oOJO/UputvCh9zSGpCRzLh8dEx7Ye7r7yGsLSbW4Mqe7Rrx1ZC0OpNFoySARIiQ==}
+
+  assistant-stream@0.3.37:
+    resolution: {integrity: sha512-oxomJOPM7z09+nj2lwOhAaoH/TbRZ3EDOJ83TIgh6X1S1+CL5To/azmE8ZA2YMiXsKhhdDzqhyc5CQfU19ob5g==}
+    peerDependencies:
+      ioredis: ^5.10.1 || ^6.0.0
+      redis: ^5.12.1
+    peerDependenciesMeta:
+      ioredis:
+        optional: true
+      redis:
+        optional: true
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -14812,6 +14927,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
+    hasBin: true
+
   nanotar@0.3.0:
     resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
@@ -16347,6 +16467,12 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -16722,6 +16848,9 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-content-frame@0.0.27:
+    resolution: {integrity: sha512-IFUSMjElIp8q46wUU5HViHNEqoDWRlCzqqThQmhOLimuXPe/QC6Jr/AQ+BKxSYziQdNXUpapBq4Ir/t6dS0Ldg==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -16769,6 +16898,9 @@ packages:
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -18070,6 +18202,33 @@ packages:
       '@types/react':
         optional: true
 
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
@@ -18720,6 +18879,24 @@ packages:
       react:
         optional: true
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -19183,6 +19360,64 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@assistant-ui/core@0.3.13(@assistant-ui/store@0.3.9(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4))(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(assistant-cloud@0.1.40(ioredis@5.11.1))(ioredis@5.11.1)(react@19.2.4)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))':
+    dependencies:
+      '@assistant-ui/store': 0.3.9(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4)
+      '@assistant-ui/tap': 0.9.12(@types/react@19.2.17)(react@19.2.4)
+      assistant-stream: 0.3.37(ioredis@5.11.1)
+      nanoid: 6.0.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+      assistant-cloud: 0.1.40(ioredis@5.11.1)
+      react: 19.2.4
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    transitivePeerDependencies:
+      - ioredis
+      - redis
+
+  '@assistant-ui/react@0.15.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ioredis@5.11.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))':
+    dependencies:
+      '@assistant-ui/core': 0.3.13(@assistant-ui/store@0.3.9(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4))(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(assistant-cloud@0.1.40(ioredis@5.11.1))(ioredis@5.11.1)(react@19.2.4)(zustand@5.0.14(@types/react@19.2.17)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))
+      '@assistant-ui/store': 0.3.9(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4)
+      '@assistant-ui/tap': 0.9.12(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      assistant-cloud: 0.1.40(ioredis@5.11.1)
+      assistant-stream: 0.3.37(ioredis@5.11.1)
+      radix-ui: 1.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.4)
+      safe-content-frame: 0.0.27
+      zod: 4.4.3
+      zustand: 5.0.14(@types/react@19.2.17)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - immer
+      - ioredis
+      - redis
+      - use-sync-external-store
+
+  '@assistant-ui/store@0.3.9(@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4))(@types/react@19.2.17)(react@19.2.4)':
+    dependencies:
+      '@assistant-ui/tap': 0.9.12(@types/react@19.2.17)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.4
+
+  '@assistant-ui/tap@0.9.12(@types/react@19.2.17)(react@19.2.4)':
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.4
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -24115,6 +24350,15 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-accessible-icon@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-accordion@1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -24158,6 +24402,19 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-alert-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -24239,6 +24496,20 @@ snapshots:
       '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-avatar@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -24366,6 +24637,19 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-context-menu@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -24459,6 +24743,29 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dialog@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -24665,6 +24972,20 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-form@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -24678,6 +24999,23 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-hover-card@1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -24798,6 +25136,24 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-menubar@1.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-navigation-menu@1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -24862,6 +25218,26 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-one-time-password-field@0.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.3
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -24874,6 +25250,22 @@ snapshots:
       '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-password-toggle-field@0.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -25145,6 +25537,16 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-progress@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -25486,6 +25888,26 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-toast@1.2.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-toggle-group@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -25553,6 +25975,21 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-toolbar@1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.7
@@ -25570,6 +26007,27 @@ snapshots:
       '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tooltip@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -25718,6 +26176,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.3)
       react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.5(@types/react@19.2.17)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      react: 19.2.4
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -29067,6 +29532,21 @@ snapshots:
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
+
+  assistant-cloud@0.1.40(ioredis@5.11.1):
+    dependencies:
+      assistant-stream: 0.3.37(ioredis@5.11.1)
+    transitivePeerDependencies:
+      - ioredis
+      - redis
+
+  assistant-stream@0.3.37(ioredis@5.11.1):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      nanoid: 6.0.1
+      secure-json-parse: 4.1.0
+    optionalDependencies:
+      ioredis: 5.11.1
 
   ast-kit@2.2.0:
     dependencies:
@@ -34766,6 +35246,8 @@ snapshots:
 
   nanoid@3.3.16: {}
 
+  nanoid@6.0.1: {}
+
   nanotar@0.3.0: {}
 
   napi-build-utils@2.0.0: {}
@@ -36643,6 +37125,69 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  radix-ui@1.6.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/primitive': 1.1.7
+      '@radix-ui/react-accessible-icon': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-accordion': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-alert-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-aspect-ratio': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-avatar': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-checkbox': 1.3.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collection': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context': 1.2.2(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-context-menu': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dialog': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-form': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-hover-card': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-label': 2.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-menubar': 1.1.24(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-navigation-menu': 1.2.22(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-one-time-password-field': 0.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-password-toggle-field': 0.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popover': 1.1.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-progress': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-scroll-area': 1.2.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select': 2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slider': 1.4.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-switch': 1.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast': 1.2.23(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toggle-group': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toolbar': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.6(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-effect-event': 0.0.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.5(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-is-hydrated': 0.1.3(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.4(@types/react@19.2.17)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
@@ -36985,6 +37530,15 @@ snapshots:
       prismjs: 1.30.0
       react: 19.2.4
       refractor: 5.0.0
+
+  react-textarea-autosize@8.5.9(@types/react@19.2.17)(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      react: 19.2.4
+      use-composed-ref: 1.4.0(@types/react@19.2.17)(react@19.2.4)
+      use-latest: 1.3.0(@types/react@19.2.17)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -37548,6 +38102,8 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-content-frame@0.0.27: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -37598,6 +38154,8 @@ snapshots:
       kind-of: 6.0.3
 
   secure-json-parse@2.7.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   selderee@0.11.0:
     dependencies:
@@ -39021,6 +39579,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  use-composed-ref@1.4.0(@types/react@19.2.17)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.17)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-latest@1.3.0(@types/react@19.2.17)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.17)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.3):
     dependencies:
       detect-node-es: 1.1.0
@@ -39885,5 +40462,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       react: 19.2.4
+
+  zustand@5.0.14(@types/react@19.2.17)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1738,6 +1738,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.17)
+      ai:
+        specifier: ^6.0.236
+        version: 6.0.236(zod@4.4.3)
       jsdom:
         specifier: 'catalog:'
         version: 26.1.0


### PR DESCRIPTION
## What changed

- add the publishable `@openuidev/assistant-ui` integration package
- expose display and human Tool UI renderers for streamed OpenUI Lang
- register `present_openui` as a display-only frontend tool and `prompt_openui` as a human tool
- preserve submitted form state on replay and defer parser fallbacks until streaming completes
- add `createOpenUIIntegration`, which creates the toolkit and instructions from one library and one set of tool names
- add an optional `@openuidev/assistant-ui/ai-sdk` subpath for safe `prompt_openui` continuation
- document installation, runtime-scoped registration, customization, and continuation behavior
- add focused tests for rendering, tool wiring, matched configuration, replay, errors, and AI SDK continuation

## Why

assistant-ui already owns the conversation, tool-call lifecycle, persistence, and human-in-the-loop flow. OpenUI can remain an optional renderer for the streamed tool argument. Packaging that boundary in the OpenUI monorepo gives applications a maintained integration without replacing assistant-ui's schema-driven tools.

Creating the toolkit and instructions independently made it possible for custom libraries or tool names to drift. The matched integration factory removes that footgun. The optional AI SDK helper centralizes the latest-step completion checks required by `prompt_openui` without adding AI SDK code to the package's main entry point.

This follows the package direction discussed in [assistant-ui/assistant-ui#5758](https://github.com/assistant-ui/assistant-ui/issues/5758).

## Impact

This PR is package-only; it does not add an example application. Consumers can use the default integration or create a matched custom integration with their own component library, tool names, descriptions, prompt rules, renderer props, and error handling.

The `ai` peer is optional and is only needed when importing `@openuidev/assistant-ui/ai-sdk`. The main package entry remains independent of the AI SDK.

## Validation

- `pnpm --filter @openuidev/assistant-ui run ci` (typecheck, 12 tests, lint, formatting)
- `pnpm --filter @openuidev/assistant-ui run build`
- `pnpm --filter @openuidev/assistant-ui run check:publint`
- `pnpm --filter @openuidev/assistant-ui run check:attw`
