### PR TITLE
fix(cli): re-prompt when the project directory already exists

### DIFF
--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -12,6 +12,7 @@ import {
 import { runSkillInstall, shouldInstallSkill } from "../lib/install-skill";
 import { runCommand } from "../lib/process-runner";
 import { resolveArgs } from "../lib/resolve-args";
+import { resolveAvailableTarget } from "../lib/target-dir";
 import { CliCancelledError, CreateError, telemetry } from "../lib/telemetry";
 import { cliErrorProperties, processErrorProperties } from "../lib/utils";
 
@@ -121,7 +122,8 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     immediate_arg: options.immediate,
   });
 
-  const args = await resolveArgs(
+  // Resolved on its own, and validated before anything else is asked
+  const nameArgs = await resolveArgs(
     {
       name: options.name
         ? { value: options.name }
@@ -129,6 +131,16 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
             prompt: { type: "input", message: "Project name?", default: "openui-agent" },
             required: true,
           },
+    },
+    interactive,
+  );
+  const { name, targetDir } = await resolveAvailableTarget(
+    (nameArgs as { name: string }).name,
+    interactive,
+  );
+
+  const args = await resolveArgs(
+    {
       template: options.template
         ? { value: options.template }
         : {
@@ -152,7 +164,7 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     interactive,
   );
 
-  const { name, template } = args as { name: string; template: TemplateName };
+  const { template } = args as { template: TemplateName };
   const aiSetup = aiSetupFromTemplate(template);
   telemetry.register({ template, ai_setup: aiSetup });
   telemetry.capture("cli_ai_setup_selected", {
@@ -160,16 +172,6 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     template,
     ai_setup: aiSetup,
   });
-
-  const targetDir = path.resolve(process.cwd(), name);
-  if (fs.existsSync(targetDir)) {
-    throw new CreateError(
-      "preflight",
-      `Directory "${name}" already exists.`,
-      "filesystem",
-      "TARGET_EXISTS",
-    );
-  }
 
   const templateDir = path.join(__dirname, "..", "templates", template);
   if (!fs.existsSync(templateDir)) {

--- a/packages/openui-cli/src/lib/target-dir.ts
+++ b/packages/openui-cli/src/lib/target-dir.ts
@@ -1,0 +1,76 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { resolveArgs } from "./resolve-args";
+import { CreateError, telemetry } from "./telemetry";
+
+/** How many times an interactive run may re-prompt before aborting. */
+const MAX_NAME_RETRIES = 5;
+
+/** Suggest the next free `<base>-<n>` so the retry prompt has a usable default. */
+function suggestAvailableName(name: string): string {
+  const numbered = /^(.*?)-(\d+)$/.exec(name);
+  const base = numbered?.[1] || name;
+  let suffix = numbered ? Number(numbered[2]) + 1 : 2;
+  while (suffix < 1000 && fs.existsSync(path.resolve(process.cwd(), `${base}-${suffix}`))) {
+    suffix += 1;
+  }
+  return `${base}-${suffix}`;
+}
+
+/** Resolve a project directory that does not exist yet */
+export async function resolveAvailableTarget(
+  requestedName: string,
+  interactive: boolean,
+): Promise<{ name: string; targetDir: string }> {
+  let name = requestedName;
+  let retries = 0;
+
+  for (;;) {
+    const targetDir = path.resolve(process.cwd(), name);
+    if (!fs.existsSync(targetDir)) {
+      if (retries > 0) telemetry.capture("cli_target_name_retried", { retries });
+      return { name, targetDir };
+    }
+
+    const exhausted = retries >= MAX_NAME_RETRIES;
+
+    // Fired on every collision, in both modes. Interactive runs now recover
+    // instead of throwing, so without this the TARGET_EXISTS signal that used
+    // to reach analytics via cli_create_failed would disappear for them.
+    telemetry.capture("cli_target_exists", {
+      interactive,
+      attempt: retries + 1,
+      exhausted,
+      error_code: "TARGET_EXISTS",
+    });
+
+    if (!interactive || exhausted) {
+      throw new CreateError(
+        "preflight",
+        exhausted
+          ? `Directory "${name}" already exists. Aborting after ${MAX_NAME_RETRIES} attempts.`
+          : `Directory "${name}" already exists.`,
+        "filesystem",
+        "TARGET_EXISTS",
+      );
+    }
+
+    console.error(`Directory "${name}" already exists. Choose a different project name.`);
+    retries += 1;
+    const retry = await resolveArgs(
+      {
+        name: {
+          prompt: {
+            type: "input",
+            message: "Project name?",
+            default: suggestAvailableName(name),
+          },
+          required: true,
+        },
+      },
+      interactive,
+    );
+    name = (retry as { name: string }).name.trim();
+  }
+}


### PR DESCRIPTION
## What

`openui create` aborted outright when the target directory already existed, so you had to start the whole run again. Worse, it only checked *after* the template prompt — you answered everything, then got rejected.

## Changes

- Check the name as soon as it's resolved, before any other prompt is shown.
- Interactive runs report the collision and ask again, defaulting to the next free `<name>-<n>`. After 5 attempts they abort, as before.
- Non-interactive runs still fail immediately with `TARGET_EXISTS` — there's nobody to ask.
- Moved the logic into `lib/target-dir.ts` so `create-app.ts` stays readable.
- Added `cli_target_exists`, fired on every collision in both modes. Interactive runs now recover instead of throwing, so the signal that used to reach analytics via `cli_create_failed` would otherwise have been lost.

Independent of the backend-framework stack (#964–#969); both touch `create-app.ts`, so whichever lands second will need a trivial rebase.

## Test Plan

- [x] Verified locally

`tsc`, `prettier` and `eslint` clean. Built the CLI and ran:

- taken name, no `--template`, non-interactive → `Error: Directory "taken" already exists.`, exit 1 — proves the name is now checked *before* template resolution
- free name, no `--template`, non-interactive → `Error: Missing required argument --template` (control)

Also diffed every `telemetry.capture` / `telemetry.register` call site against `main`: all 27 existing events are preserved, with `cli_target_exists` and `cli_target_name_retried` added.

## Checklist

- [x] I considered backwards compatibility
