### PR TITLE
fix(docs): repair garbled model-board note in benchmark dataset

### DIFF
--- a/docs/lib/benchmark-agent-data.ts
+++ b/docs/lib/benchmark-agent-data.ts
@@ -216,7 +216,7 @@ export const benchmarkAgentDataset = {
     },
     model_board: {
       evidence_status: "summary-only",
-      note: "The model-board measurements are published here as summary rows. Raw generations and per-run verdicts for every row are committed in the benchmark repository for independent rescoring.11 regime and still lack per-row evidence and pricing links. Do not treat current-main results as row-identical evidence for this board.",
+      note: "The model-board measurements are published here as summary rows. Raw generations and per-run verdicts for every row are committed in the benchmark repository for independent rescoring.",
       raw_results: null,
     },
   },


### PR DESCRIPTION
`provenance.model_board.note` in the benchmark agent dataset carried a corrupted fragment — `...for independent rescoring.11 regime and still lack per-row evidence and pricing links. Do not treat current-main results as row-identical evidence for this board.` — left over from removing a `0.2.11` scorer reference. It shipped verbatim in `/benchmarks/data.json`, so agents ingesting the dataset got a broken sentence.

Trimmed to a clean sentence: the model-board rows are summaries; raw generations and per-run verdicts are committed in the benchmark repo for independent rescoring.

One-line change; no numbers affected.