### PR TITLE
fix: provide theme for assistant-ui renderers

### DIFF
--- a/packages/assistant-ui/README.md
+++ b/packages/assistant-ui/README.md
@@ -11,8 +11,15 @@ pnpm add @openuidev/assistant-ui @assistant-ui/react @openuidev/react-ui @openui
 Import the OpenUI styles once in your app:
 
 ```css
+@layer theme, base, openui, components, utilities;
+
 @import "@openuidev/react-ui/layered/styles/index.css";
 ```
+
+The layer declaration keeps OpenUI above Tailwind's reset and below application
+components and utilities. The tool renderers include OpenUI's light
+`ThemeProvider` by default so their design tokens match a light assistant-ui
+shell.
 
 ## Register the tools and instructions
 
@@ -88,7 +95,17 @@ const openui = createOpenUIIntegration({
 
 The result exposes `toolkit`, `instructions`, and the resolved `toolNames`.
 `createOpenUIIntegration` also accepts custom descriptions, prompt options,
-renderer props, error handling, and an error fallback.
+renderer props, theming, error handling, and an error fallback. Pass theme props
+through the integration factory to customize the rendered tools:
+
+```tsx
+const openui = createOpenUIIntegration({
+  theme: { mode: "dark" },
+});
+```
+
+If the application already wraps assistant-ui in an OpenUI `ThemeProvider`, set
+`disableThemeProvider: true` and let the host provider own the theme.
 
 ## Human-tool continuation
 

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/assistant-ui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "OpenUI Lang tool renderers and instruction wiring for assistant-ui",
   "license": "MIT",
   "engines": {

--- a/packages/assistant-ui/src/__tests__/renderers.test.tsx
+++ b/packages/assistant-ui/src/__tests__/renderers.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
 
-import { ThemeProvider } from "@openuidev/react-ui";
 import { act, type ComponentProps } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -54,13 +53,21 @@ describe("OpenUIPrompt", () => {
 
   const renderPrompt = async (props: PromptProps) => {
     await act(async () => {
-      root.render(
-        <ThemeProvider mode="light">
-          <OpenUIPrompt {...props} />
-        </ThemeProvider>,
-      );
+      root.render(<OpenUIPrompt {...props} />);
     });
   };
+
+  it("provides OpenUI theme tokens by default", async () => {
+    await renderPrompt(makeProps());
+
+    expect(document.head.querySelector("style[data-openui-theme]")).not.toBeNull();
+  });
+
+  it("can defer theming to a host provider", async () => {
+    await renderPrompt(makeProps({ disableThemeProvider: true }));
+
+    expect(document.head.querySelector("style[data-openui-theme]")).toBeNull();
+  });
 
   it("submits once and restores the completed form state", async () => {
     const addResult = vi.fn();

--- a/packages/assistant-ui/src/renderers.tsx
+++ b/packages/assistant-ui/src/renderers.tsx
@@ -9,7 +9,7 @@ import {
   type OpenUIError,
   type RendererProps,
 } from "@openuidev/react-lang";
-import { openuiChatLibrary } from "@openuidev/react-ui";
+import { openuiChatLibrary, ThemeProvider, type ThemeProps } from "@openuidev/react-ui";
 import { useCallback, useRef, useState, type ComponentType } from "react";
 
 export interface OpenUIToolArgs extends Record<string, unknown> {
@@ -40,6 +40,10 @@ export type OpenUIRendererProps = Omit<
 export interface OpenUIToolUIOptions {
   library?: Library;
   rendererProps?: OpenUIRendererProps;
+  /** Theme props passed to <ThemeProvider>. */
+  theme?: ThemeProps;
+  /** When true, skips wrapping in <ThemeProvider>. */
+  disableThemeProvider?: boolean;
   ErrorFallback?: OpenUIErrorFallback | null;
   onError?: (errors: OpenUIError[]) => void;
 }
@@ -62,6 +66,8 @@ export function OpenUIContent({
   onAction,
   library = openuiChatLibrary,
   rendererProps,
+  theme,
+  disableThemeProvider,
   ErrorFallback = DefaultOpenUIErrorFallback,
   onError,
 }: OpenUIContentProps) {
@@ -74,7 +80,7 @@ export function OpenUIContent({
     [onError],
   );
 
-  return (
+  const content = (
     <>
       <Renderer
         {...rendererProps}
@@ -90,6 +96,8 @@ export function OpenUIContent({
       )}
     </>
   );
+
+  return disableThemeProvider ? content : <ThemeProvider {...theme}>{content}</ThemeProvider>;
 }
 
 export type OpenUIPresentProps = ToolCallMessagePartProps<OpenUIToolArgs, OpenUIPresentResult> &


### PR DESCRIPTION
## Summary

- wrap assistant-ui OpenUI tool renderers in `ThemeProvider` by default
- expose `theme` and `disableThemeProvider` options, matching the existing React integrations
- document CSS layer ordering and theme customization
- add regression coverage for the package-owned provider and host-owned opt-out
- bump `@openuidev/assistant-ui` from `0.0.1` to `0.0.2`

## Root cause

The earlier embedded assistant-ui docs demo owned a custom `OpenUIThemeProvider`. When that demo was removed and the renderer moved into `@openuidev/assistant-ui`, the theme boundary was not carried into the package. The renderer tests continued to wrap `OpenUIPrompt` in `ThemeProvider` manually, which masked the missing production default.

Without the provider, layered OpenUI tokens could follow the system color scheme. A dark system scheme inside a light assistant-ui shell therefore rendered dark-mode text tokens against the light shell background.

## Behavior

The package now initializes light OpenUI theme tokens by default. Consumers can pass any `ThemeProps` through `theme`, or set `disableThemeProvider: true` when the host already owns an OpenUI provider.

## Validation

- `pnpm --filter @openuidev/assistant-ui run ci`
- `pnpm --filter @openuidev/assistant-ui run check:publint`
- `pnpm --filter @openuidev/assistant-ui run check:attw`
- reproduced and visually verified in an assistant-ui shell
