### PR TITLE
fix(docs): remove broken Merriweather font

### DIFF
--- a/docs/app/components/theme-builder/layout.tsx
+++ b/docs/app/components/theme-builder/layout.tsx
@@ -1,7 +1,6 @@
 import {
   DM_Sans,
   Lato,
-  Merriweather,
   Montserrat,
   Nunito,
   Playfair_Display,
@@ -43,12 +42,6 @@ const playfairDisplay = Playfair_Display({
   subsets: ["latin"],
 });
 
-const merriweather = Merriweather({
-  variable: "--font-merriweather",
-  subsets: ["latin"],
-  weight: ["400", "700"],
-});
-
 const sourceSans3 = Source_Sans_3({
   variable: "--font-source-sans-3",
   subsets: ["latin"],
@@ -66,7 +59,6 @@ const fontClassName = [
   montserrat.variable,
   nunito.variable,
   playfairDisplay.variable,
-  merriweather.variable,
   sourceSans3.variable,
   dmSans.variable,
 ].join(" ");

--- a/docs/app/components/theme-builder/page.tsx
+++ b/docs/app/components/theme-builder/page.tsx
@@ -30,7 +30,6 @@ type FontOption =
   | "montserrat"
   | "nunito"
   | "playfair-display"
-  | "merriweather"
   | "source-sans-3"
   | "dm-sans";
 
@@ -87,11 +86,6 @@ const FONT_OPTIONS: Array<{ value: FontOption; label: string; family: string }> 
     value: "playfair-display",
     label: "Playfair Display",
     family: 'var(--font-playfair-display), "Playfair Display", serif',
-  },
-  {
-    value: "merriweather",
-    label: "Merriweather",
-    family: 'var(--font-merriweather), "Merriweather", serif',
   },
   {
     value: "source-sans-3",

--- a/docs/content/docs/api-reference/meta.json
+++ b/docs/content/docs/api-reference/meta.json
@@ -6,10 +6,10 @@
     "react-lang",
     "react-headless",
     "react-ui",
-    "assistant-ui",
-    "langchain",
     "react-email",
+    "cli",
     "devtools",
-    "cli"
+    "langchain",
+    "assistant-ui"
   ]
 }


### PR DESCRIPTION
## Summary

- remove the Merriweather `next/font` loader and corresponding theme-builder option
- reorder API references so CLI appears earlier and LangChain/assistant-ui appear last

## Root cause

Google Merriweather `.woff2` URLs returned HTTP 404 during the production Vercel build, causing Next.js/Turbopack module-resolution failures in generated font CSS.

## Impact

The docs build no longer depends on the missing Merriweather assets. Other theme-builder font previews and the primary site fonts are unchanged. The API-reference navigation now groups core packages before integration packages.

## Validation

- `pnpm exec prettier --check docs/app/components/theme-builder/layout.tsx docs/app/components/theme-builder/page.tsx docs/content/docs/api-reference/meta.json`
- `pnpm --filter @openuidev/docs run types:check`
- `pnpm --filter @openuidev/docs run build`