### PR TITLE
docs: remove unsupported request-level BYOK

### DIFF
--- a/docs/content/docs/openui-cloud/api/chat-completions.mdx
+++ b/docs/content/docs/openui-cloud/api/chat-completions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Chat Completions (Embed)
+title: Chat Completions
 description: "Use the OpenAI-compatible embed endpoint for text, managed or self-hosted generative UI, and function tools."
 ---
 

--- a/docs/content/docs/openui-cloud/api/chat-completions.mdx
+++ b/docs/content/docs/openui-cloud/api/chat-completions.mdx
@@ -116,14 +116,3 @@ const completion = await embedClient.chat.completions.create({
 ```
 
 In this mode, prompt assembly, output validation, and rendering are owned by your application.
-
-### Request-level provider key
-
-For a request-level self-hosted key flow, encrypt the provider key with `POST /encryption/encrypt`, then include this object in the request body:
-
-```ts
-byok: {
-  provider,
-  encryptedApiKey,
-}
-```


### PR DESCRIPTION
## What changed

- Remove the request-level provider-key section from the OpenUI Cloud Chat Completions guide.
- Rename the page title from `Chat Completions (Embed)` to `Chat Completions`.
- Keep the supported console-based BYOK documentation unchanged.

## Why

The documented `/encryption/encrypt` flow is not part of the published API: both known route variants return 404, and the repository contains no implementation or request contract for `encryptedApiKey`. Leaving the example published directs users to a nonfunctional credential flow.

## Validation

- `pnpm --filter @openuidev/docs types:check`
- `pnpm --filter @openuidev/docs build`
- `git diff --check`
- Repository-wide search confirms no remaining `/encryption/encrypt`, `encryptedApiKey`, or request-level BYOK references.
