### PR TITLE
chore: allow publishing assistant-ui

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -12,6 +12,7 @@ on:
         required: true
         type: choice
         options:
+          - assistant-ui
           - react-ui
           - react-headless
           - react-lang


### PR DESCRIPTION
## Summary

- add `assistant-ui` to the manual npm publish workflow package choices

## Why

`@openuidev/assistant-ui@0.0.2` is merged on `main`, but the publish workflow cannot currently select `packages/assistant-ui`. As a result, npm still exposes `0.0.1` as the latest published version.

After this merges, dispatch **Publish NPM packages** with `assistant-ui` to publish `0.0.2`.

## Validation

- parsed `.github/workflows/publish-npm-package.yml` successfully as YAML
- verified the workflow resolves the selected package through `packages/${{ inputs.package }}`