### PR TITLE
feat(supabase-chat): add OrcaRouter as a named gateway option

### DIFF
--- a/examples/supabase-chat/.env.local.example
+++ b/examples/supabase-chat/.env.local.example
@@ -3,3 +3,9 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 OPENROUTER_API_KEY=sk-or-v1-...
 # Optional: defaults to openai/gpt-5.5
 # OPENROUTER_MODEL=openai/gpt-5.5
+
+# OrcaRouter — Anthropic-compatible AI gateway (https://www.orcarouter.ai)
+# Setting ORCAROUTER_API_KEY routes the example through OrcaRouter instead of
+# OpenRouter (base URL https://api.orcarouter.ai/v1 is applied automatically):
+# ORCAROUTER_API_KEY=sk-orca-...
+# ORCAROUTER_MODEL=anthropic/claude-haiku-4.5

--- a/examples/supabase-chat/README.md
+++ b/examples/supabase-chat/README.md
@@ -68,6 +68,10 @@ cp .env.local.example .env.local
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase dashboard → Settings → API → anon/public key |
 | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | `OPENROUTER_MODEL` _(optional)_ | Defaults to `openai/gpt-5.5` |
+| `ORCAROUTER_API_KEY` _(optional)_ | Setting this routes the example through [OrcaRouter](https://www.orcarouter.ai) instead of OpenRouter |
+| `ORCAROUTER_MODEL` _(optional)_ | Defaults to `anthropic/claude-haiku-4.5` |
+
+> Using [OrcaRouter](https://www.orcarouter.ai)? Set `ORCAROUTER_API_KEY` (and optionally `ORCAROUTER_MODEL`) and the example streams Claude models through the same OpenAI-compatible client — no code changes needed.
 
 ### 5. Install and run
 

--- a/examples/supabase-chat/src/app/api/chat/route.ts
+++ b/examples/supabase-chat/src/app/api/chat/route.ts
@@ -3,7 +3,15 @@ import { NextRequest } from "next/server";
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
 
-const MODEL = process.env.OPENROUTER_MODEL ?? "openai/gpt-5.5";
+// Gateway selection. OpenRouter (https://openrouter.ai/api/v1) is the default;
+// setting ORCAROUTER_API_KEY routes the example through OrcaRouter
+// (https://api.orcarouter.ai/v1) — an Anthropic-compatible AI gateway — using
+// the same OpenAI-compatible client. See .env.local.example for both options.
+const ORCAROUTER_ENABLED = Boolean(process.env.ORCAROUTER_API_KEY);
+
+const MODEL = ORCAROUTER_ENABLED
+  ? process.env.ORCAROUTER_MODEL ?? "anthropic/claude-haiku-4.5"
+  : process.env.OPENROUTER_MODEL ?? "openai/gpt-5.5";
 
 /**
  * POST /api/chat
@@ -24,8 +32,12 @@ export async function POST(req: NextRequest) {
   const supabase = await createSupabaseServer();
 
   const client = new OpenAI({
-    apiKey: process.env.OPENROUTER_API_KEY,
-    baseURL: "https://openrouter.ai/api/v1",
+    apiKey: ORCAROUTER_ENABLED
+      ? process.env.ORCAROUTER_API_KEY
+      : process.env.OPENROUTER_API_KEY,
+    baseURL: ORCAROUTER_ENABLED
+      ? "https://api.orcarouter.ai/v1"
+      : "https://openrouter.ai/api/v1",
   });
 
   const stream = await client.chat.completions.create({


### PR DESCRIPTION
# Add OrcaRouter as a named gateway option in the supabase-chat example

This PR adds [OrcaRouter](https://www.orcarouter.ai) as a named, switchable gateway in `examples/supabase-chat`, mirroring the existing OpenRouter wiring.

## What changed

- `examples/supabase-chat/src/app/api/chat/route.ts`: gateway selection is now `ORCAROUTER_API_KEY`-gated. When set, the example's OpenAI-compatible client is pointed at `https://api.orcarouter.ai/v1` with OrcaRouter's namespaced Claude model ids (`anthropic/claude-haiku-4.5` default via `ORCAROUTER_MODEL`). When unset, behavior is identical to before — OpenRouter remains the default (`https://openrouter.ai/api/v1`, `openai/gpt-5.5`).
- `examples/supabase-chat/.env.local.example`: documents the `ORCAROUTER_API_KEY` / `ORCAROUTER_MODEL` override next to the existing OpenRouter vars.
- `examples/supabase-chat/README.md`: adds the two new env rows to the config table plus a one-line note.

No new dependencies — it reuses the example's existing `openai` SDK client.

## Why OrcaRouter

OrcaRouter is an Anthropic-compatible AI gateway that serves Claude and OpenAI models through a single OpenAI-compatible endpoint (`https://api.orcarouter.ai/v1`). It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Verified end-to-end: a live `chat.completions` request to `https://api.orcarouter.ai/v1` with `anthropic/claude-haiku-4.5` (the exact config the README documents) returned HTTP 200 with content `ORCA-OK`.

I'm an engineer on the OrcaRouter team.
