### PR TITLE
Fix link to observability in devtools documentation

### DIFF
--- a/docs/content/docs/api-reference/devtools.mdx
+++ b/docs/content/docs/api-reference/devtools.mdx
@@ -3,7 +3,7 @@ title: "@openuidev/devtools"
 description: API reference for the development-only devtools widget.
 ---
 
-Development-only UI widget for OpenUI apps. Renders a floating button that opens a left side drawer listing the events captured by [`@openuidev/observability`](/docs/api-reference/observability) — level, a one-line summary, and a drill-in stack trace per entry. Development only visibility is controlled by the environment flag.
+Development-only UI widget for OpenUI apps. Renders a floating button that opens a left side drawer listing the events captured by [`@openuidev/observability`](https://github.com/thesysdev/openui/blob/HEAD/packages/observability) — level, a one-line summary, and a drill-in stack trace per entry. Development only visibility is controlled by the environment flag.
 
 <img
   src="/images/api-reference/devtools.gif"


### PR DESCRIPTION
Redirect to Github Readme for now like the Devtools Readme