### PR TITLE
Ship BYOK devtools CTA: devtools 0.0.5 + CLI 0.2.7 templates

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/devtools",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Development-only UI widget for OpenUI apps: surfaces errors captured by @openuidev/observability",
   "license": "MIT",
   "type": "module",

--- a/packages/openui-cli/package.json
+++ b/packages/openui-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/cli",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CLI for OpenUI — scaffold generative UI chat apps and generate LLM system prompts from component libraries",
   "bin": {
     "openui": "dist/index.js"

--- a/packages/openui-cli/src/templates/openui-cloud/package.json
+++ b/packages/openui-cli/src/templates/openui-cloud/package.json
@@ -24,7 +24,7 @@
     "zustand": "^4.5.5"
   },
   "devDependencies": {
-    "@openuidev/devtools": "^0.0.3",
+    "@openuidev/devtools": "^0.0.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/packages/openui-cli/src/templates/openui-self-hosted/package.json
+++ b/packages/openui-cli/src/templates/openui-self-hosted/package.json
@@ -24,7 +24,7 @@
     "react-dom": "19.2.3"
   },
   "devDependencies": {
-    "@openuidev/devtools": "^0.0.3",
+    "@openuidev/devtools": "^0.0.5",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Why

The BYOK CTA in the OpenUI Devtools (`QuotaErrorRow`, commit 1c665817) shipped in source but never reached users. Two independent breaks:

1. **Publish gap** — the BYOK commit didn't bump the version, so `@openuidev/devtools@0.0.4` on npm is the pre-BYOK build. The CTA code was never published.
2. **Dependency pin** — both CLI templates pinned `@openuidev/devtools` at `^0.0.3`. For a `0.0.x` package the caret collapses to the exact patch (`>=0.0.3 <0.0.4`), so generated apps installed `0.0.3` and never saw the CTA — even `0.0.4` was unreachable.

Result: on non-paid/free-tier workspaces (`ERR_BILLING_THRESHOLD_EXCEEDED`), devtools showed only "Purchase Credits", never the "Add your own key" (BYOK) button.

## Changes

- `@openuidev/devtools` → **0.0.5** (ships the BYOK CTA)
- Both templates (`openui-cloud`, `openui-self-hosted`) pin devtools → **0.0.5** (exact, avoiding the `0.0.x` caret trap)
- `@openuidev/cli` → **0.2.7** (templates are baked into the CLI's `dist/`, so the CLI must be republished for the pin to reach users; 0.2.6 is already on npm)

## Publish runbook (order matters)

The template `package-lock.json` files still resolve devtools `0.0.3` and **must be regenerated to 0.0.5 before the CLI is published** — npm scaffolds run `npm ci`, which hard-fails on an out-of-sync lockfile. The lockfile can only be regenerated once `0.0.5` is live on npm. So:

1. Dispatch **Publish NPM packages → `devtools`** → publishes `0.0.5`.
2. Regenerate both templates' `package-lock.json` (devtools 0.0.3 → 0.0.5) and push to this branch.
3. Dispatch **Publish NPM packages → `openui-cli`** → publishes `0.2.7`.
4. Merge.

