### PR TITLE
Share one observability bus across duplicate copies

### DIFF
--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/devtools",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Development-only UI widget for OpenUI apps: surfaces errors captured by @openuidev/observability",
   "license": "MIT",
   "type": "module",

--- a/packages/observability-cloud/package.json
+++ b/packages/observability-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/observability-cloud",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Cloud sink for @openuidev/observability: batches OpenUI events and ships them to Thesys ingest",
   "license": "MIT",
   "type": "module",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/observability",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Framework-free observability event bus for OpenUI: emit and listen to events",
   "license": "MIT",
   "type": "module",

--- a/packages/observability/src/observability.test.ts
+++ b/packages/observability/src/observability.test.ts
@@ -108,6 +108,12 @@ describe("observability bus", () => {
     expect(received?.detail.id).toBe("event-1");
   });
 
+  it("shares one bus across duplicate copies via Symbol.for", () => {
+    const key = Symbol.for("openui.observability");
+    const store = globalThis as { [key]?: typeof observability };
+    expect(store[key]).toBe(observability);
+  });
+
   it("a throwing listener does not break the others", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const good = vi.fn();

--- a/packages/observability/src/observability.ts
+++ b/packages/observability/src/observability.ts
@@ -63,5 +63,11 @@ function createObservability(): Observability {
   return bus;
 }
 
-/** The shared observability bus. Import this everywhere — there is one per app. */
-export const observability: Observability = createObservability();
+/**
+ * The shared observability bus. Keyed on globalThis via `Symbol.for` so
+ * duplicate copies of this module (ESM/CJS dual builds, nested package
+ * versions) still share one instance.
+ */
+const BUS_KEY = Symbol.for("openui.observability");
+const store = globalThis as { [BUS_KEY]?: Observability };
+export const observability: Observability = (store[BUS_KEY] ??= createObservability());

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-headless",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Headless React primitives for AI chat — state management, streaming adapters for OpenAI, Vercel AI SDK, and AG-UI, message format converters, and thread management for OpenUI generative UI apps",
   "license": "MIT",
   "type": "module",

--- a/packages/react-headless/package.json
+++ b/packages/react-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-headless",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Headless React primitives for AI chat — state management, streaming adapters for OpenAI, Vercel AI SDK, and AG-UI, message format converters, and thread management for OpenUI generative UI apps",
   "license": "MIT",
   "type": "module",

--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-lang",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Define component libraries, generate LLM system prompts, and render streaming OpenUI Lang output in React — the core runtime for OpenUI generative UI",
   "license": "MIT",
   "type": "module",

--- a/packages/react-ui/package.json
+++ b/packages/react-ui/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "name": "@openuidev/react-ui",
   "license": "MIT",
-  "version": "0.13.7",
+  "version": "0.13.8",
   "description": "Component library for Generative UI SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Summary
- Key the observability singleton on `Symbol.for("openui.observability")` so nested 0.0.2 vs 0.0.3 copies still share one bus — that's why LLM events vanished after the 0.0.3 publish.
- Bump `@openuidev/observability` to 0.0.4, plus consumers so they can republish against it: `react-headless` 0.9.9, `react-lang` 0.2.14, `devtools` 0.0.8.

## Test plan
- [ ] Send a Cloud chat and confirm Inspect shows `fetchLLM:request` / `fetchLLM:response` alongside stream events
- [ ] `pnpm --filter @openuidev/observability test`