### PR TITLE
chore: bump lang-core to 0.2.16

### DIFF
--- a/packages/lang-core/package.json
+++ b/packages/lang-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/lang-core",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "description": "Framework-agnostic core for OpenUI Lang: parser, prompt generation, validation, and type definitions",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump @openuidev/lang-core from 0.2.15 to 0.2.16.

## Verification

- Validated the package manifest JSON.
- Version-only change; the lockfile remains unchanged, matching prior lang-core bump PRs.