### PR TITLE
Move observability emission to `processMessage()` to capture for all `llm` instances

### DIFF
--- a/packages/react-headless/src/adapters/fetchLLM.ts
+++ b/packages/react-headless/src/adapters/fetchLLM.ts
@@ -1,7 +1,6 @@
-import { observability, ObservabilityLevel, toErrorInfo } from "@openuidev/observability";
+import { observability, toErrorInfo } from "@openuidev/observability";
 import { identityMessageFormat, type MessageFormat } from "../types/messageFormat";
 import type { StreamProtocolAdapter } from "../types/stream";
-import { getResponseErrorMessage } from "./httpError";
 import type { ChatLLM } from "./types";
 
 export interface FetchLLMOptions {
@@ -17,10 +16,6 @@ export interface FetchLLMOptions {
   fetch?: typeof fetch;
   /** Extra fields merged into the request body (e.g. `model`) */
   body?: Record<string, unknown>;
-}
-
-function levelForStatus(status: number): ObservabilityLevel {
-  return status >= 400 ? "error" : "info";
 }
 
 /**
@@ -60,18 +55,7 @@ export function fetchLLM({
         }),
         signal,
       }).then(
-        async (response) => {
-          observability(levelForStatus(response.status), {
-            kind: response.ok ? "fetchLLM:response" : "fetchLLM:error",
-            requestId: runId,
-            url,
-            status: response.status,
-            ok: response.ok,
-            threadId,
-            ...(await buildObservabilityErrorDetail(response)),
-          });
-          return response;
-        },
+        async (response) => response,
         (error: unknown) => {
           observability.error({
             kind: "fetchLLM:error",
@@ -85,16 +69,5 @@ export function fetchLLM({
       );
     },
     streamProtocol: streamAdapter,
-  };
-}
-
-async function buildObservabilityErrorDetail(response: Response) {
-  if (response.ok) return {};
-  const res = await response.clone().json();
-  return {
-    error: res?.error,
-    ...(!res.message
-      ? await getResponseErrorMessage(response).then((message) => ({ message }))
-      : { message: res.message }),
   };
 }

--- a/packages/react-headless/src/store/createChatStore.ts
+++ b/packages/react-headless/src/store/createChatStore.ts
@@ -1,8 +1,10 @@
+import { observability } from "@openuidev/observability";
 import { createStore } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { getResponseErrorMessage } from "../adapters/httpError";
 import type { ChatLLM, ChatStorage } from "../adapters/types";
 import { processStreamedMessage } from "../stream/processStreamedMessage";
+import { buildObservabilityErrorDetail, levelForStatus } from "./observability";
 import type { ChatStore, Message, Thread, UserMessage } from "./types";
 
 export interface CreateChatStoreConfig {
@@ -178,8 +180,18 @@ export const createChatStore = (configRef: React.RefObject<CreateChatStoreConfig
             signal: abortController.signal,
           });
 
-          if (response instanceof Response && !response.ok) {
-            throw new Error(await getResponseErrorMessage(response));
+          if (response instanceof Response) {
+            observability(levelForStatus(response.status), {
+              kind: response.ok ? "LLM:response" : "LLM:error",
+              threadId,
+              status: response.status,
+              ok: response.ok,
+              ...(await buildObservabilityErrorDetail(response)),
+            });
+
+            if (!response.ok) {
+              throw new Error(await getResponseErrorMessage(response));
+            }
           }
 
           await processStreamedMessage({

--- a/packages/react-headless/src/store/observability.ts
+++ b/packages/react-headless/src/store/observability.ts
@@ -1,0 +1,17 @@
+import { ObservabilityLevel } from "@openuidev/observability";
+import { getResponseErrorMessage } from "../adapters/httpError";
+
+export async function buildObservabilityErrorDetail(response: Response) {
+  if (response.ok) return {};
+  const res = await response.clone().json();
+  return {
+    error: res?.error,
+    ...(!res.message
+      ? await getResponseErrorMessage(response).then((message: string) => ({ message }))
+      : { message: res.message }),
+  };
+}
+
+export function levelForStatus(status: number): ObservabilityLevel {
+  return status >= 400 ? "error" : "info";
+}

--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/react-lang",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "Define component libraries, generate LLM system prompts, and render streaming OpenUI Lang output in React — the core runtime for OpenUI generative UI",
   "license": "MIT",
   "type": "module",

--- a/packages/react-lang/package.json
+++ b/packages/react-lang/package.json
@@ -82,7 +82,6 @@
   },
   "author": "engineering@thesys.dev",
   "dependencies": {
-    "@openuidev/devtools": "workspace:^",
     "@openuidev/lang-core": "workspace:^",
     "@openuidev/observability": "workspace:^"
   },

--- a/packages/react-lang/src/devtoolsBootstrap.ts
+++ b/packages/react-lang/src/devtoolsBootstrap.ts
@@ -46,7 +46,7 @@ if (process.env.NODE_ENV === "development" && typeof document !== "undefined") {
             __autoMounted: true,
           });
         };
-
+        // Module evaluation can happen before <body> exists (script in <head>).
         if (document.body) mount();
         else document.addEventListener("DOMContentLoaded", mount, { once: true });
       })

--- a/packages/react-lang/src/devtoolsBootstrap.ts
+++ b/packages/react-lang/src/devtoolsBootstrap.ts
@@ -38,8 +38,8 @@ if (process.env.NODE_ENV === "development" && typeof document !== "undefined") {
         const mount = () => {
           devtools.mountOpenUIDevtools({
             React: react,
-            createPortal: reactDom.createPortal,
-            createRoot: reactDomClient.createRoot,
+            ReactDOM: reactDom,
+            ReactDOMClient: reactDomClient,
             // Closed over this module's graph so the bundler resolves it —
             // the CDN file never imports "@openuidev/react-lang" itself.
             loadReactLang: () => import("@openuidev/react-lang"),

--- a/packages/react-lang/src/devtoolsBootstrap.ts
+++ b/packages/react-lang/src/devtoolsBootstrap.ts
@@ -3,9 +3,10 @@
  *
  * This module runs as a top-level side effect when the web entry is loaded in
  * a browser. In production builds the whole block is dead-code-eliminated by
- * the consumer's bundler (the NODE_ENV condition folds to false), so neither
- * `@openuidev/devtools` nor `react-dom/client` enters the production graph.
- * The React Native entry (index.native.ts) never imports this module.
+ * the consumer's bundler (the NODE_ENV condition folds to false), so
+ * `react-dom` / `react-dom/client` never enter the production graph, and
+ * nothing is fetched. The React Native entry (index.native.ts) never imports
+ * this module.
  *
  * This module is inlined into the web entry (dist/index.*), which is listed
  * in package.json's `sideEffects` so bundlers preserve the side effect while
@@ -21,17 +22,31 @@ if (process.env.NODE_ENV === "development" && typeof document !== "undefined") {
   // (ESM/CJS dual build, multiple package versions).
   if (!flags[AUTO_MOUNT_FLAG]) {
     flags[AUTO_MOUNT_FLAG] = true;
-    Promise.all([import("@openuidev/devtools"), import("react"), import("react-dom/client")])
-      .then(([devtools, react, reactDomClient]) => {
+
+    // Pinned to the protocol major, not @latest: cached for days, and a
+    // protocol-breaking release (mount() args, Symbol keys, event kinds)
+    // would otherwise take down every app that hasn't bumped.
+    const url = "https://cdn.jsdelivr.net/npm/@openuidev/devtools@0/dist/devtools.browser.js";
+
+    Promise.all([
+      import(/* webpackIgnore: true */ /* @vite-ignore */ url),
+      import("react"),
+      import("react-dom"),
+      import("react-dom/client"),
+    ])
+      .then(([devtools, react, reactDom, reactDomClient]) => {
         const mount = () => {
-          const host = document.createElement("div");
-          host.setAttribute("data-openui-devtools-root", "");
-          document.body.appendChild(host);
-          reactDomClient
-            .createRoot(host)
-            .render(react.createElement(devtools.OpenUIDevtools, { __autoMounted: true }));
+          devtools.mountOpenUIDevtools({
+            React: react,
+            createPortal: reactDom.createPortal,
+            createRoot: reactDomClient.createRoot,
+            // Closed over this module's graph so the bundler resolves it —
+            // the CDN file never imports "@openuidev/react-lang" itself.
+            loadReactLang: () => import("@openuidev/react-lang"),
+            __autoMounted: true,
+          });
         };
-        // Module evaluation can happen before <body> exists (script in <head>).
+
         if (document.body) mount();
         else document.addEventListener("DOMContentLoaded", mount, { once: true });
       })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1929,9 +1929,6 @@ importers:
 
   packages/react-lang:
     dependencies:
-      '@openuidev/devtools':
-        specifier: workspace:^
-        version: link:../devtools
       '@openuidev/lang-core':
         specifier: workspace:^
         version: link:../lang-core


### PR DESCRIPTION
## What

Describe the change and why it is needed.

## Changes

- 

## Test Plan

Describe how you validated this change.

- [ ] Not applicable (explain why)
- [ ] Verified locally

## Checklist

- [ ] I linked a related issue, if applicable
- [ ] I updated docs/README when needed
- [ ] I considered backwards compatibility
