### PR TITLE
fix react-ui invalid chart geometry

### DIFF
--- a/packages/react-ui/src/components/Charts/shared/LineInBarShape/LineInBarShape.test.tsx
+++ b/packages/react-ui/src/components/Charts/shared/LineInBarShape/LineInBarShape.test.tsx
@@ -1,0 +1,32 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { LineInBarShape } from "./LineInBarShape";
+
+const validGeometry = {
+  x: 10,
+  y: 20,
+  width: 100,
+  height: 24,
+  orientation: "horizontal" as const,
+};
+
+describe("LineInBarShape", () => {
+  it("renders finite SVG geometry", () => {
+    const markup = renderToStaticMarkup(<LineInBarShape {...validGeometry} />);
+
+    expect(markup).toContain("<path");
+    expect(markup).toContain("<line");
+    expect(markup).not.toContain("NaN");
+  });
+
+  it.each(["x", "y", "width", "height"] as const)(
+    "skips rendering when %s is not finite",
+    (dimension) => {
+      const markup = renderToStaticMarkup(
+        <LineInBarShape {...validGeometry} {...{ [dimension]: Number.NaN }} />,
+      );
+
+      expect(markup).toBe("");
+    },
+  );
+});

--- a/packages/react-ui/src/components/Charts/shared/LineInBarShape/LineInBarShape.tsx
+++ b/packages/react-ui/src/components/Charts/shared/LineInBarShape/LineInBarShape.tsx
@@ -327,6 +327,27 @@ const LineInBarShape: FunctionComponent<LineInBarShapeProps> = React.memo((props
     };
   }, [x, y, adjustedX, adjustedY, width, height, adjustedWidth, adjustedHeight, isVertical]);
 
+  const hasFiniteGeometry = [
+    x,
+    y,
+    width,
+    height,
+    adjustedX,
+    adjustedY,
+    adjustedWidth,
+    adjustedHeight,
+    rTL,
+    rTR,
+    rBL,
+    rBR,
+  ].every(Number.isFinite);
+
+  // Recharts can briefly provide NaN dimensions while a responsive chart is
+  // being measured (for example, inside an inactive tab). Rendering those
+  // values produces invalid SVG coordinates and React warnings. The chart will
+  // render normally once Recharts supplies valid geometry on a later pass.
+  if (!hasFiniteGeometry) return null;
+
   return (
     <g>
       <path d={path} fill={fill} stroke={stroke} strokeWidth={strokeWidth} opacity={opacity} />


### PR DESCRIPTION
## Summary

- skip LineInBarShape rendering while Recharts supplies non-finite responsive-layout geometry
- render normally again once a later layout pass supplies valid dimensions
- add regression coverage for valid SVG output and non-finite x, y, width, and height values

## Root cause

Recharts can briefly provide NaN dimensions while measuring a responsive bar chart, including charts in containers that have not finished layout. LineInBarShape used those values as SVG path and line coordinates, producing invalid DOM attributes and React warnings.

The custom shape now validates all DOM-bound geometry at its render boundary and returns null only for the invalid pass. It remains stateless and renders normally when Recharts provides finite geometry.

## Validation

- pnpm --filter @openuidev/react-ui run ci (39 tests)
- pnpm --filter @openuidev/react-ui run typecheck
- pnpm --filter @openuidev/react-ui run build

Extracted from https://github.com/thesysdev/openui/pull/985 to keep the assistant-ui package change focused.
