### PR TITLE
fix(observability-cloud): report the real SDK version on the wire (0.0.3)

### DIFF
--- a/packages/observability-cloud/package.json
+++ b/packages/observability-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/observability-cloud",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Cloud sink for @openuidev/observability: batches OpenUI events and ships them to Thesys ingest",
   "license": "MIT",
   "type": "module",

--- a/packages/observability-cloud/package.json
+++ b/packages/observability-cloud/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "test": "vitest run --passWithNoTests",
-    "build": "tsdown",
+    "check:version-sync": "node scripts/check-version-sync.mjs",
+    "build": "pnpm run check:version-sync && tsdown",
     "watch": "tsdown --watch",
     "typecheck": "tsc --noEmit",
     "lint:check": "eslint ./src",

--- a/packages/observability-cloud/scripts/check-version-sync.mjs
+++ b/packages/observability-cloud/scripts/check-version-sync.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Fails the build when `SDK_VERSION` in src/core/wire.ts has drifted from the
+ * version in package.json.
+ *
+ * Why this exists: `SDK_VERSION` is what every envelope reports as
+ * `sdk.version`, and it is maintained by hand. It was missed on the 0.0.2
+ * release, so every 0.0.2 client identified itself as 0.0.1 on the wire and
+ * ingest could not tell the two releases apart.
+ *
+ * There is already a unit test asserting this (src/core/wire.test.ts), but a
+ * release can be cut without the tests passing — that is exactly how 0.0.2
+ * shipped. This runs as part of `build`, which `prepare` invokes, so it also
+ * guards `npm publish`.
+ *
+ * Deliberately wired into the `build` script rather than named `prebuild`:
+ * pnpm ships with `enable-pre-post-scripts=false` by default, so a `prebuild`
+ * script would silently never run.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const packageJsonPath = join(packageRoot, "package.json");
+const wirePath = join(packageRoot, "src/core/wire.ts");
+
+function fail(message) {
+  console.error(`\n  version-sync check failed\n\n  ${message}\n`);
+  process.exit(1);
+}
+
+const { version: packageVersion } = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+if (typeof packageVersion !== "string") {
+  fail(`Could not read a "version" string from ${packageJsonPath}`);
+}
+
+const wireSource = readFileSync(wirePath, "utf8");
+const match = wireSource.match(/export const SDK_VERSION\s*=\s*["']([^"']+)["']/);
+if (!match) {
+  fail(
+    `Could not find an \`export const SDK_VERSION = "…"\` declaration in ${wirePath}.\n` +
+      `  If it was renamed or is now derived at build time, update this script to match.`,
+  );
+}
+
+const sdkVersion = match[1];
+if (sdkVersion !== packageVersion) {
+  fail(
+    `SDK_VERSION is "${sdkVersion}" but package.json is "${packageVersion}".\n\n` +
+      `  SDK_VERSION is reported on every envelope as sdk.version, so a mismatch\n` +
+      `  makes ingest unable to tell releases apart.\n\n` +
+      `  Fix: set SDK_VERSION to "${packageVersion}" in src/core/wire.ts`,
+  );
+}
+
+console.log(`version-sync ok: SDK_VERSION and package.json are both ${packageVersion}`);

--- a/packages/observability-cloud/scripts/check-version-sync.mjs
+++ b/packages/observability-cloud/scripts/check-version-sync.mjs
@@ -1,23 +1,4 @@
 #!/usr/bin/env node
-/**
- * Fails the build when `SDK_VERSION` in src/core/wire.ts has drifted from the
- * version in package.json.
- *
- * Why this exists: `SDK_VERSION` is what every envelope reports as
- * `sdk.version`, and it is maintained by hand. It was missed on the 0.0.2
- * release, so every 0.0.2 client identified itself as 0.0.1 on the wire and
- * ingest could not tell the two releases apart.
- *
- * There is already a unit test asserting this (src/core/wire.test.ts), but a
- * release can be cut without the tests passing — that is exactly how 0.0.2
- * shipped. This runs as part of `build`, which `prepare` invokes, so it also
- * guards `npm publish`.
- *
- * Deliberately wired into the `build` script rather than named `prebuild`:
- * pnpm ships with `enable-pre-post-scripts=false` by default, so a `prebuild`
- * script would silently never run.
- */
-
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/observability-cloud/src/core/wire.ts
+++ b/packages/observability-cloud/src/core/wire.ts
@@ -2,7 +2,7 @@ import type { ObservabilityLevel } from "@openuidev/observability";
 import type { StreamWireEvent } from "../events/stream";
 
 /** Must be kept in sync with packages/observability-cloud/package.json on release. */
-export const SDK_VERSION = "0.0.1";
+export const SDK_VERSION = "0.0.3";
 
 export interface WireEventBase {
   id: string;


### PR DESCRIPTION
## Problem

`SDK_VERSION` in `src/core/wire.ts` was never bumped for the 0.0.2 release, so it still read `"0.0.1"`:

```ts
/** Must be kept in sync with packages/observability-cloud/package.json on release. */
export const SDK_VERSION = "0.0.1";   // package.json: 0.0.2
```

That constant is what every envelope reports:

```json
{"v":1,"sdk":{"name":"observability-cloud","version":"0.0.1"},...}
```

So **every 0.0.2 client identifies itself as 0.0.1 on the wire.** Ingest cannot distinguish the two releases, which makes any server-side client-version analysis wrong — including the question you most want answered after shipping a fix: *how many clients have actually picked it up?*

Confirmed against a real envelope from a 0.0.2 install.

## Change

Releases **0.0.3** with the constant corrected:

- `package.json` — `0.0.2` → `0.0.3`
- `src/core/wire.ts` — `SDK_VERSION` `"0.0.1"` → `"0.0.3"`

Plus a build-time guard so it cannot drift again — see the comment below.

No behaviour change beyond the reported version.

## Note: the invariant was already covered by a test

`src/core/wire.test.ts` already asserts it:

```ts
expect(SDK_VERSION).toBe(version);   // version read from package.json
```

On current `main` that test fails:

```
FAIL  src/core/wire.test.ts > SDK_VERSION > matches package.json version
AssertionError: expected '0.0.1' to be '0.0.2'
```

So no new test is needed — this PR makes the existing one pass. Might be worth a look at whether this package's tests run in CI.

## Verification

Baseline on `main`: `1 failed | 46 passed` — the sole failure being that guard.

With this change:

- `pnpm test` — **47 passed (10 files)**
- `pnpm typecheck` — clean
- `pnpm run lint:check` / `format:check` — clean
- `pnpm run build` → built dist emits `SDK_VERSION = "0.0.3"`
